### PR TITLE
Fixed: Deleting last repeat does not result in calculates

### DIFF
--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -206,6 +206,7 @@ public class TriggerableDag {
             }
         } else {
             triggerTriggerables(mainInstance, evalContext, deleteRef, new HashSet<>(0));
+            evaluateChildrenTriggerables(mainInstance, evalContext, deletedElement, false, new HashSet<>(0));
         }
     }
 

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -185,22 +185,27 @@ public class TriggerableDag {
         //After a repeat group has been deleted, the following repeat groups position has changed.
         //Evaluate triggerables which depend on the repeat group reference. Directly or indirectly.
         String repeatGroupName = deletedElement.getName();
-        for (int i = deletedElement.getMultiplicity(); i < parentElement.getChildMultiplicity(repeatGroupName); i++) {
-            TreeElement repeatGroup = parentElement.getChild(repeatGroupName, i);
+        boolean lastRepeatGroup = deletedElement.getMultiplicity() == parentElement.getChildMultiplicity(repeatGroupName);
+        if (!lastRepeatGroup) {
+            for (int i = deletedElement.getMultiplicity(); i < parentElement.getChildMultiplicity(repeatGroupName); i++) {
+                TreeElement repeatGroup = parentElement.getChild(repeatGroupName, i);
 
-            Set<QuickTriggerable> alreadyEvaluated = triggerTriggerables(mainInstance, evalContext, repeatGroup.getRef(), new HashSet<>(0));
-            publishSummary("Deleted", repeatGroup.getRef(), alreadyEvaluated);
+                Set<QuickTriggerable> alreadyEvaluated = triggerTriggerables(mainInstance, evalContext, repeatGroup.getRef(), new HashSet<>(0));
+                publishSummary("Deleted", repeatGroup.getRef(), alreadyEvaluated);
 
-            if (repeatGroup.getRef().equals(deleteRef)) {
-                // Evaluate the children triggerables only once, for the deleted repeat group.
-                //  Only children of the deleted repeat group have actually changed (they're gone) and thus calculations depend
-                //  on the must be re-evaluated, the following repeat groups have been shifted along with their children.
-                //  If there are calculations - regardless if inside the repeat or outside - that depend on the following
-                //  repeat group positions, they will fired cascade by the above code anyway.
-                //  Unit test for this scenario:
-                //  Safe2014DagImplTest#deleteThirdRepeatGroup_evaluatesTriggerables_indirectlyDependentOnTheRepeatGroupsNumber
-                evaluateChildrenTriggerables(mainInstance, evalContext, repeatGroup, false, alreadyEvaluated);
+                if (repeatGroup.getRef().equals(deleteRef)) {
+                    // Evaluate the children triggerables only once, for the deleted repeat group.
+                    //  Only children of the deleted repeat group have actually changed (they're gone) and thus calculations depend
+                    //  on the must be re-evaluated, the following repeat groups have been shifted along with their children.
+                    //  If there are calculations - regardless if inside the repeat or outside - that depend on the following
+                    //  repeat group positions, they will fired cascade by the above code anyway.
+                    //  Unit test for this scenario:
+                    //  Safe2014DagImplTest#deleteThirdRepeatGroup_evaluatesTriggerables_indirectlyDependentOnTheRepeatGroupsNumber
+                    evaluateChildrenTriggerables(mainInstance, evalContext, repeatGroup, false, alreadyEvaluated);
+                }
             }
+        } else {
+            triggerTriggerables(mainInstance, evalContext, deleteRef, new HashSet<>(0));
         }
     }
 

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
+
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.core.model.instance.TreeElement;
@@ -1437,5 +1438,32 @@ public class TriggerableDagTest {
         logger.info("Deletion of {} repeats took {}", numberOfRepeats, duration.toString());
     }
 
+    @Test
+    public void deleteLastRepeat_evaluatesTriggerables() throws IOException {
+        Scenario scenario = Scenario.init("Delete last repeat instance", html(
+            head(
+                title("Delete last repeat instance"),
+                model(
+                    mainInstance(t("data id=\"delete-last-repeat-instance\"",
+                        t("repeat-count"),
 
+                        t("repeat",
+                            t("question")),
+                        t("repeat",
+                            t("question")),
+                        t("repeat",
+                            t("question"))
+                    )),
+                    bind("/data/repeat-count").type("int").calculate("count(/data/repeat)")
+                ),
+                body(
+                    repeat("/data/repeat",
+                        input("question"))
+                ))));
+
+        assertThat(scenario.answerOf("/data/repeat-count"), is(intAnswer(3)));
+
+        scenario.removeRepeat("/data/repeat[2]");
+        assertThat(scenario.answerOf("/data/repeat-count"), is(intAnswer(2)));
+    }
 }

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -1466,4 +1466,33 @@ public class TriggerableDagTest {
         scenario.removeRepeat("/data/repeat[2]");
         assertThat(scenario.answerOf("/data/repeat-count"), is(intAnswer(2)));
     }
+
+    @Test
+    public void deleteLastRepeat_evaluatesTriggerables_indirectlyDependentOnTheDeletedRepeat() throws IOException {
+        Scenario scenario = Scenario.init("Delete last repeat instance", html(
+            head(
+                title("Delete last repeat instance"),
+                model(
+                    mainInstance(t("data id=\"delete-last-repeat-instance\"",
+                        t("summary"),
+
+                        t("repeat",
+                            t("question", "a")),
+                        t("repeat",
+                            t("question", "b")),
+                        t("repeat",
+                            t("question", "c"))
+                    )),
+                    bind("/data/summary").type("string").calculate("concat(/data/repeat/question)")
+                ),
+                body(
+                    repeat("/data/repeat",
+                        input("question"))
+                ))));
+
+        assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("abc")));
+
+        scenario.removeRepeat("/data/repeat[2]");
+        assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("ab")));
+    }
 }


### PR DESCRIPTION
Closes #https://github.com/getodk/collect/issues/3016

#### What has been done to verify that this works as intended?
I added an automated test and tested this change manually with Collect.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug fix.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It just fixes the but it shouldn't cause any problems so I'm not even sue if it requires testing... maybe just in case.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the [issue](https://github.com/getodk/collect/issues/3016) would be good for testing if needed.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.