### PR TITLE
Add `FormIndex#getPreviousLevel` and `FormEntryController#jumpToNewRepeat`

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -547,4 +547,12 @@ public class FormIndex implements Serializable {
             i++;
         }
     }
+
+    public FormIndex getPreviousLevel() {
+        if (isTerminal()) {
+            return null;
+        } else {
+            return new FormIndex(nextLevel.getPreviousLevel(), this);
+        }
+    }
 }

--- a/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -16,7 +16,6 @@
 
 package org.javarosa.core.model;
 
-import jdk.internal.jline.internal.Nullable;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.Objects;
 

--- a/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -244,7 +244,7 @@ public class FormIndex implements Serializable {
 
     /**
      * @return An index into the next level of specificity past the current context. An
-     * example would be an index  into an element that is a child of the element referenced
+     * example would be an index into an element that is a child of the element referenced
      * by the local index.
      */
     public FormIndex getNextLevel() {
@@ -549,6 +549,11 @@ public class FormIndex implements Serializable {
         }
     }
 
+    /**
+     * @return An index into the previous level of specificity from this index. Could
+     * also be described as returning the index representing the parent element of this
+     * index
+     */
     public FormIndex getPreviousLevel() {
         if (isTerminal()) {
             return null;

--- a/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -16,6 +16,7 @@
 
 package org.javarosa.core.model;
 
+import jdk.internal.jline.internal.Nullable;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.Objects;
 

--- a/src/main/java/org/javarosa/form/api/FormEntryController.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryController.java
@@ -303,6 +303,10 @@ public class FormEntryController {
 
     public void jumpToNewRepeatPrompt() {
         FormIndex repeatIndex = getRepeatGroupIndex(getModel().getFormIndex(), getModel().getForm());
+        if (repeatIndex == null) {
+            return;
+        }
+
         int repeatDepth = repeatIndex.getDepth();
 
         do {
@@ -316,8 +320,11 @@ public class FormEntryController {
         if (element instanceof GroupDef && ((GroupDef) element).getRepeat()) {
             return index;
         } else {
-            FormIndex previousLevel = index.getPreviousLevel();
-            return getRepeatGroupIndex(previousLevel, formDef);
+            if (index.getPreviousLevel() != null) {
+                return getRepeatGroupIndex(index.getPreviousLevel(), formDef);
+            } else {
+                return null;
+            }
         }
     }
 }

--- a/src/main/java/org/javarosa/form/api/FormEntryController.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryController.java
@@ -301,6 +301,10 @@ public class FormEntryController {
         model.setLanguage(language);
     }
 
+    /**
+     * Jump to the prompt to add a new repeat for the repeat the controller is currently in. If the current
+     * position in the form is no in a repeat nothing will happen.
+     */
     public void jumpToNewRepeatPrompt() {
         FormIndex repeatIndex = getRepeatGroupIndex(getModel().getFormIndex(), getModel().getForm());
         if (repeatIndex == null) {

--- a/src/main/java/org/javarosa/form/api/FormEntryController.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryController.java
@@ -303,7 +303,7 @@ public class FormEntryController {
 
     /**
      * Jump to the prompt to add a new repeat for the repeat the controller is currently in. If the current
-     * position in the form is no in a repeat nothing will happen.
+     * position in the form is not in a repeat nothing will happen.
      */
     public void jumpToNewRepeatPrompt() {
         FormIndex repeatIndex = getRepeatGroupIndex(getModel().getFormIndex(), getModel().getForm());

--- a/src/test/java/org/javarosa/core/model/FormIndexTest.java
+++ b/src/test/java/org/javarosa/core/model/FormIndexTest.java
@@ -1,0 +1,100 @@
+package org.javarosa.core.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.javarosa.core.model.FormIndex.createBeginningOfFormIndex;
+import static org.javarosa.core.test.Scenario.getRef;
+
+public class FormIndexTest {
+
+    @Test
+    public void getPreviousLevel_atBeginningOfForm_returnsNull() {
+        assertThat(createBeginningOfFormIndex().getPreviousLevel(), is(nullValue()));
+    }
+
+    @Test
+    public void getPreviousLevel_atTheTopLevelOfTheForm_returnsNull() {
+        FormIndex formIndex = new FormIndex(0, getRef("/data/question"));
+        assertThat(formIndex.getPreviousLevel(), is(nullValue()));
+    }
+
+    @Test
+    public void getPreviousLevel_forIndexInGroup_returnsGroup() {
+        FormIndex groupThenQuestionIndex = new FormIndex(
+            new FormIndex(0, getRef("/data/group/question")),
+            7,
+            getRef("/data/group")
+        );
+
+        FormIndex groupIndex = new FormIndex(7, getRef("/data/group"));
+        assertThat(groupThenQuestionIndex.getPreviousLevel(), is(groupIndex));
+    }
+
+    @Test
+    public void getPreviousLevel_forIndexInNestedGroup_returnsInnerGroup() {
+        FormIndex groupThenGroupThenQuestionIndex = new FormIndex(
+            new FormIndex(
+                new FormIndex(0, getRef("/data/outer_group/inner_group/question")),
+                5,
+                getRef("/data/outer_group/inner_group")),
+            1,
+            getRef("/data/outer_group")
+        );
+
+        FormIndex innerGroupIndex = new FormIndex(
+            new FormIndex(5, getRef("/data/outer_group/inner_group")),
+            1,
+            getRef("/data/outer_group")
+        );
+        assertThat(groupThenGroupThenQuestionIndex.getPreviousLevel(), is(innerGroupIndex));
+    }
+
+    @Test
+    public void getPreviousLevel_forRepeatIndex_returnsNull() {
+        FormIndex repeatIndex = new FormIndex(
+            0,
+            2,
+            getRef("/data/repeat[2]")
+        );
+
+        assertThat(repeatIndex.getPreviousLevel(), is(nullValue()));
+    }
+
+    @Test
+    public void getPreviousLevel_forIndexInRepeat_returnsRepeatWithMultiplicity() {
+        FormIndex repeatThenQuestionIndex = new FormIndex(
+            new FormIndex(0, getRef("/data/repeat[2]/question")),
+            7,
+            2,
+            getRef("/data/repeat[2]")
+        );
+
+        FormIndex repeatIndex = new FormIndex(7, 2, getRef("/data/repeat[2]"));
+        assertThat(repeatThenQuestionIndex.getPreviousLevel(), is(repeatIndex));
+    }
+
+    @Test
+    public void getPreviousLevel_forIndexInNestedRepeat_returnsInnerRepeatWithMultiplicity() {
+        FormIndex repeatThenRepeatThenQuestionIndex = new FormIndex(
+            new FormIndex(
+                new FormIndex(0, getRef("/data/repeat[2]/repeat[3]/question")),
+                0,
+                3,
+                getRef("/data/repeat[2]/question")),
+            7,
+            2,
+            getRef("/data/repeat[2]")
+        );
+
+        FormIndex innerRepeatIndex = new FormIndex(
+            new FormIndex(0, 3, getRef("/data/repeat[2]/repeat[3]")),
+            7,
+            2,
+            getRef("/data/repeat[2]")
+        );
+        assertThat(repeatThenRepeatThenQuestionIndex.getPreviousLevel(), is(innerRepeatIndex));
+    }
+}

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -189,8 +189,10 @@ public class Scenario {
      * assertThat(formIndex.getReference(), is(getRef("/data/question[0]")));
      * </code>
      *
-     * If we used just used <code>getRef("/data/question")</code> the test would fail as the multiplicity defaults
-     * to <code>0</code>.
+     * This is because <code>getRef</code> has no way of knowing if a node without multiplicity (<code>[x]</code>) is
+     * a question/group or an unbounded repeat (which would have a multiplicity of <code>-1</code>). Adding the
+     * explicit <code>[0]</code> lets <code>getRef</code> know that the node is not an unbounded repeat and that it,
+     * like a real question or group, should have the default multiplicity of <code>0</code>.
      */
     public static TreeReference getRef(String xpath) {
         if (xpath.trim().isEmpty())

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -180,6 +180,17 @@ public class Scenario {
      * For this reason, this method will try to detect these predicates,
      * turn them into multiplicity values, and remove them from the output
      * reference.
+     *
+     * When using the result of this method for test assertions against {@link FormIndex#getReference()} we need to
+     * specify multiplicity on all steps. For example the following would pass for a form index pointing at a
+     * question at the top level of the form:
+     *
+     * <code>
+     * assertThat(formIndex.getReference(), is(getRef("/data/question[0]")));
+     * </code>
+     *
+     * If we used just used <code>getRef("/data/question")</code> the test would fail as the multiplicity defaults
+     * to <code>0</code>.
      */
     public static TreeReference getRef(String xpath) {
         if (xpath.trim().isEmpty())

--- a/src/test/java/org/javarosa/form/api/FormEntryControllerTest.java
+++ b/src/test/java/org/javarosa/form/api/FormEntryControllerTest.java
@@ -149,4 +149,34 @@ public class FormEntryControllerTest {
         controller.jumpToNewRepeatPrompt();
         assertThat(controller.getModel().getFormIndex().toString(), is("0_1, "));
     }
+
+    @Test
+    public void jumpToNewRepeatPrompt_whenNotInRepeat_doesNothing() throws Exception {
+        Scenario scenario = Scenario.init("questionsOnly", html(
+            head(
+                title("form"),
+                model(
+                    mainInstance(
+                        t("data",
+                            t("question1"),
+                            t("question2")
+                        )
+                    ),
+                    bind("/data/question1").type("int"),
+                    bind("/data/question1").type("int")
+                )
+            ),
+            body(
+                input("/data/question1"),
+                input("/data/question2")
+            )
+        ));
+
+        FormEntryController controller = new FormEntryController(new FormEntryModel(scenario.getFormDef()));
+        assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
+        assertThat(controller.getModel().getFormIndex().toString(), is("0, "));
+
+        controller.jumpToNewRepeatPrompt();
+        assertThat(controller.getModel().getFormIndex().toString(), is("0, "));
+    }
 }

--- a/src/test/java/org/javarosa/form/api/FormEntryControllerTest.java
+++ b/src/test/java/org/javarosa/form/api/FormEntryControllerTest.java
@@ -1,0 +1,152 @@
+package org.javarosa.form.api;
+
+import org.javarosa.core.test.Scenario;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
+import static org.javarosa.core.util.XFormsElement.body;
+import static org.javarosa.core.util.XFormsElement.group;
+import static org.javarosa.core.util.XFormsElement.head;
+import static org.javarosa.core.util.XFormsElement.html;
+import static org.javarosa.core.util.XFormsElement.input;
+import static org.javarosa.core.util.XFormsElement.mainInstance;
+import static org.javarosa.core.util.XFormsElement.model;
+import static org.javarosa.core.util.XFormsElement.repeat;
+import static org.javarosa.core.util.XFormsElement.t;
+import static org.javarosa.core.util.XFormsElement.title;
+import static org.javarosa.form.api.FormEntryController.EVENT_GROUP;
+import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
+import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
+
+public class FormEntryControllerTest {
+
+    @Test
+    public void jumpToNewRepeatPrompt_whenInRepeat_jumpsToRepeatPrompt() throws Exception {
+        Scenario scenario = Scenario.init("repeat", html(
+            head(
+                title("form"),
+                model(
+                    mainInstance(
+                        t("data",
+                            t("repeat",
+                                t("question1"),
+                                t("question2")
+                            )
+                        )
+                    ),
+                    bind("/data/repeat/question1").type("int"),
+                    bind("/data/repeat/question2").type("int")
+                )
+            ),
+            body(
+                group("/data/repeat",
+                    repeat("/data/repeat",
+                        input("/data/repeat/question1"),
+                        input("/data/repeat/question2")
+                    )
+                )
+            )
+        ));
+
+        FormEntryController controller = new FormEntryController(new FormEntryModel(scenario.getFormDef()));
+
+        assertThat(controller.stepToNextEvent(), is(EVENT_REPEAT));
+        assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
+        assertThat(controller.getModel().getFormIndex().toString(), is("0_0, 0, "));
+
+        controller.jumpToNewRepeatPrompt();
+        assertThat(controller.getModel().getFormIndex().toString(), is("0_1, "));
+    }
+
+    @Test
+    public void jumpToNewRepeatPrompt_whenInOuterOfNestedRepeat_jumpsToOutRepeatPrompt() throws Exception {
+        Scenario scenario = Scenario.init("nestedRepeat", html(
+            head(
+                title("form"),
+                model(
+                    mainInstance(
+                        t("data",
+                            t("repeat1",
+                                t("question1"),
+                                t("question2"),
+                                t("repeat2",
+                                    t("question3")
+                                )
+                            )
+                        )
+                    ),
+                    bind("/data/repeat1/question1").type("int"),
+                    bind("/data/repeat1/question2").type("int"),
+                    bind("/data/repeat1/repeat2/question3").type("int")
+                )
+            ),
+            body(
+                group("/data/repeat1",
+                    repeat("/data/repeat1",
+                        input("/data/repeat1/question1"),
+                        input("/data/repeat1/question2"),
+                        group("/data/repeat1/repeat2",
+                            repeat("/data/repeat1/repeat2",
+                                input("/data/repeat1/repeat2/question3")
+                            )
+                        )
+                    )
+                )
+            )
+        ));
+
+        FormEntryController controller = new FormEntryController(new FormEntryModel(scenario.getFormDef()));
+
+        assertThat(controller.stepToNextEvent(), is(EVENT_REPEAT));
+        assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
+        assertThat(controller.getModel().getFormIndex().toString(), is("0_0, 0, "));
+
+        controller.jumpToNewRepeatPrompt();
+        assertThat(controller.getModel().getFormIndex().toString(), is("0_1, "));
+    }
+
+    @Test
+    public void jumpToNewRepeatPrompt_whenInGroupInRepeat_jumpsToRepeatPrompt() throws Exception {
+        Scenario scenario = Scenario.init("groupInRepeat", html(
+            head(
+                title("form"),
+                model(
+                    mainInstance(
+                        t("data",
+                            t("repeat",
+                                t("group",
+                                    t("question1"),
+                                    t("question2")
+                                )
+                            )
+                        )
+                    ),
+                    bind("/data/repeat/group/question1").type("int"),
+                    bind("/data/repeat/group/question1").type("int")
+                )
+            ),
+            body(
+                group("/data/repeat",
+                    repeat("/data/repeat",
+                        group("/data/repeat/group",
+                            input("/data/repeat/group/question1"),
+                            input("/data/repeat/group/question2")
+                        )
+                    )
+                )
+            )
+        ));
+
+        FormEntryController controller = new FormEntryController(new FormEntryModel(scenario.getFormDef()));
+
+        assertThat(controller.stepToNextEvent(), is(EVENT_REPEAT));
+        assertThat(controller.stepToNextEvent(), is(EVENT_GROUP));
+        assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
+        assertThat(controller.getModel().getFormIndex().toString(), is("0_0, 0, 0, "));
+
+        controller.jumpToNewRepeatPrompt();
+        assertThat(controller.getModel().getFormIndex().toString(), is("0_1, "));
+    }
+}

--- a/src/test/java/org/javarosa/form/api/FormEntryControllerTest.java
+++ b/src/test/java/org/javarosa/form/api/FormEntryControllerTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.test.Scenario.getRef;
 import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
 import static org.javarosa.core.util.XFormsElement.body;
 import static org.javarosa.core.util.XFormsElement.group;
@@ -54,10 +55,10 @@ public class FormEntryControllerTest {
 
         assertThat(controller.stepToNextEvent(), is(EVENT_REPEAT));
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
-        assertThat(controller.getModel().getFormIndex().toString(), is("0_0, 0, "));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[0]/question1[0]")));
 
         controller.jumpToNewRepeatPrompt();
-        assertThat(controller.getModel().getFormIndex().toString(), is("0_1, "));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[1]")));
     }
 
     @Test
@@ -101,10 +102,10 @@ public class FormEntryControllerTest {
 
         assertThat(controller.stepToNextEvent(), is(EVENT_REPEAT));
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
-        assertThat(controller.getModel().getFormIndex().toString(), is("0_0, 0, "));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[0]/question1[0]")));
 
         controller.jumpToNewRepeatPrompt();
-        assertThat(controller.getModel().getFormIndex().toString(), is("0_1, "));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[1]")));
     }
 
     @Test
@@ -151,10 +152,10 @@ public class FormEntryControllerTest {
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
         assertThat(controller.stepToNextEvent(), is(EVENT_REPEAT));
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
-        assertThat(controller.getModel().getFormIndex().toString(), is("0_0, 2_0, 0, "));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[0]/repeat2[0]/question3[0]")));
 
         controller.jumpToNewRepeatPrompt();
-        assertThat(controller.getModel().getFormIndex().toString(), is("0_0, 2_1, "));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[0]/repeat2[1]")));
     }
 
     @Test
@@ -194,10 +195,10 @@ public class FormEntryControllerTest {
         assertThat(controller.stepToNextEvent(), is(EVENT_REPEAT));
         assertThat(controller.stepToNextEvent(), is(EVENT_GROUP));
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
-        assertThat(controller.getModel().getFormIndex().toString(), is("0_0, 0, 0, "));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[0]/group[0]/question1[0]")));
 
         controller.jumpToNewRepeatPrompt();
-        assertThat(controller.getModel().getFormIndex().toString(), is("0_1, "));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[1]")));
     }
 
     @Test
@@ -224,9 +225,9 @@ public class FormEntryControllerTest {
 
         FormEntryController controller = new FormEntryController(new FormEntryModel(scenario.getFormDef()));
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
-        assertThat(controller.getModel().getFormIndex().toString(), is("0, "));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/question1[0]")));
 
         controller.jumpToNewRepeatPrompt();
-        assertThat(controller.getModel().getFormIndex().toString(), is("0, "));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/question1[0]")));
     }
 }


### PR DESCRIPTION
These were added in as helpers in Collect (as part of https://github.com/opendatakit/collect/pull/3656) recently but seemed like they should actually live in JavaRosa.

#### What has been done to verify that this works as intended?

Wrote new tests for the new features.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just add the new features. Now existing code was actually changed so this should be low risk to merge.