### PR TITLE
Fixed editingFormsSavedInDifferentTimezoneTest

### DIFF
--- a/src/test/java/org/javarosa/core/model/data/test/TimeDataLimitationsTest.java
+++ b/src/test/java/org/javarosa/core/model/data/test/TimeDataLimitationsTest.java
@@ -6,6 +6,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Date;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
@@ -46,7 +47,9 @@ public class TimeDataLimitationsTest {
     public void editingFormsSavedInDifferentTimezoneTest() {
         // A user is in Warsaw (GMT+2) saved a form with the time question
         TimeZone.setDefault(TimeZone.getTimeZone("Europe/Warsaw"));
-        String savedTime = "10:00:00.000+02:00";
+
+        boolean isSummerTime = TimeZone.getDefault().inDaylightTime(new Date());
+        String savedTime = isSummerTime ? "10:00:00.000+02:00" : "10:00:00.000+01:00";
 
         // A user opens saved form in Warsaw as well - the hour should be the same
         TimeData timeData = new TimeData(DateUtils.parseTime(savedTime));


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I ran the fixed test.

#### Why is this the best possible solution? Were any other approaches considered?
The time offset in Warsaw depends on whether it's summer or winter time so it should be respected.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.
