### PR TITLE
Itemset filtering

### DIFF
--- a/src/jmh/java/org/javarosa/benchmarks/NigeriaWardsBrowsingRunBenchmark.java
+++ b/src/jmh/java/org/javarosa/benchmarks/NigeriaWardsBrowsingRunBenchmark.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.benchmarks;
+
+import static org.javarosa.benchmarks.BenchmarkUtils.dryRun;
+import static org.javarosa.benchmarks.BenchmarkUtils.prepareAssets;
+import static org.javarosa.form.api.FormEntryController.EVENT_BEGINNING_OF_FORM;
+import static org.javarosa.form.api.FormEntryController.EVENT_END_OF_FORM;
+import static org.javarosa.form.api.FormEntryController.EVENT_GROUP;
+import static org.javarosa.form.api.FormEntryController.EVENT_PROMPT_NEW_REPEAT;
+import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
+import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
+import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT_JUNCTURE;
+
+import java.nio.file.Path;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.services.locale.Localizer;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryController;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class NigeriaWardsBrowsingRunBenchmark {
+    public static void main(String[] args) {
+        dryRun(NigeriaWardsBrowsingRunBenchmark.class);
+    }
+
+    @State(Scope.Thread)
+    public static class NigeriaWardsState {
+        private FormEntryController fec;
+
+        @Setup(Level.Invocation)
+        public void setUp() {
+            Path assetsPath = prepareAssets("nigeria_wards_internal.xml");
+            Path formFile = assetsPath.resolve("nigeria_wards_internal.xml");
+            FormParseInit formParseInit = new FormParseInit(formFile);
+            fec = formParseInit.getFormEntryController();
+            Localizer l = formParseInit.getFormDef().getLocalizer();
+            l.setDefaultLocale("en");
+            l.setLocale("en");
+            fec.stepToNextEvent();
+        }
+
+        @TearDown(Level.Invocation)
+        public void tearDown() {
+            fec = null;
+        }
+    }
+
+    @Benchmark
+    public void select_a_state_lga_and_ward_browse_back_to_beginning_and_go_through_to_the_end_of_the_form(NigeriaWardsState state, Blackhole bh) {
+        // Answer the first question
+        bh.consume(state.fec.answerQuestion(new StringData("7b0ded95031647702b8bed17dce7698a"), true)); // Abia
+
+        // Step to the next question and force a call to populateDynamicChoices()
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.getModel().getQuestionPrompt().getSelectChoices());
+
+        // Answer the second question
+        bh.consume(state.fec.answerQuestion(new StringData("6fa741c46485b9c618f14b79edf50e88"), true)); // Aba North
+
+        // Step to the next question and force a call to populateDynamicChoices()
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.getModel().getQuestionPrompt().getSelectChoices());
+
+        // Answer the third question
+        bh.consume(state.fec.answerQuestion(new StringData("90fa443787485709a5b11c5f7925fb71"), true)); // Ariaria
+
+        // Step back and force a call to populateDynamicChoices()
+        bh.consume(state.fec.stepToPreviousEvent());
+        bh.consume(state.fec.getModel().getQuestionPrompt().getSelectChoices());
+
+        // Step back and force a call to populateDynamicChoices()
+        bh.consume(state.fec.stepToPreviousEvent());
+        bh.consume(state.fec.getModel().getQuestionPrompt().getSelectChoices());
+
+        // Step to the next question and force a call to populateDynamicChoices()
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.getModel().getQuestionPrompt().getSelectChoices());
+
+        // Step to the next question and force a call to populateDynamicChoices()
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.getModel().getQuestionPrompt().getSelectChoices());
+
+        // Step through the rest of questions to the form's end
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.stepToNextEvent());
+    }
+
+    private static String decodeJumpResult(int code) {
+        switch (code) {
+            case EVENT_BEGINNING_OF_FORM:
+                return "Beginning of Form";
+            case EVENT_END_OF_FORM:
+                return "End of Form";
+            case EVENT_PROMPT_NEW_REPEAT:
+                return "Prompt new Repeat";
+            case EVENT_QUESTION:
+                return "Question";
+            case EVENT_GROUP:
+                return "Group";
+            case EVENT_REPEAT:
+                return "Repeat";
+            case EVENT_REPEAT_JUNCTURE:
+                return "Repeat Juncture";
+        }
+        return "Unknown";
+    }
+}

--- a/src/jmh/java/org/javarosa/benchmarks/NigeriaWardsSimpleRunBenchmark.java
+++ b/src/jmh/java/org/javarosa/benchmarks/NigeriaWardsSimpleRunBenchmark.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.javarosa.benchmarks;
+
+import static org.javarosa.benchmarks.BenchmarkUtils.dryRun;
+import static org.javarosa.benchmarks.BenchmarkUtils.prepareAssets;
+
+import java.nio.file.Path;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.services.locale.Localizer;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryController;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class NigeriaWardsSimpleRunBenchmark {
+    public static void main(String[] args) {
+        dryRun(NigeriaWardsSimpleRunBenchmark.class);
+    }
+
+    @State(Scope.Thread)
+    public static class NigeriaWardsState {
+        private FormEntryController fec;
+
+        @Setup(Level.Invocation)
+        public void setUp() {
+            Path assetsPath = prepareAssets("nigeria_wards_internal.xml");
+            Path formFile = assetsPath.resolve("nigeria_wards_internal.xml");
+            FormParseInit formParseInit = new FormParseInit(formFile);
+            fec = formParseInit.getFormEntryController();
+            Localizer l = formParseInit.getFormDef().getLocalizer();
+            l.setDefaultLocale("en");
+            l.setLocale("en");
+            fec.stepToNextEvent();
+        }
+
+        @TearDown(Level.Invocation)
+        public void tearDown() {
+            fec = null;
+        }
+    }
+
+    @Benchmark
+    public void select_a_state_lga_and_ward_and_go_through_to_the_end_of_the_form(NigeriaWardsState state, Blackhole bh) {
+        // Answer the first question
+        bh.consume(state.fec.answerQuestion(new StringData("7b0ded95031647702b8bed17dce7698a"), true)); // Abia
+
+        // Step to the next question and force a call to populateDynamicChoices()
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.getModel().getQuestionPrompt().getSelectChoices());
+
+        // Answer the second question
+        bh.consume(state.fec.answerQuestion(new StringData("6fa741c46485b9c618f14b79edf50e88"), true)); // Aba North
+
+        // Step to the next question and force a call to populateDynamicChoices()
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.getModel().getQuestionPrompt().getSelectChoices());
+
+        // Answer the third question
+        bh.consume(state.fec.answerQuestion(new StringData("90fa443787485709a5b11c5f7925fb71"), true)); // Ariaria
+
+        // Step through the rest of questions to the form's end
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.stepToNextEvent());
+        bh.consume(state.fec.stepToNextEvent());
+    }
+}

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -324,6 +324,11 @@ public class EvaluationContext {
         return child != null ? child.getRef() : null;
     }
 
