### PR TITLE
#45 repeat-groups are not respecting the jr:count setting after a change to a lower value

### DIFF
--- a/resources/limited-repeats-count-non-relevant-index-after-repeat-group.xml
+++ b/resources/limited-repeats-count-non-relevant-index-after-repeat-group.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>limited repeats count</h:title>
+        <model>
+            <instance>
+                <data id="limited-repeats-count">
+                    <repeat_count/>
+                    <limited_repeat>
+                        <free_text_1/>
+                        <free_text_2/>
+                    </limited_repeat>
+                    <non_relevant_text/>
+                </data>
+            </instance>
+            <bind nodeset="/data/repeat_count" type="int"/>
+            <bind nodeset="/data/limited_repeat" relevant="/data/repeat_count > 0"/>
+            <bind nodeset="/data/limited_repeat/free_text_1" type="string"/>
+            <bind nodeset="/data/limited_repeat/free_text_2" type="string"/>
+            <bind nodeset="/data/non_relevant_text" type="string" relevant="false()"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/repeat_count">
+            <label>repeat count</label>
+        </input>
+        <group>
+            <label>limited repeat</label>
+            <repeat nodeset="/data/limited_repeat" jr:count="/data/repeat_count"
+                    jr:noAddRemove="true()" appearance="field-list">
+                <input ref="/data/limited_repeat/free_text_1">
+                    <label>free text 1</label>
+                </input>
+                <input ref="/data/limited_repeat/free_text_2">
+                    <label>free text 2</label>
+                </input>
+            </repeat>
+        </group>
+        <input ref="/data/non_relevant_text">
+            <label>should not be visible</label>
+        </input>
+    </h:body>
+</h:html>

--- a/resources/limited-repeats-count.xml
+++ b/resources/limited-repeats-count.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>limited repeats count</h:title>
+        <model>
+            <instance>
+                <data id="limited-repeats-count">
+                    <repeat_count/>
+                    <limited_repeat>
+                        <free_text_1/>
+                        <free_text_2/>
+                    </limited_repeat>
+                </data>
+            </instance>
+            <bind nodeset="/data/repeat_count" type="int"/>
+            <bind nodeset="/data/limited_repeat" relevant="/data/repeat_count > 0"/>
+            <bind nodeset="/data/limited_repeat/free_text_1" type="string"/>
+            <bind nodeset="/data/limited_repeat/free_text_2" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/repeat_count">
+            <label>repeat count</label>
+        </input>
+        <group>
+            <label>limited repeat</label>
+            <repeat nodeset="/data/limited_repeat" jr:count="/data/repeat_count"
+                    jr:noAddRemove="true()" appearance="field-list">
+                <input ref="/data/limited_repeat/free_text_1">
+                    <label>free text 1</label>
+                </input>
+                <input ref="/data/limited_repeat/free_text_2">
+                    <label>free text 2</label>
+                </input>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/src/org/javarosa/form/api/FormEntryController.java
+++ b/src/org/javarosa/form/api/FormEntryController.java
@@ -196,7 +196,18 @@ public class FormEntryController {
             }
         } while (index.isInForm() && !model.isIndexRelevant(index));
 
-        return jumpToIndex(index);
+        int event = jumpToIndex(index);
+
+        /* The above call may update the model (add or remove repeat groups) which may result in
+         * the model's current form index pointing to the first form element after
+         * the deleted repeat group which in fact may be non-relevant so it should be
+         * jumped over.
+         */
+        if (!model.getFormIndex().isInForm() || model.isIndexRelevant()) {
+            return event;
+        } else {
+            return stepEvent(forward);
+        }
     }
 
 

