### PR TITLE
Allow zero arg normalize-space and string-length calls (#468)

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -387,12 +387,22 @@ public class XPathFuncExpr extends XPathExpression {
             return toString(argVals[0]).startsWith(toString(argVals[1]));
         } else if (name.equals("ends-with") && args.length == 2) {
             return toString(argVals[0]).endsWith(toString(argVals[1]));
-        } else if (name.equals("string-length")) {
-            assertArgsCount(name, args, 1);
-            return stringLength(argVals[0]);
-        } else if (name.equals("normalize-space")) {
-            assertArgsCount(name, args, 1);
-            return normalizeSpace(argVals[0]);
+        } else if (name.equals("string-length") && args.length <= 1) {
+            Object arg;
+            if (args.length == 1) {
+                arg = argVals[0];
+            } else {
+                arg = (XPathPathExpr.fromRef(evalContext.getContextRef())).eval(model, evalContext).unpack();
+            }
+            return stringLength(arg);
+        } else if (name.equals("normalize-space") && args.length <= 1) {
+            Object arg;
+            if (args.length == 1) {
+                arg = argVals[0];
+            } else {
+                arg = (XPathPathExpr.fromRef(evalContext.getContextRef())).eval(model, evalContext).unpack();
+            }
+            return normalizeSpace(arg);
         } else if (name.equals("checklist") && args.length >= 2) { //non-standard
             if (args.length == 3 && argVals[2] instanceof XPathNodeset) {
                 return checklist(argVals[0], argVals[1], ((XPathNodeset) argVals[2]).toArgList());


### PR DESCRIPTION
Hi @lognaturel , PTAL

Closes #468 

#### What has been done to verify that this works as intended?
Four extra test cases to verify normalize-space() and string-length() calls in the normal case and in the exceptional case

#### Why is this the best possible solution? Were any other approaches considered?
The new behaviour might demand some discussion. If the two functions are called without a model/context, an `XPathException` will be thrown, one alternative is to not handle the function if it is not called without a model/context and throw `XPathUnhandledException` instead.
The idiom of the ifblock might be up for discussion too, whether we want to have a separate block for the empty args case instead.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Preexiting behaviour with single argument has not been changed. A slim risk is that a preexisting application calling no args normalize-space and string-length expecting `XPathUnhandledException` will instead get a valid `XPathNodeSet` instead. 

#### Do we need any specific form for testing your changes? If so, please attach one.
None

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
https://github.com/opendatakit/docs/issues/1214