+    private TreeReference getAttributeByName(String name, AbstractTreeElement<TreeElement> node) {
+        TreeElement attribute = node.getAttribute(null, name);
+        return attribute != null ? attribute.getRef() : null;
+    }
+
     private void originalAlgorithm(TreeReference sourceRef, DataInstance sourceInstance, List<TreeReference> refs, boolean includeTemplates, AbstractTreeElement<TreeElement> node, List<XPathExpression> predicates, int depth) {
         // Get the next set of matching references
         final String name = sourceRef.getName(depth);
@@ -385,10 +390,9 @@ public class EvaluationContext {
                 treeReferences.add(child.getRef());
             }
             if (includeTemplates) {
-                AbstractTreeElement template = node.getChild(name, TreeReference.INDEX_TEMPLATE);
-                if (template != null) {
-                    treeReferences.add(template.getRef());
-                }
+                TreeReference templateRef = getChildRefByNameAndMult(name, TreeReference.INDEX_TEMPLATE, node);
+                if (templateRef != null)
+                    treeReferences.add(templateRef);
             }
             return treeReferences;
         }
@@ -396,17 +400,15 @@ public class EvaluationContext {
             //TODO: Make this test mult >= 0?
             //If the multiplicity is a simple integer, just get
             //the appropriate child
-            AbstractTreeElement child = node.getChild(name, mult);
-            if (child != null) {
-                return Arrays.asList(child.getRef());
-            }
+            TreeReference childRef = getChildRefByNameAndMult(name, mult, node);
+            if (childRef != null)
+                return Arrays.asList(childRef);
         }
 
         if (mult == TreeReference.INDEX_ATTRIBUTE) {
-            AbstractTreeElement attribute = node.getAttribute(null, name);
-            if (attribute != null) {
-                return Arrays.asList(attribute.getRef());
-            }
+            TreeReference attributeRef = getAttributeByName(name, node);
+            if (attributeRef != null)
+                return Arrays.asList(attributeRef);
         }
         return new ArrayList<>();
     }

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -379,14 +379,11 @@ public class EvaluationContext {
 
     private List<TreeReference> getRefs(boolean includeTemplates, AbstractTreeElement<TreeElement> node, String name, int mult) {
         if (node.getNumChildren() > 0 && mult == TreeReference.INDEX_UNBOUND) {
+            int i = 0;
             final List<TreeReference> treeReferences = new ArrayList<>(1);
-            List<TreeElement> childrenWithName = node.getChildrenWithName(name);
-            final int count = childrenWithName.size();
-            for (int i = 0; i < count; i++) {
-                TreeElement child = childrenWithName.get(i);
-                if (child.getMultiplicity() != i) {
+            for (TreeElement child : node.getChildrenWithName(name)) {
+                if (child.getMultiplicity() != i++)
                     throw new IllegalStateException("Unexpected multiplicity mismatch");
-                }
                 treeReferences.add(child.getRef());
             }
             if (includeTemplates) {

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
@@ -37,7 +36,9 @@ import org.javarosa.xpath.expr.XPathPathExpr;
  * function handlers and (not supported) variable bindings.
  */
 public class EvaluationContext {
-    /** Unambiguous anchor reference for relative paths */
+    /**
+     * Unambiguous anchor reference for relative paths
+     */
     private TreeReference contextNode;
     private HashMap<String, IFunctionHandler> functionHandlers;
     private HashMap<String, Object> variables;
@@ -45,7 +46,7 @@ public class EvaluationContext {
     public boolean isConstraint; //true if we are evaluating a constraint
     public IAnswerData candidateValue; //if isConstraint, this is the value being validated
     public boolean isCheckAddChild; //if isConstraint, true if we are checking the constraint of a parent node on how
-                                    //  many children it may have
+    //  many children it may have
 
     private String outputTextForm = null; //Responsible for informing itext what form is requested if relevant
 
@@ -61,8 +62,10 @@ public class EvaluationContext {
     private DataInstance instance;
     private int[] predicateEvaluationProgress;
 
-    /** Copy Constructor **/
-    private EvaluationContext (EvaluationContext base) {
+    /**
+     * Copy Constructor
+     **/
+    private EvaluationContext(EvaluationContext base) {
         //TODO: These should be deep, not shallow
         functionHandlers = base.functionHandlers;
         formInstances = base.formInstances;
@@ -84,27 +87,27 @@ public class EvaluationContext {
         currentContextPosition = base.currentContextPosition;
     }
 
-    public EvaluationContext (EvaluationContext base, TreeReference context) {
+    public EvaluationContext(EvaluationContext base, TreeReference context) {
         this(base);
         this.contextNode = context;
     }
 
-    public EvaluationContext (EvaluationContext base, HashMap<String, DataInstance> formInstances, TreeReference context) {
+    public EvaluationContext(EvaluationContext base, HashMap<String, DataInstance> formInstances, TreeReference context) {
         this(base, context);
         this.formInstances = formInstances;
     }
 
-    public EvaluationContext (DataInstance instance, HashMap<String, DataInstance> formInstances, EvaluationContext base) {
+    public EvaluationContext(DataInstance instance, HashMap<String, DataInstance> formInstances, EvaluationContext base) {
         this(base);
         this.formInstances = formInstances;
         this.instance = instance;
     }
 
-    public EvaluationContext (DataInstance instance) {
+    public EvaluationContext(DataInstance instance) {
         this(instance, new HashMap<String, DataInstance>());
     }
 
-    public EvaluationContext (DataInstance instance, HashMap<String, DataInstance> formInstances) {
+    public EvaluationContext(DataInstance instance, HashMap<String, DataInstance> formInstances) {
         this.formInstances = formInstances;
         this.instance = instance;
         this.contextNode = TreeReference.rootRef();
@@ -118,7 +121,7 @@ public class EvaluationContext {
             (instance != null && id.equals(instance.getName()) ? instance : null);
     }
 
-    public TreeReference getContextRef () {
+    public TreeReference getContextRef() {
         return contextNode;
     }
 
@@ -130,11 +133,11 @@ public class EvaluationContext {
         return (original == null) ? contextNode : original;
     }
 
-    public void addFunctionHandler (IFunctionHandler fh) {
+    public void addFunctionHandler(IFunctionHandler fh) {
         functionHandlers.put(fh.getName(), fh);
     }
 
-    public HashMap<String, IFunctionHandler> getFunctionHandlers () {
+    public HashMap<String, IFunctionHandler> getFunctionHandlers() {
         return functionHandlers;
     }
 
@@ -162,12 +165,12 @@ public class EvaluationContext {
         //Otherwise check whether the value is one of the normal first
         //order datatypes used in xpath evaluation
         if (value instanceof Boolean ||
-                   value instanceof Double  ||
-                   value instanceof String  ||
-                   value instanceof Date    ||
-                   value instanceof IExprDataType) {
-                variables.put(name, value);
-                return;
+            value instanceof Double ||
+            value instanceof String ||
+            value instanceof Date ||
+            value instanceof IExprDataType) {
+            variables.put(name, value);
+            return;
         }
 
         //Some datatypes can be trivially converted to a first order
@@ -192,16 +195,16 @@ public class EvaluationContext {
     /**
      * Searches for all repeated nodes that match the pattern of the 'ref'
      * argument.
-     *
+     * <p>
      * '/' returns {'/'}
      * can handle sub-repetitions (e.g., {/a[1]/b[1], /a[1]/b[2], /a[2]/b[1]})
      *
      * @param ref Potentially ambiguous reference
      * @return Null if 'ref' is relative reference. Otherwise, returns a vector
-     * of references that point to nodes that match 'ref' argument. These
-     * references are unambiguous (no index will ever be INDEX_UNBOUND). Template
-     * nodes won't be included when matching INDEX_UNBOUND, but will be when
-     * INDEX_TEMPLATE is explicitly set.
+     *     of references that point to nodes that match 'ref' argument. These
+     *     references are unambiguous (no index will ever be INDEX_UNBOUND). Template
+     *     nodes won't be included when matching INDEX_UNBOUND, but will be when
+     *     INDEX_TEMPLATE is explicitly set.
      */
     public List<TreeReference> expandReference(TreeReference ref, boolean includeTemplates) {
         if (!ref.isAbsolute()) {
@@ -212,7 +215,7 @@ public class EvaluationContext {
 
         if (baseInstance == null) {
             throw new RuntimeException("Unable to expand reference " + ref.toString(true) +
-                    ", no appropriate instance in evaluation context");
+                ", no appropriate instance in evaluation context");
         }
 
         List<TreeReference> treeReferences = new ArrayList<>(1);
@@ -455,6 +458,7 @@ public class EvaluationContext {
         }
         return null;
     }
+
     private EvaluationContext rescope(TreeReference treeRef, int currentContextPosition) {
         EvaluationContext ec = new EvaluationContext(this, treeRef);
         // broken:

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -406,28 +406,6 @@ public class EvaluationContext {
         return null;
     }
 
-    private EvaluationContext rescope(TreeReference treeRef, int currentContextPosition) {
-        EvaluationContext ec = new EvaluationContext(this, treeRef);
-        // broken:
-        ec.currentContextPosition = currentContextPosition;
-        //If there was no original context position, we'll want to set the next original
-        //context to be this rescoping (which would be the backup original one).
-        if (original != null) {
-            ec.setOriginalContext(getOriginalContext());
-        } else {
-            //Check to see if we have a context, if not, the treeRef is the original declared
-            //nodeset.
-            if (TreeReference.rootRef().equals(getContextRef())) {
-                ec.setOriginalContext(treeRef);
-            } else {
-                //If we do have a legit context, use it!
-                ec.setOriginalContext(getContextRef());
-            }
-
-        }
-        return ec;
-    }
-
     public DataInstance getMainInstance() {
         return instance;
     }

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -63,7 +63,6 @@ public class EvaluationContext {
     private int currentContextPosition = -1;
 
     private DataInstance instance;
-    private int[] predicateEvaluationProgress;
 
     /**
      * Copy Constructor
@@ -339,9 +338,6 @@ public class EvaluationContext {
     }
 
     private List<TreeReference> filterRefs(DataInstance sourceInstance, List<XPathExpression> predicates, List<TreeReference> treeReferences) {
-        if (!predicates.isEmpty() && predicateEvaluationProgress != null)
-            predicateEvaluationProgress[1] += treeReferences.size();
-
         if (predicates.isEmpty())
             return treeReferences;
 
@@ -352,8 +348,6 @@ public class EvaluationContext {
             while (passes && predicateIterator.hasNext()) {
                 // TODO This sentence will throw if the predicate produces a value that's not casteable to Boolean. Throw a controlled exception with a useful message instead.
                 passes = (Boolean) predicateIterator.next().eval(sourceInstance, this);
-                if (predicateEvaluationProgress != null)
-                    predicateEvaluationProgress[0]++;
             }
             if (passes)
                 filteredRefs.add(ref);

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -260,11 +260,10 @@ public class EvaluationContext {
         final AbstractTreeElement<TreeElement> node = (AbstractTreeElement<TreeElement>) sourceInstance.resolveReference(workingRef);
 
         boolean runPredicates = true;
-        boolean toggleOptimizedFiltering = true;
         if (node.getNumChildren() > 0) {
             if (mult == TreeReference.INDEX_UNBOUND) {
                 List<TreeElement> childrenWithName = null;
-                if (toggleOptimizedFiltering && predicates != null && predicates.size() == 1 && predicates.get(0) instanceof XPathEqExpr) {
+                if (predicates != null && predicates.size() == 1 && predicates.get(0) instanceof XPathEqExpr) {
                     XPathEqExpr eqExpr = (XPathEqExpr) predicates.get(0);
                     XPathPathExpr valueExpr = null;
                     String filterFieldName = null;

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -373,10 +373,9 @@ public class EvaluationContext {
     }
 
     private List<TreeReference> getRefs(boolean includeTemplates, AbstractTreeElement<TreeElement> node, String name, int mult) {
-        final List<TreeReference> treeReferences = new ArrayList<>(1);
-
         if (node.getNumChildren() > 0) {
             if (mult == TreeReference.INDEX_UNBOUND) {
+                final List<TreeReference> treeReferences = new ArrayList<>(1);
                 List<TreeElement> childrenWithName = node.getChildrenWithName(name);
                 final int count = childrenWithName.size();
                 for (int i = 0; i < count; i++) {
@@ -392,13 +391,14 @@ public class EvaluationContext {
                         treeReferences.add(template.getRef());
                     }
                 }
+                return treeReferences;
             } else if (mult != TreeReference.INDEX_ATTRIBUTE) {
                 //TODO: Make this test mult >= 0?
                 //If the multiplicity is a simple integer, just get
                 //the appropriate child
                 AbstractTreeElement child = node.getChild(name, mult);
                 if (child != null) {
-                    treeReferences.add(child.getRef());
+                    return Arrays.asList(child.getRef());
                 }
             }
         }
@@ -406,10 +406,10 @@ public class EvaluationContext {
         if (mult == TreeReference.INDEX_ATTRIBUTE) {
             AbstractTreeElement attribute = node.getAttribute(null, name);
             if (attribute != null) {
-                treeReferences.add(attribute.getRef());
+                return Arrays.asList(attribute.getRef());
             }
         }
-        return treeReferences;
+        return new ArrayList<>();
     }
 
     private String extractEqExprFieldName(XPathExpression eqExprPart) {

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -373,33 +373,32 @@ public class EvaluationContext {
     }
 
     private List<TreeReference> getRefs(boolean includeTemplates, AbstractTreeElement<TreeElement> node, String name, int mult) {
-        if (node.getNumChildren() > 0) {
-            if (mult == TreeReference.INDEX_UNBOUND) {
-                final List<TreeReference> treeReferences = new ArrayList<>(1);
-                List<TreeElement> childrenWithName = node.getChildrenWithName(name);
-                final int count = childrenWithName.size();
-                for (int i = 0; i < count; i++) {
-                    TreeElement child = childrenWithName.get(i);
-                    if (child.getMultiplicity() != i) {
-                        throw new IllegalStateException("Unexpected multiplicity mismatch");
-                    }
-                    treeReferences.add(child.getRef());
+        if (node.getNumChildren() > 0 && mult == TreeReference.INDEX_UNBOUND) {
+            final List<TreeReference> treeReferences = new ArrayList<>(1);
+            List<TreeElement> childrenWithName = node.getChildrenWithName(name);
+            final int count = childrenWithName.size();
+            for (int i = 0; i < count; i++) {
+                TreeElement child = childrenWithName.get(i);
+                if (child.getMultiplicity() != i) {
+                    throw new IllegalStateException("Unexpected multiplicity mismatch");
                 }
-                if (includeTemplates) {
-                    AbstractTreeElement template = node.getChild(name, TreeReference.INDEX_TEMPLATE);
-                    if (template != null) {
-                        treeReferences.add(template.getRef());
-                    }
+                treeReferences.add(child.getRef());
+            }
+            if (includeTemplates) {
+                AbstractTreeElement template = node.getChild(name, TreeReference.INDEX_TEMPLATE);
+                if (template != null) {
+                    treeReferences.add(template.getRef());
                 }
-                return treeReferences;
-            } else if (mult != TreeReference.INDEX_ATTRIBUTE) {
-                //TODO: Make this test mult >= 0?
-                //If the multiplicity is a simple integer, just get
-                //the appropriate child
-                AbstractTreeElement child = node.getChild(name, mult);
-                if (child != null) {
-                    return Arrays.asList(child.getRef());
-                }
+            }
+            return treeReferences;
+        }
+        if (node.getNumChildren() > 0 && mult != TreeReference.INDEX_ATTRIBUTE) {
+            //TODO: Make this test mult >= 0?
+            //If the multiplicity is a simple integer, just get
+            //the appropriate child
+            AbstractTreeElement child = node.getChild(name, mult);
+            if (child != null) {
+                return Arrays.asList(child.getRef());
             }
         }
 

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -330,12 +330,7 @@ public class EvaluationContext {
     }
 
     private void originalAlgorithm(TreeReference sourceRef, DataInstance sourceInstance, List<TreeReference> refs, boolean includeTemplates, AbstractTreeElement<TreeElement> node, List<XPathExpression> predicates, int depth) {
-        // Get the next set of matching references
-        final String name = sourceRef.getName(depth);
-
-        //ETHERTON: Is this where we should test for predicates?
-        final int mult = sourceRef.getMultiplicity(depth);
-        final List<TreeReference> treeReferences = getRefs(includeTemplates, node, name, mult);
+        List<TreeReference> treeReferences = getRefs(includeTemplates, node, sourceRef.getName(depth), sourceRef.getMultiplicity(depth));
 
         filterRefs(sourceInstance, predicates, treeReferences);
 

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -367,36 +367,34 @@ public class EvaluationContext {
             }
         }
 
-        if (predicates != null && predicateEvaluationProgress != null) {
+        if (!predicates.isEmpty() && predicateEvaluationProgress != null) {
             predicateEvaluationProgress[1] += treeReferences.size();
         }
 
-        if (predicates != null) {
-            boolean firstTime = true;
-            List<TreeReference> passed = new ArrayList<TreeReference>(treeReferences.size());
-            for (XPathExpression xpe : predicates) {
-                for (int i = 0; i < treeReferences.size(); ++i) {
-                    //if there are predicates then we need to see if e.nextElement meets the standard of the predicate
-                    TreeReference treeRef = treeReferences.get(i);
+        boolean firstTime = true;
+        List<TreeReference> passed = new ArrayList<TreeReference>(treeReferences.size());
+        for (XPathExpression xpe : predicates) {
+            for (int i = 0; i < treeReferences.size(); ++i) {
+                //if there are predicates then we need to see if e.nextElement meets the standard of the predicate
+                TreeReference treeRef = treeReferences.get(i);
 
-                    //test the predicate on the treeElement
-                    EvaluationContext evalContext = rescope(treeRef, (firstTime ? treeRef.getMultLast() : i));
-                    Object o = xpe.eval(sourceInstance, evalContext);
-                    if (o instanceof Boolean) {
-                        boolean testOutcome = (Boolean) o;
-                        if (testOutcome) {
-                            passed.add(treeRef);
-                        }
+                //test the predicate on the treeElement
+                EvaluationContext evalContext = rescope(treeRef, (firstTime ? treeRef.getMultLast() : i));
+                Object o = xpe.eval(sourceInstance, evalContext);
+                if (o instanceof Boolean) {
+                    boolean testOutcome = (Boolean) o;
+                    if (testOutcome) {
+                        passed.add(treeRef);
                     }
                 }
-                firstTime = false;
-                treeReferences.clear();
-                treeReferences.addAll(passed);
-                passed.clear();
+            }
+            firstTime = false;
+            treeReferences.clear();
+            treeReferences.addAll(passed);
+            passed.clear();
 
-                if (predicateEvaluationProgress != null) {
-                    predicateEvaluationProgress[0]++;
-                }
+            if (predicateEvaluationProgress != null) {
+                predicateEvaluationProgress[0]++;
             }
         }
 

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -261,7 +261,6 @@ public class EvaluationContext {
 
         boolean runPredicates = true;
         boolean toggleOptimizedFiltering = true;
-        boolean toggleFilteredValuesCache = true;
         if (node.getNumChildren() > 0) {
             if (mult == TreeReference.INDEX_UNBOUND) {
                 List<TreeElement> childrenWithName = null;
@@ -283,7 +282,7 @@ public class EvaluationContext {
                         XPathNodeset eval = valueExpr.eval(sourceInstance, ec);
                         String value = (String) eval.getValAt(0);
                         if (value != null) {
-                            childrenWithName = node.getChildrenWithName(name, filterFieldName, value, toggleFilteredValuesCache);
+                            childrenWithName = node.getChildrenWithName(name, filterFieldName, value);
                             runPredicates = false;
                         }
                     }

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -332,35 +332,9 @@ public class EvaluationContext {
         final int mult = sourceRef.getMultiplicity(depth);
         final List<TreeReference> treeReferences = new ArrayList<>(1);
 
-        boolean runPredicates = true;
         if (node.getNumChildren() > 0) {
             if (mult == TreeReference.INDEX_UNBOUND) {
-                List<TreeElement> childrenWithName = null;
-                if (predicates != null && predicates.size() == 1 && predicates.get(0) instanceof XPathEqExpr) {
-                    XPathEqExpr eqExpr = (XPathEqExpr) predicates.get(0);
-                    XPathPathExpr valueExpr = null;
-                    String filterFieldName = null;
-                    String fieldNameInA = extractEqExprFieldName(eqExpr.a);
-                    String fieldNameInB = extractEqExprFieldName(eqExpr.b);
-                    if (fieldNameInA != null) {
-                        filterFieldName = fieldNameInA;
-                        valueExpr = (XPathPathExpr) eqExpr.b;
-                    } else if (fieldNameInB != null) {
-                        filterFieldName = fieldNameInB;
-                        valueExpr = (XPathPathExpr) eqExpr.a;
-                    }
-                    if (filterFieldName != null && valueExpr != null) {
-                        EvaluationContext ec = new EvaluationContext(this, valueExpr.getReference());
-                        XPathNodeset eval = valueExpr.eval(sourceInstance, ec);
-                        String value = (String) eval.getValAt(0);
-                        if (value != null) {
-                            childrenWithName = node.getChildrenWithName(name, filterFieldName, value);
-                            runPredicates = false;
-                        }
-                    }
-                }
-                if (childrenWithName == null)
-                    childrenWithName = node.getChildrenWithName(name);
+                List<TreeElement> childrenWithName = node.getChildrenWithName(name);
                 final int count = childrenWithName.size();
                 for (int i = 0; i < count; i++) {
                     TreeElement child = childrenWithName.get(i);
@@ -393,11 +367,11 @@ public class EvaluationContext {
             }
         }
 
-        if (predicates != null && runPredicates && predicateEvaluationProgress != null) {
+        if (predicates != null && predicateEvaluationProgress != null) {
             predicateEvaluationProgress[1] += treeReferences.size();
         }
 
-        if (predicates != null && runPredicates) {
+        if (predicates != null) {
             boolean firstTime = true;
             List<TreeReference> passed = new ArrayList<TreeReference>(treeReferences.size());
             for (XPathExpression xpe : predicates) {

--- a/src/main/java/org/javarosa/core/model/instance/AbstractTreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/AbstractTreeElement.java
@@ -26,6 +26,7 @@ public interface AbstractTreeElement<T extends AbstractTreeElement> {
      */
     public abstract List<T> getChildrenWithName(String name);
 
+    public abstract List<T> getChildrenWithName(String name, String filterField, String filterValue, boolean useCache);
     public abstract boolean hasChildren();
 
     public abstract int getNumChildren();

--- a/src/main/java/org/javarosa/core/model/instance/AbstractTreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/AbstractTreeElement.java
@@ -26,7 +26,7 @@ public interface AbstractTreeElement<T extends AbstractTreeElement> {
      */
     public abstract List<T> getChildrenWithName(String name);
 
-    public abstract List<T> getChildrenWithName(String name, String filterField, String filterValue, boolean useCache);
+    public abstract List<T> getChildrenWithName(String name, String filterField, String filterValue);
     public abstract boolean hasChildren();
 
     public abstract int getNumChildren();

--- a/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -227,8 +227,8 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
     }
 
     @Override
-    public List<TreeElement> getChildrenWithName(String name, String filterField, String filterValue, boolean useCache) {
-        return children.get(name, filterField, filterValue, useCache);
+    public List<TreeElement> getChildrenWithName(String name, String filterField, String filterValue) {
+        return children.get(name, filterField, filterValue);
     }
     private int getNumChildrenWithName(String name) {
         return children.getCount(name);

--- a/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -62,7 +62,7 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
  *
  * <p>TODO: Split out the bind-able session data from this class and leave only the mandatory values to speed up
  * new DOM-like models</p>
- 
+
  * @author Clayton Sims
  */
 
@@ -226,6 +226,10 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
         return children.get(name);
     }
 
+    @Override
+    public List<TreeElement> getChildrenWithName(String name, String filterField, String filterValue, boolean useCache) {
+        return children.get(name, filterField, filterValue, useCache);
+    }
     private int getNumChildrenWithName(String name) {
         return children.getCount(name);
     }

--- a/src/main/java/org/javarosa/core/model/instance/utils/TreeElementChildrenList.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/TreeElementChildrenList.java
@@ -120,34 +120,21 @@ public class TreeElementChildrenList implements Iterable<TreeElement> {
 
     private final Map<FilterKey, List<TreeElement>> filteredRawValuesCache = new ConcurrentHashMap<>();
 
-    public List<TreeElement> get(String name, String filterFieldName, String filterValue, boolean useCache) {
-        if (!useCache) {
-            List<TreeElement> filteredRawValues = new ArrayList<>();
-            int multiplicitySeq = 0;
-            for (TreeElement rawValue : this)
-                if (rawValue.getName().equals(name) && rawValue.getChildrenWithName(filterFieldName).get(0).getValue().getDisplayText().equals(filterValue)) {
-                    // Set the mult so that populateDynamicChoices doesn't complain
-                    TreeElement rawValueCopy = rawValue.shallowCopy();
-                    rawValueCopy.setMult(multiplicitySeq++);
-                    filteredRawValues.add(rawValueCopy);
-                }
-            return filteredRawValues;
-        } else {
-            FilterKey key = new FilterKey(name, filterFieldName, filterValue);
-            if (filteredRawValuesCache.containsKey(key))
-                return filteredRawValuesCache.get(key);
-            List<TreeElement> filteredRawValues = new ArrayList<>();
-            int multiplicitySeq = 0;
-            for (TreeElement rawValue : this)
-                if (rawValue.getName().equals(name) && rawValue.getChildrenWithName(filterFieldName).get(0).getValue().getDisplayText().equals(filterValue)) {
-                    // Set the mult so that populateDynamicChoices doesn't complain
-                    TreeElement rawValueCopy = rawValue.shallowCopy();
-                    rawValueCopy.setMult(multiplicitySeq++);
-                    filteredRawValues.add(rawValueCopy);
-                }
-            filteredRawValuesCache.put(key, filteredRawValues);
-            return filteredRawValues;
-        }
+    public List<TreeElement> get(String name, String filterFieldName, String filterValue) {
+        FilterKey key = new FilterKey(name, filterFieldName, filterValue);
+        if (filteredRawValuesCache.containsKey(key))
+            return filteredRawValuesCache.get(key);
+        List<TreeElement> filteredRawValues = new ArrayList<>();
+        int multiplicitySeq = 0;
+        for (TreeElement rawValue : this)
+            if (rawValue.getName().equals(name) && rawValue.getChildrenWithName(filterFieldName).get(0).getValue().getDisplayText().equals(filterValue)) {
+                // Set the mult so that populateDynamicChoices doesn't complain
+                TreeElement rawValueCopy = rawValue.shallowCopy();
+                rawValueCopy.setMult(multiplicitySeq++);
+                filteredRawValues.add(rawValueCopy);
+            }
+        filteredRawValuesCache.put(key, filteredRawValues);
+        return filteredRawValues;
     }
 
     /**

--- a/src/main/java/org/javarosa/core/model/instance/utils/TreeElementChildrenList.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/TreeElementChildrenList.java
@@ -125,14 +125,9 @@ public class TreeElementChildrenList implements Iterable<TreeElement> {
         if (filteredRawValuesCache.containsKey(key))
             return filteredRawValuesCache.get(key);
         List<TreeElement> filteredRawValues = new ArrayList<>();
-        int multiplicitySeq = 0;
         for (TreeElement rawValue : this)
-            if (rawValue.getName().equals(name) && rawValue.getChildrenWithName(filterFieldName).get(0).getValue().getDisplayText().equals(filterValue)) {
-                // Set the mult so that populateDynamicChoices doesn't complain
-                TreeElement rawValueCopy = rawValue.shallowCopy();
-                rawValueCopy.setMult(multiplicitySeq++);
-                filteredRawValues.add(rawValueCopy);
-            }
+            if (rawValue.getName().equals(name) && rawValue.getChildrenWithName(filterFieldName).get(0).getValue().getDisplayText().equals(filterValue))
+                filteredRawValues.add(rawValue);
         filteredRawValuesCache.put(key, filteredRawValues);
         return filteredRawValues;
     }

--- a/src/main/java/org/javarosa/core/model/instance/utils/TreeElementChildrenList.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/TreeElementChildrenList.java
@@ -1,13 +1,15 @@
 package org.javarosa.core.model.instance.utils;
 
-import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.core.model.instance.TreeReference;
+import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.TreeReference;
 
 /**
  * A collection of {@link TreeElement} children. They are stored in an {@link ArrayList}.
@@ -16,27 +18,36 @@ import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICIT
  */
 public class TreeElementChildrenList implements Iterable<TreeElement> {
     private final List<TreeElement> children = new ArrayList<>();
-    /** If all children have the same name, and all multiplicities are ≥ 0, children can be located in constant time */
+    /**
+     * If all children have the same name, and all multiplicities are ≥ 0, children can be located in constant time
+     */
     private boolean allHaveSameNameAndNormalMult = true;
 
-    /** Returns the number of children */
+    /**
+     * Returns the number of children
+     */
     public int size() {
         return children.size();
     }
 
-    @Override public Iterator<TreeElement> iterator() {
+    @Override
+    public Iterator<TreeElement> iterator() {
         return children.iterator();
     }
 
-    /** Adds a child at the specified index */
+    /**
+     * Adds a child at the specified index
+     */
     public void add(int index, TreeElement child) {
         checkAndSetSameNameAndNormalMult(child.getName(), child.getMultiplicity());
         children.add(index, child);
     }
 
-    /** Adds all of the provided children */
+    /**
+     * Adds all of the provided children
+     */
     public void addAll(Iterable<TreeElement> childIterable) {
-        for (TreeElement child: childIterable) {
+        for (TreeElement child : childIterable) {
             checkAndSetSameNameAndNormalMult(child.getName(), child.getMultiplicity());
             children.add(child);
         }
@@ -59,19 +70,89 @@ public class TreeElementChildrenList implements Iterable<TreeElement> {
         children.add(newIndex, child);
     }
 
-    /** Gets the child at the specified index */
+    /**
+     * Gets the child at the specified index
+     */
     public TreeElement get(int index) {
         return children.get(index);
     }
 
-    /** Gets all children with the specified name */
+    /**
+     * Gets all children with the specified name
+     */
     public List<TreeElement> get(String name) {
         List<TreeElement> children = new ArrayList<>();
         findChildrenWithName(name, children);
         return children;
     }
 
-    /** Gets the child with the specified name and multiplicity */
+    static class FilterKey {
+        private final String name;
+        private final String field;
+        private final String value;
+
+        FilterKey(String name, String field, String value) {
+            this.name = name;
+            this.field = field;
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            FilterKey filterKey = (FilterKey) o;
+            return Objects.equals(name, filterKey.name) &&
+                Objects.equals(field, filterKey.field) &&
+                Objects.equals(value, filterKey.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, field, value);
+        }
+
+        @Override
+        public String toString() {
+            return name + '[' + field + ':' + value + ']';
+        }
+    }
+
+    private final Map<FilterKey, List<TreeElement>> filteredRawValuesCache = new ConcurrentHashMap<>();
+
+    public List<TreeElement> get(String name, String filterFieldName, String filterValue, boolean useCache) {
+        if (!useCache) {
+            List<TreeElement> filteredRawValues = new ArrayList<>();
+            int multiplicitySeq = 0;
+            for (TreeElement rawValue : this)
+                if (rawValue.getName().equals(name) && rawValue.getChildrenWithName(filterFieldName).get(0).getValue().getDisplayText().equals(filterValue)) {
+                    // Set the mult so that populateDynamicChoices doesn't complain
+                    TreeElement rawValueCopy = rawValue.shallowCopy();
+                    rawValueCopy.setMult(multiplicitySeq++);
+                    filteredRawValues.add(rawValueCopy);
+                }
+            return filteredRawValues;
+        } else {
+            FilterKey key = new FilterKey(name, filterFieldName, filterValue);
+            if (filteredRawValuesCache.containsKey(key))
+                return filteredRawValuesCache.get(key);
+            List<TreeElement> filteredRawValues = new ArrayList<>();
+            int multiplicitySeq = 0;
+            for (TreeElement rawValue : this)
+                if (rawValue.getName().equals(name) && rawValue.getChildrenWithName(filterFieldName).get(0).getValue().getDisplayText().equals(filterValue)) {
+                    // Set the mult so that populateDynamicChoices doesn't complain
+                    TreeElement rawValueCopy = rawValue.shallowCopy();
+                    rawValueCopy.setMult(multiplicitySeq++);
+                    filteredRawValues.add(rawValueCopy);
+                }
+            filteredRawValuesCache.put(key, filteredRawValues);
+            return filteredRawValues;
+        }
+    }
+
+    /**
+     * Gets the child with the specified name and multiplicity
+     */
     public TreeElement get(String name, int multiplicity) {
         TreeElementChildrenList.ElementAndLoc el = getChildAndLoc(name, multiplicity);
         if (el == null) {
@@ -80,12 +161,16 @@ public class TreeElementChildrenList implements Iterable<TreeElement> {
         return el.treeElement;
     }
 
-    /** Gets a count of all children with the specified name */
+    /**
+     * Gets a count of all children with the specified name
+     */
     public int getCount(String name) {
         return findChildrenWithName(name, null);
     }
 
-    /** Sets {@link #allHaveSameNameAndNormalMult} */
+    /**
+     * Sets {@link #allHaveSameNameAndNormalMult}
+     */
     private void checkAndSetSameNameAndNormalMult(String name, int mult) {
         allHaveSameNameAndNormalMult = sameNameAndNormalMult(name, mult);
     }
@@ -98,12 +183,13 @@ public class TreeElementChildrenList implements Iterable<TreeElement> {
      */
     private boolean sameNameAndNormalMult(String name, int mult) {
         return allHaveSameNameAndNormalMult && mult >= 0 &&
-                (children.isEmpty() || name.equals(children.get(0).getName()));
+            (children.isEmpty() || name.equals(children.get(0).getName()));
     }
 
     /**
      * Returns the count of children with the given name, and if {@code results} is not null, stores the children there.
-     * @param name the name to look for
+     *
+     * @param name    the name to look for
      * @param results a List into which to store the children, or null
      * @return the number of children with the given name
      */
@@ -118,7 +204,7 @@ public class TreeElementChildrenList implements Iterable<TreeElement> {
         int count = 0;
         for (TreeElement child : children) {
             if ((child.getMultiplicity() != TreeReference.INDEX_TEMPLATE) &&
-                    TreeElementNameComparator.elementMatchesName(child, name)) {
+                TreeElementNameComparator.elementMatchesName(child, name)) {
                 ++count;
                 if (results != null) {
                     results.add(child);
@@ -128,17 +214,23 @@ public class TreeElementChildrenList implements Iterable<TreeElement> {
         return count;
     }
 
-    /** Removes a child at the specified index */
+    /**
+     * Removes a child at the specified index
+     */
     public TreeElement remove(int index) {
         return children.remove(index);
     }
 
-    /** Removes a specific child */
+    /**
+     * Removes a specific child
+     */
     public boolean remove(TreeElement treeElement) {
         return children.remove(treeElement);
     }
 
-    /** Removes the first child with the given name and multiplicity, if one exists */
+    /**
+     * Removes the first child with the given name and multiplicity, if one exists
+     */
     public void remove(String name, int multiplicity) {
         TreeElement child = get(name, multiplicity);
         if (child != null) {
@@ -152,7 +244,9 @@ public class TreeElementChildrenList implements Iterable<TreeElement> {
         }
     }
 
-    /** Removes all children */
+    /**
+     * Removes all children
+     */
     public void clear() {
         children.clear();
     }
@@ -173,7 +267,7 @@ public class TreeElementChildrenList implements Iterable<TreeElement> {
 
     private ElementAndLoc getChildAndLoc(String name, int multiplicity) {
         if (name.equals(TreeReference.NAME_WILDCARD)) {
-            if(multiplicity == TreeReference.INDEX_TEMPLATE || children.size() < multiplicity + 1) {
+            if (multiplicity == TreeReference.INDEX_TEMPLATE || children.size() < multiplicity + 1) {
                 return null;
             }
             return new ElementAndLoc(children.get(multiplicity), multiplicity); //droos: i'm suspicious of this


### PR DESCRIPTION
We're trying to find out ways to improve user-experience of big cascading selects.

This PR explores hijacking the normal XPath filtering of an itemset's nodeset when it uses a predicate with an XPath expression like `[field = /some/other/path]`.

The hijack consists in resolving the field name and filtering value defined in the predicate during `EvaluationContext.expandReferenceAccumulator()` and letting the `TreeElementChildrenList` compute a filtered list in memory with that.

This is a super narrow optimization that targets the main use case of cascading selects.

Check out https://github.com/opendatakit/javarosa/commit/b59e3f026a0d6eebc8f177f685eaeb76efbe7ba4

Benchmark results for the "browsing" use-case defined in the `NigeriaWardsBrowsingRunBenchmark` class:

| Settings | Time | Error |
| --- | --- | --- |
| No filtering hijack, no cache	| 24,698.80 µs	| 361.68 µs |
| Filtering hijack, no cache	| 15,410.88 µs	| 147.33 µs |
| Filtering hijack, cache	| 8,141.32 µs	| 100.18 µs |

![chart](https://user-images.githubusercontent.com/205913/57876230-2c09d900-7815-11e9-8312-26b6ced0b34c.png)