### PR TITLE
Close streams to avoid resource leaks

### DIFF
--- a/src/jmh/java/org/javarosa/benchmarks/utils/FormDefCache.java
+++ b/src/jmh/java/org/javarosa/benchmarks/utils/FormDefCache.java
@@ -119,38 +119,28 @@ public class FormDefCache {
     }
 
     private static FormDef deserializeFormDef(File serializedFormDef) {
-        FileInputStream fis;
-        FormDef fd;
-        try {
-            // create new form def
-            fd = new FormDef();
-            fis = new FileInputStream(serializedFormDef);
-            DataInputStream dis = new DataInputStream(fis);
-
-            // read serialized formdef into new formdef
+        try (FileInputStream fis = new FileInputStream(serializedFormDef);
+             DataInputStream dis = new DataInputStream(fis)) {
+            FormDef fd = new FormDef();
             fd.readExternal(dis, ExtUtil.defaultPrototypes());
-            dis.close();
+            return fd;
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
-            fd = null;
+            return null;
         }
-
-        return fd;
     }
 
 
     public static String getMd5Hash(File file) {
-        final InputStream is;
-        try {
-            is = new FileInputStream(file);
-
+        try (InputStream is = new FileInputStream(file)){
+            return getMd5Hash(is);
         } catch (FileNotFoundException e) {
             logger.debug(String.format("Cache file %s not found", file.getAbsolutePath()), e);
             return null;
-
+        } catch (IOException e) {
+            logger.debug(String.format("Error creating cache file %s", file.getAbsolutePath()), e);
+            return null;
         }
-
-        return getMd5Hash(is);
     }
 
 

--- a/src/main/java/org/javarosa/core/reference/ReferenceDataSource.java
+++ b/src/main/java/org/javarosa/core/reference/ReferenceDataSource.java
@@ -64,8 +64,7 @@ public class ReferenceDataSource implements LocaleDataSource {
 
     @Override
     public OrderedMap<String, String> getLocalizedText() {
-        try {
-            InputStream is = ReferenceManager.instance().deriveReference(referenceURI).getStream();
+        try (InputStream is = ReferenceManager.instance().deriveReference(referenceURI).getStream()) {
             return LocalizationUtils.parseLocaleInput(is);
         } catch (IOException e) {
             logger.error("Error", e);

--- a/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -169,9 +169,9 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
      * @see org.javarosa.core.services.storage.IStorageUtility#readBytes(int)
      */
     public byte[] readBytes(int id) {
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        try {
-            data.get(DataUtil.integer(id)).writeExternal(new DataOutputStream(stream));
+        try (ByteArrayOutputStream stream = new ByteArrayOutputStream();
+             DataOutputStream dataOutputStream = new DataOutputStream(stream)) {
+            data.get(DataUtil.integer(id)).writeExternal(dataOutputStream);
             return stream.toByteArray();
         } catch (IOException e) {
             throw new RuntimeException("Couldn't serialize data to return to readBytes");

--- a/src/main/java/org/javarosa/xml/InternalDataInstanceParser.java
+++ b/src/main/java/org/javarosa/xml/InternalDataInstanceParser.java
@@ -26,8 +26,7 @@ public class InternalDataInstanceParser {
      */
     public static HashMap<String, DataInstance> buildInstances(String xFormSrc) {
             HashMap<String, DataInstance> internalDataInstances = new HashMap<>();
-            try {
-                InputStream inputStream  = new FileInputStream(xFormSrc);
+            try (InputStream inputStream  = new FileInputStream(xFormSrc)) {
                 KXmlParser parser = ElementParser.instantiateParser(inputStream);
                 TreeElementParser treeElementParser =
                     new TreeElementParser(parser,0, "");

--- a/src/test/java/org/javarosa/core/test/FormParseInit.java
+++ b/src/test/java/org/javarosa/core/test/FormParseInit.java
@@ -3,8 +3,11 @@ package org.javarosa.core.test;
 import static org.javarosa.form.api.FormEntryController.EVENT_END_OF_FORM;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Path;
-
+import java.util.List;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
@@ -14,11 +17,6 @@ import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.xform.util.XFormUtils;
-
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,16 +48,15 @@ public class FormParseInit {
 
     private void init() {
         String xf_name = FORM_NAME;
-        FileInputStream is;
-        try {
-            is = new FileInputStream(xf_name);
+        try (FileInputStream is = new FileInputStream(xf_name)) {
+            xform = XFormUtils.getFormFromInputStream(is);
         } catch (FileNotFoundException e) {
             logger.error("Error: the file '{}' could not be found!", xf_name);
             throw new RuntimeException("Error: the file '" + xf_name + "' could not be found!");
+        } catch (IOException e) {
+            logger.debug(String.format("Error reading form with name %s", xf_name), e);
+            throw new RuntimeException("Error reading form with name '" + xf_name);
         }
-
-        // Parse the form
-        xform = XFormUtils.getFormFromInputStream(is);
 
         femodel = new FormEntryModel(xform);
         fec = new FormEntryController(femodel);


### PR DESCRIPTION
Now that Collect checks for unclosed streams, I saw that form deserialization always left an open `InputStream`. I searched for `Stream` across the project and used try with resources.

#### What has been done to verify that this works as intended?
Ran all tests and verify that they pass. Visually inspected the code.

#### Why is this the best possible solution? Were any other approaches considered?
I considered only making the `FormDefCache` change that I saw logged but I figure that it's a good time to change all of the cases I can find.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no user-facing changes other than a slightly reduced risk of resource leaks.

I think this is quite low risk and easy to visually verify but if there is a problem with the code, loading a form def from xml or cache, localization and selects with choice filters are at risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.
