### PR TITLE
Fix unexpected prompt to add not relevant repeat instances

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -547,7 +547,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             TreeReference parentPath = templNode.getParent().getRef().genericize();
             TreeElement parentNode = mainInstance
                 .resolveReference(parentPath.contextualize(repeatRef));
-            relev = parentNode.isRelevant();
+            relev = parentNode.isRelevant() && templNode.isRelevant() && templNode.hasChildren();
         }
 
         return relev;

--- a/src/test/java/org/javarosa/xform/parse/RepeatGroupsRelevanceTest.java
+++ b/src/test/java/org/javarosa/xform/parse/RepeatGroupsRelevanceTest.java
@@ -1,0 +1,39 @@
+package org.javarosa.xform.parse;
+
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryModel;
+import org.junit.Test;
+
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.junit.Assert.assertFalse;
+
+public class RepeatGroupsRelevanceTest {
+
+    @Test
+    public void isRepeatRelevantTest() {
+        FormParseInit fpi = new FormParseInit(r("repeat_groups_relevance.xml"));
+        FormEntryModel formEntryModel = fpi.getFormEntryModel();
+        FormDef formDef = fpi.getFormDef();
+
+        formEntryModel.setQuestionIndex(formEntryModel.incrementIndex(formEntryModel.getFormIndex()));
+        formEntryModel.setQuestionIndex(formEntryModel.incrementIndex(formEntryModel.getFormIndex()));
+
+        // repeatable group made not relevant by the previous question
+        assertFalse(formDef.isRepeatRelevant(formDef.getChildInstanceRef(formEntryModel.getFormIndex())));
+
+        formEntryModel.setQuestionIndex(formEntryModel.incrementIndex(formEntryModel.getFormIndex()));
+        formEntryModel.setQuestionIndex(formEntryModel.incrementIndex(formEntryModel.getFormIndex()));
+        formEntryModel.setQuestionIndex(formEntryModel.incrementIndex(formEntryModel.getFormIndex()));
+
+        // repeatable group marked as not relevant
+        assertFalse(formDef.isRepeatRelevant(formDef.getChildInstanceRef(formEntryModel.getFormIndex())));
+
+        formEntryModel.setQuestionIndex(formEntryModel.incrementIndex(formEntryModel.getFormIndex()));
+        formEntryModel.setQuestionIndex(formEntryModel.incrementIndex(formEntryModel.getFormIndex()));
+        formEntryModel.setQuestionIndex(formEntryModel.incrementIndex(formEntryModel.getFormIndex()));
+
+        // empty repeatable group
+        assertFalse(formDef.isRepeatRelevant(formDef.getChildInstanceRef(formEntryModel.getFormIndex())));
+    }
+}

--- a/src/test/resources/repeat_groups_relevance.xml
+++ b/src/test/resources/repeat_groups_relevance.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>repeatGroupsRelevance</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="repeatGroupsRelevance">
+                    <s1>no</s1>
+                    <gr1 jr:template="">
+                        <q1 />
+                    </gr1>
+                    <gr1>
+                        <q1 />
+                    </gr1>
+                    <gr2 jr:template="">
+                        <q2 />
+                    </gr2>
+                    <gr2>
+                        <q2 />
+                    </gr2>
+                    <qr3 jr:template="" />
+                    <qr3 />
+                    <meta>
+                        <instanceID />
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/s1" type="string" />
+            <bind nodeset="/data/gr1" relevant=" /data/s1  = 'yes'" />
+            <bind nodeset="/data/gr1/q1" type="string" />
+            <bind nodeset="/data/gr2" relevant="false()" />
+            <bind nodeset="/data/gr2/q2" type="string" />
+            <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string" />
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/data/s1">
+            <label>Yes/No</label>
+            <item>
+                <label>Yes</label>
+                <value>yes</value>
+            </item>
+            <item>
+                <label>No</label>
+                <value>no</value>
+            </item>
+        </select1>
+        <group ref="/data/gr1">
+            <label>Relevant: if yes selected n the previous question</label>
+            <repeat nodeset="/data/gr1">
+                <input ref="/data/gr1/q1">
+                    <label>text1</label>
+                </input>
+            </repeat>
+        </group>
+        <group ref="/data/gr2">
+            <label>Relevant: no</label>
+            <repeat nodeset="/data/gr2">
+                <input ref="/data/gr2/q2">
+                    <label>tex2</label>
+                </input>
+            </repeat>
+        </group>
+        <group ref="/data/qr3">
+            <label>Empty group</label>
+            <repeat nodeset="/data/qr3" />
+        </group>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Closes #https://github.com/getodk/collect/issues/2992

#### What has been done to verify that this works as intended?
I tested the changes manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
If repeatable group doesn't contain any questions or is marked as not relevant a user shouldn't be asked to add it. I fixed those two cases. There is one more possible case that could be fixed - the case where a group has children but all of them are not relevant. However I decided to leave it as is because it's a case that would require going through all children that also might be other nested groups evaluating them etc. So since it's a rare case and the current behavior is not a big problem I think it doesn't make sense to implement complex and risky code for it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The change is related to reparable groups. It should just fix cases where a group is marked as not relevant or doesn't have any elements inside.

#### Do we need any specific form for testing your changes? If so, please attach one.
I used: 
[relevantRepeats.xlsx](https://github.com/getodk/javarosa/files/4502073/relevantRepeats.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.