--- a/src/org/javarosa/form/api/FormEntryController.java
+++ b/src/org/javarosa/form/api/FormEntryController.java
@@ -208,7 +208,7 @@ public class FormEntryController {
      */
     public int jumpToIndex(FormIndex index) {
         model.setQuestionIndex(index);
-        return model.getEvent(index);
+        return model.getEvent(model.getFormIndex());
     }
 
     public FormIndex descendIntoRepeat (int n) {

--- a/src/org/javarosa/form/api/FormEntryModel.java
+++ b/src/org/javarosa/form/api/FormEntryModel.java
@@ -281,8 +281,7 @@ public class FormEntryModel {
         if (!currentFormIndex.equals(index)) {
             // See if a hint exists that says we should have a model for this
             // already
-            createModelIfNecessary(index);
-            currentFormIndex = index;
+            currentFormIndex = createModelIfNecessary(index);
         }
     }
 
@@ -425,7 +424,9 @@ public class FormEntryModel {
 
 
     /**
-     * For the current index: Checks whether the index represents a node which
+     * For the current index:
+     *
+     * 1. Checks whether the index represents a node which
      * should exist given a non-interactive repeat, along with a count for that
      * repeat which is beneath the dynamic level specified.
      *
@@ -437,10 +438,16 @@ public class FormEntryModel {
      * the interface, it will merely use the xforms repeat hint to create new
      * nodes that are assumed to exist
      *
+     * 2. Checks whether the index represents a node which should have been deleted because
+     * the count for that repeat had been changed to a lower value.
+     * If this index does represent such a node, this and all further extraneous
+     * repeat groups are deleted and it returns the first index after the last deleted repeat group.
+     *
      * @param index The index to be evaluated as to whether the underlying model is
      *        hinted to exist
+     * @return The current index after the model update
      */
-    private void createModelIfNecessary(FormIndex index) {
+    private FormIndex createModelIfNecessary(FormIndex index) {
         if (index.isInForm()) {
             IFormElement e = getForm().getChild(index);
             if (e instanceof GroupDef) {
@@ -454,23 +461,43 @@ public class FormEntryModel {
                         long fullcount = ((Integer) count.getValue()).intValue();
                         TreeReference ref = getForm().getChildInstanceRef(index);
                         TreeElement element = getForm().getMainInstance().resolveReference(ref);
-                        if (element == null) {
-                            if (index.getTerminal().getInstanceIndex() < fullcount) {
-
-                              try {
+                        int currentInstanceIndex = index.getTerminal().getInstanceIndex();
+                        if (currentInstanceIndex < fullcount && element == null) {
+                            try {
                                 getForm().createNewRepeat(index);
-                              } catch (InvalidReferenceException ire) {
+                            } catch (InvalidReferenceException ire) {
                                 ire.printStackTrace();
                                 throw new RuntimeException("Invalid Reference while creting new repeat!" + ire.getMessage());
-                              }
                             }
+                        } else if (currentInstanceIndex >= fullcount && element != null) {
+                            /*
+                             *  Delete the excessive repeat groups.
+                             *
+                             *  When a repeat group is deleted then all the following groups are shifted to fill the gap.
+                             *  Example:
+                             *  There are 6 repeat groups and the 4th is deleted.
+                             *  The 5th becomes the 4th and the 6th becomes the 5th. The index still points to
+                             *  the 4th repeat group which used to be the 5th so the form element represented by
+                             *  the index still exists.
+                             *
+                             *  The loop keeps deleting repeat groups pointed by the index
+                             *  (so in the above example it would be the 4th) till the last one is deleted.
+                             */
+                            do {
+                                getForm().deleteRepeat(index);
+                            } while (getForm().getMainInstance().resolveReference(index.getReference()) != null);
+
+                            /* At this moment index points to a non-existing repeat group so we must
+                             * leave it by stepping to the next form index.
+                             */
+                            return incrementIndex(index);
                         }
                     }
                 }
             }
         }
+        return index;
     }
-
 
     public boolean isIndexCompoundContainer() {
     	return isIndexCompoundContainer(getFormIndex());

--- a/test/org/javarosa/core/form/api/test/LimitedRepeatCountTests.java
+++ b/test/org/javarosa/core/form/api/test/LimitedRepeatCountTests.java
@@ -1,0 +1,68 @@
+package org.javarosa.core.form.api.test;
+
+
+import org.javarosa.core.PathConst;
+import org.javarosa.core.model.data.IntegerData;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class LimitedRepeatCountTests {
+
+    private static final int TEN_REPEAT_COUNT = 10;
+    private static final int NINE_REPEAT_COUNT = 9;
+    private static final int FIVE_REPEAT_COUNT = 5;
+
+    @Test
+    public void testRemoveExtraneousRepeatGroups() {
+        FormParseInit formParseInit = new FormParseInit();
+        formParseInit.setFormToParse(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(), "limited-repeats-count.xml").toString());
+
+        FormEntryController formEntryController = formParseInit.getFormEntryController();
+
+        assertTrue(formEntryController.getModel().getFormIndex().isBeginningOfFormIndex());
+
+        formEntryController.stepToNextEvent();
+
+        FormEntryPrompt questionPrompt = formEntryController.getModel().getQuestionPrompt();
+
+        assertEquals("/data/repeat_count", questionPrompt.getQuestion().getBind().getReference().toString());
+        formEntryController.answerQuestion(questionPrompt.getIndex(), new IntegerData(TEN_REPEAT_COUNT), true);
+
+        for (int i = 0; i < TEN_REPEAT_COUNT; i++) {
+            assertEquals(FormEntryController.EVENT_REPEAT, formEntryController.stepToNextEvent());
+            assertEquals(FormEntryController.EVENT_QUESTION, formEntryController.stepToNextEvent());
+            assertEquals(FormEntryController.EVENT_QUESTION, formEntryController.stepToNextEvent());
+        }
+        assertEquals(FormEntryController.EVENT_END_OF_FORM, formEntryController.stepToNextEvent());
+
+        formEntryController.jumpToIndex(questionPrompt.getIndex());
+        assertEquals("/data/repeat_count", questionPrompt.getQuestion().getBind().getReference().toString());
+        formEntryController.answerQuestion(questionPrompt.getIndex(), new IntegerData(NINE_REPEAT_COUNT), true);
+
+        for (int i = 0; i < NINE_REPEAT_COUNT; i++) {
+            assertEquals(FormEntryController.EVENT_REPEAT, formEntryController.stepToNextEvent());
+            assertEquals(FormEntryController.EVENT_QUESTION, formEntryController.stepToNextEvent());
+            assertEquals(FormEntryController.EVENT_QUESTION, formEntryController.stepToNextEvent());
+        }
+        assertEquals(FormEntryController.EVENT_END_OF_FORM, formEntryController.stepToNextEvent());
+
+        formEntryController.jumpToIndex(questionPrompt.getIndex());
+        assertEquals("/data/repeat_count", questionPrompt.getQuestion().getBind().getReference().toString());
+        formEntryController.answerQuestion(questionPrompt.getIndex(), new IntegerData(FIVE_REPEAT_COUNT), true);
+
+        for (int i = 0; i < FIVE_REPEAT_COUNT; i++) {
+            assertEquals(FormEntryController.EVENT_REPEAT, formEntryController.stepToNextEvent());
+            assertEquals(FormEntryController.EVENT_QUESTION, formEntryController.stepToNextEvent());
+            assertEquals(FormEntryController.EVENT_QUESTION, formEntryController.stepToNextEvent());
+        }
+        assertEquals(FormEntryController.EVENT_END_OF_FORM, formEntryController.stepToNextEvent());
+    }
+
+}

--- a/test/org/javarosa/core/form/api/test/LimitedRepeatCountTests.java
+++ b/test/org/javarosa/core/form/api/test/LimitedRepeatCountTests.java
@@ -26,6 +26,26 @@ public class LimitedRepeatCountTests {
 
         FormEntryController formEntryController = formParseInit.getFormEntryController();
 
+        testSteps(formEntryController);
+    }
+
+    @Test
+    public void testRemoveExtraneousRepeatGroups_withNonRelevantIndexAfterRepeatGroup() {
+        FormParseInit formParseInit = new FormParseInit();
+        formParseInit.setFormToParse(Paths.get(PathConst.getTestResourcePath().getAbsolutePath(), "limited-repeats-count-non-relevant-index-after-repeat-group.xml").toString());
+
+        FormEntryController formEntryController = formParseInit.getFormEntryController();
+
+        testSteps(formEntryController);
+    }
+
+    /**
+     * Steps are shared between {@link LimitedRepeatCountTests#testRemoveExtraneousRepeatGroups()}
+     * and {@link LimitedRepeatCountTests#testRemoveExtraneousRepeatGroups_withNonRelevantIndexAfterRepeatGroup()}.
+     * The only difference is in forms they use.
+     * @param formEntryController
+     */
+    private void testSteps(FormEntryController formEntryController) {
         assertTrue(formEntryController.getModel().getFormIndex().isBeginningOfFormIndex());
 
         formEntryController.stepToNextEvent();
@@ -64,5 +84,4 @@ public class LimitedRepeatCountTests {
         }
         assertEquals(FormEntryController.EVENT_END_OF_FORM, formEntryController.stepToNextEvent());
     }
-
 }


### PR DESCRIPTION
Fixes #45.

I hope commits messages, code and comments are comprehensive but here goes a short summary. 

The code responsible for actual deletion of the extraneous repeats is simple:
```
   do {
     getForm().deleteRepeat(index);
   } while (getForm().getMainInstance().resolveReference(index.getReference()) != null);
```
but  after the deletion, `index` points to the non-existing repeat group which leads to an error shown on UI (ODK Collect) . To fix this, the index must be incremented after the deletion and before it's assigned to `currentFormIndex`. This leads to another problem - a non-relevant (hidden) form element may be present right after the deleted repeat group. Skipping over such indices takes place *before* updating the model so it must be repeated. It's achieved by checking the current index after `jumpToIndex(index)` and recursively calling `stepEvent(forward)` if needed.