### PR TITLE
Support triggers for relative references

### DIFF
--- a/src/main/java/org/javarosa/core/model/condition/Triggerable.java
+++ b/src/main/java/org/javarosa/core/model/condition/Triggerable.java
@@ -103,12 +103,7 @@ public abstract class Triggerable implements Externalizable {
     public abstract boolean isCascadingToChildren();
 
     public Set<TreeReference> getTriggers() {
-        Set<TreeReference> relTriggers = expr.getTriggers(originalContextRef);
-        Set<TreeReference> absTriggers = new HashSet<>();
-        for (TreeReference r : relTriggers) {
-            absTriggers.add(r.anchor(originalContextRef));
-        }
-        return absTriggers;
+        return expr.getTriggers(originalContextRef);
     }
 
     public TreeReference contextualizeContextRef(TreeReference anchorRef) {

--- a/src/main/java/org/javarosa/core/model/condition/Triggerable.java
+++ b/src/main/java/org/javarosa/core/model/condition/Triggerable.java
@@ -103,7 +103,7 @@ public abstract class Triggerable implements Externalizable {
     public abstract boolean isCascadingToChildren();
 
     public Set<TreeReference> getTriggers() {
-        Set<TreeReference> relTriggers = expr.getTriggers(null);  /// should this be originalContextRef???
+        Set<TreeReference> relTriggers = expr.getTriggers(originalContextRef);
         Set<TreeReference> absTriggers = new HashSet<>();
         for (TreeReference r : relTriggers) {
             absTriggers.add(r.anchor(originalContextRef));

--- a/src/main/java/org/javarosa/xpath/XPathConditional.java
+++ b/src/main/java/org/javarosa/xpath/XPathConditional.java
@@ -124,8 +124,8 @@ public class XPathConditional implements IConditionExpr {
                 }
 
                 //we can't generate this properly without an absolute reference
-                if(!ref.isAbsolute()) { throw new IllegalArgumentException("can't get triggers for relative references");}
-                TreeReference predicateContext = ref.getSubReference(i);
+                if (!contextualized.isAbsolute()) {throw new IllegalArgumentException("can't get triggers for relative references");}
+                TreeReference predicateContext = contextualized.getSubReference(i);
 
                 for(XPathExpression predicate : predicates) {
                     getTriggers(predicate, v, predicateContext);

--- a/src/main/java/org/javarosa/xpath/XPathConditional.java
+++ b/src/main/java/org/javarosa/xpath/XPathConditional.java
@@ -111,14 +111,10 @@ public class XPathConditional implements IConditionExpr {
             }
 
             // TODO: It's possible we should just handle this the same way as "genericize". Not entirely clear.
-            if (contextualized.hasPredicates()) {
-                contextualized = contextualized.removePredicates();
-            }
+            triggersSoFar.add(contextualized.removePredicates());
 
-            triggersSoFar.add(contextualized);
-
-            for (int i = 0; i < ref.size() ; i++) {
-                List<XPathExpression> predicates = ref.getPredicate(i);
+            for (int i = 0; i < contextualized.size() ; i++) {
+                List<XPathExpression> predicates = contextualized.getPredicate(i);
                 if (predicates == null) {
                     continue;
                 }

--- a/src/main/java/org/javarosa/xpath/XPathConditional.java
+++ b/src/main/java/org/javarosa/xpath/XPathConditional.java
@@ -122,7 +122,7 @@ public class XPathConditional implements IConditionExpr {
                 if (!contextualized.isAbsolute()) {
                     throw new IllegalArgumentException("can't get triggers for relative references");
                 }
-                TreeReference predicateContext = contextualized.getSubReference(i);
+                TreeReference predicateContext = contextualized.getSubReference(i).removePredicates();
 
                 for (XPathExpression predicate : predicates) {
                     getTriggers(predicate, predicateContext, triggersSoFar);

--- a/src/test/java/org/javarosa/regression/IndefiniteRepeatTest.java
+++ b/src/test/java/org/javarosa/regression/IndefiniteRepeatTest.java
@@ -106,4 +106,55 @@ public class IndefiniteRepeatTest {
         scenario.next();
         assertThat(scenario.atTheEndOfForm(), is(true));
     }
+
+    @Test
+    public void indefiniteRepeatJrCountExpression_inNestedRepeat_withRelativePaths_addsRepeatsUntilConditionMet() throws IOException {
+        Scenario scenario = Scenario.init("nested indefinite repeat", html(
+            head(
+                title("Indefinite repeat in nested repeat"),
+                model(
+                    mainInstance(t("data id=\"indefinite-nested-repeat\"",
+                        t("outer_repeat",
+                            t("inner_count"),
+                            t("target_count"),
+                            t("inner_repeat",
+                                t("add_more")
+                            )
+                        ))
+                    ),
+                    bind("/data/outer_repeat/inner_count").type("int").calculate("count(../inner_repeat)"),
+                    bind("/data/outer_repeat/target_count").type("int").calculate("if(../inner_count = 0" +
+                        "or ../inner_repeat[position() = ../inner_count]/add_more = 'yes', " +
+                        "../inner_count + 1, ../inner_count)")
+                )),
+            body(
+                repeat("/data/outer_repeat",
+                    repeat("/data/outer_repeat/inner_repeat", "target_count",
+                        input("/data/outer_repeat/inner_repeat/add_more")
+                    )
+                )
+            )));
+
+        scenario.next();
+        scenario.next();
+        scenario.next();
+        scenario.answer("yes");
+        scenario.next();
+        scenario.next();
+        scenario.answer("yes");
+        scenario.next();
+        scenario.next();
+        scenario.answer("no");
+        scenario.next();
+        scenario.createNewRepeat();
+        scenario.next();
+        scenario.next();
+        scenario.answer("yes");
+        scenario.next();
+        scenario.next();
+        scenario.answer("no");
+        scenario.next();
+        scenario.next();
+        assertThat(scenario.atTheEndOfForm(), is(true));
+    }
 }

--- a/src/test/java/org/javarosa/xpath/XPathConditionalTriggersTest.java
+++ b/src/test/java/org/javarosa/xpath/XPathConditionalTriggersTest.java
@@ -22,11 +22,11 @@ public class XPathConditionalTriggersTest {
 
     @Test
     public void getTriggers_onExpressionWithComplexRelativePathInPredicate_returnsPredicateTriggers() throws XPathSyntaxException {
-        XPathConditional expression = new XPathConditional("../inner[position() = ../node2 and /data/foo = ../x/y/z]/node3");
-        TreeReference context = Scenario.getRef("/data/outer[7]/node1");
+        XPathConditional expression = new XPathConditional("../inner[position() = anode and /data/foo = x/y/z]/anothernode");
+        TreeReference context = Scenario.getRef("/data/outer[7]/bar/baz");
 
-        assertThat(expression.getTriggers(context), hasItems(Scenario.getRef("/data/outer[7]/node2"),
-            Scenario.getRef("/data/foo"), Scenario.getRef("/data/outer[7]/x/y/z")));
+        assertThat(expression.getTriggers(context), hasItems(Scenario.getRef("/data/outer[7]/bar/inner/anode"),
+            Scenario.getRef("/data/foo"), Scenario.getRef("/data/outer[7]/bar/inner/x/y/z")));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/org/javarosa/xpath/XPathConditionalTriggersTest.java
+++ b/src/test/java/org/javarosa/xpath/XPathConditionalTriggersTest.java
@@ -1,0 +1,23 @@
+package org.javarosa.xpath;
+
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.test.Scenario;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class XPathConditionalTriggersTest {
+    @Test
+    public void predicateTriggers_areAddedToDag() throws XPathSyntaxException {
+        XPathConditional expression = new XPathConditional("../inner[position() = ../node2]/node3");
+        TreeReference context = Scenario.getRef("/data/outer[7]/node1");
+
+        TreeReference predicateTrigger = Scenario.getRef("/data/outer[7]/node2");
+
+        assertThat(expression.getTriggers(context), hasItem(predicateTrigger));
+    }
+}

--- a/src/test/java/org/javarosa/xpath/XPathConditionalTriggersTest.java
+++ b/src/test/java/org/javarosa/xpath/XPathConditionalTriggersTest.java
@@ -35,4 +35,14 @@ public class XPathConditionalTriggersTest {
 
         expression.getTriggers(null);
     }
+
+    @Test
+    public void getTriggers_onExpressionWithRelativePredicateWithCurrent_returnsTriggersContextualizedWithOriginalContext() throws XPathSyntaxException {
+        XPathConditional expression = new XPathConditional("instance('dataset')/root/item[value > current()/../../node1]/name");
+        TreeReference context = Scenario.getRef("/data/outer[7]/inner[3]/node2");
+
+        TreeReference predicateTrigger = Scenario.getRef("/data/outer[7]/node1");
+
+        assertThat(expression.getTriggers(context), hasItem(predicateTrigger));
+    }
 }

--- a/src/test/java/org/javarosa/xpath/XPathConditionalTriggersTest.java
+++ b/src/test/java/org/javarosa/xpath/XPathConditionalTriggersTest.java
@@ -5,19 +5,34 @@ import org.javarosa.core.test.Scenario;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.Test;
 
-import java.util.Set;
-
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class XPathConditionalTriggersTest {
     @Test
-    public void predicateTriggers_areAddedToDag() throws XPathSyntaxException {
+    public void getTriggers_onExpressionWithRelativePathInPredicate_returnsPredicateTriggers() throws XPathSyntaxException {
         XPathConditional expression = new XPathConditional("../inner[position() = ../node2]/node3");
         TreeReference context = Scenario.getRef("/data/outer[7]/node1");
 
         TreeReference predicateTrigger = Scenario.getRef("/data/outer[7]/node2");
 
         assertThat(expression.getTriggers(context), hasItem(predicateTrigger));
+    }
+
+    @Test
+    public void getTriggers_onExpressionWithComplexRelativePathInPredicate_returnsPredicateTriggers() throws XPathSyntaxException {
+        XPathConditional expression = new XPathConditional("../inner[position() = ../node2 and /data/foo = ../x/y/z]/node3");
+        TreeReference context = Scenario.getRef("/data/outer[7]/node1");
+
+        assertThat(expression.getTriggers(context), hasItems(Scenario.getRef("/data/outer[7]/node2"),
+            Scenario.getRef("/data/foo"), Scenario.getRef("/data/outer[7]/x/y/z")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getTriggers_onExpressionWithRelativePredicateAndNoContext_throwsError() throws XPathSyntaxException {
+        XPathConditional expression = new XPathConditional("../inner[position() = ../node2]/node3");
+
+        expression.getTriggers(null);
     }
 }


### PR DESCRIPTION
Closes #540 

Maddeningly enough, #565 still didn't fully address #540 because the test forms used had absolute references rather than the relative ones that `pyxform` now produces.

#### What has been done to verify that this works as intended?
Added and ran automated test that matches user-provided form with relative references. I also tried the user-provided forms at https://forum.opendatakit.org/t/infinite-loop-and-dynamically-delete-already-selected-options-from-list/25902 and https://forum.opendatakit.org/t/error-in-indefinite-repeat-group-inside-another-repeat-group/24729.

#### Why is this the best possible solution? Were any other approaches considered?
No other solutions considered. There's a comment on `Triggerable.getTriggers` that shows that someone already spotted that passing in a `null` context reference when the context reference is known didn't make much sense. We know exactly what the context node is and that's what we should pass in. Then, in `XPathConditional.getTriggers`, it follows that we should use the contextualized node.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should only fix the bug. It does make changes to the building of the DAG which is complex code and generally risky. However, as with other interventions for #540, the changes mostly only relate to relative references (but see keep reading for an exception). Users of XLSForm (the majority of ODK users) would only run into these modified code paths if they had nested repeats in their forms so I think this is low-risk. Prior to this change, the `expr.getTriggers` call on a relative reference always would have led to an `IllegalArgumentException` in `XPathConditional.getTriggers` so the only risk there is if the fix isn't complete.

The change to use a contextualized reference to get the predicate context affects every reference with a predicate. Predicates are used with repeats or secondary instances. I think that the test coverage here is sufficient to give confidence to the change with repeats. Expressions involving secondary instances are read-only so would not be part of the DAG.

#### Do we need any specific form for testing your changes? If so, please attach one.
https://forum.opendatakit.org/t/infinite-loop-and-dynamically-delete-already-selected-options-from-list/25902 and https://forum.opendatakit.org/t/error-in-indefinite-repeat-group-inside-another-repeat-group/24729

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.
