### PR TITLE
Reduce access to DAG methods and speed up repeat deletion when there are dependent expressions outside the repeat 

### DIFF
--- a/src/main/java/org/javarosa/core/model/QuickTriggerable.java
+++ b/src/main/java/org/javarosa/core/model/QuickTriggerable.java
@@ -33,11 +33,11 @@ public final class QuickTriggerable {
         return triggerable instanceof Condition;
     }
 
-    public boolean isRecalculate() {
+    boolean isRecalculate() {
         return triggerable instanceof Recalculate;
     }
 
-    public TreeReference contextualizeContextRef(TreeReference anchorRef) {
+    TreeReference contextualizeContextRef(TreeReference anchorRef) {
         return triggerable.contextualizeContextRef(anchorRef);
     }
 
@@ -45,7 +45,7 @@ public final class QuickTriggerable {
         return triggerable.apply(mainInstance, ec, qualified);
     }
 
-    public Set<TreeReference> getTargets() {
+    Set<TreeReference> getTargets() {
         return triggerable.getTargets();
     }
 
@@ -53,11 +53,11 @@ public final class QuickTriggerable {
         return this.triggerable.equals(triggerable);
     }
 
-    public void intersectContextWith(Triggerable other) {
+    void intersectContextWith(Triggerable other) {
         triggerable.intersectContextWith(other);
     }
 
-    public void setImmediateCascades(Set<QuickTriggerable> deps) {
+    void setImmediateCascades(Set<QuickTriggerable> deps) {
         triggerable.setImmediateCascades(deps);
     }
 
@@ -65,11 +65,11 @@ public final class QuickTriggerable {
         return triggerable.canCascade();
     }
 
-    public boolean isCascadingToChildren() {
+    boolean isCascadingToChildren() {
         return triggerable.isCascadingToChildren();
     }
 
-    public Set<QuickTriggerable> getImmediateCascades() {
+    Set<QuickTriggerable> getImmediateCascades() {
         return triggerable.getImmediateCascades();
     }
 

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -180,20 +180,20 @@ public class TriggerableDag {
     void deleteRepeatGroup(FormInstance mainInstance, EvaluationContext evalContext, TreeReference deleteRef, TreeElement parentElement, TreeElement deletedElement) {
         //After a repeat group has been deleted, the following repeat groups position has changed.
         //Evaluate triggerables which depend on the repeat group reference directly or indirectly.
-        String repeatGroupName = deletedElement.getName();
+        String repeatName = deletedElement.getName();
 
-        boolean lastRepeatGroup = deletedElement.getMultiplicity() == parentElement.getChildMultiplicity(repeatGroupName);
-        if (!lastRepeatGroup) {
+        boolean lastRepeat = deletedElement.getMultiplicity() == parentElement.getChildMultiplicity(repeatName);
+        if (!lastRepeat) {
             // triggerables outside the repeat only need to be recomputed once, not for every repeat instance
             Set<QuickTriggerable> triggerablesOutside = getTriggerablesOutsideRepeat(deleteRef.genericize());
 
-            for (int i = deletedElement.getMultiplicity(); i < parentElement.getChildMultiplicity(repeatGroupName); i++) {
-                TreeElement repeatGroup = parentElement.getChild(repeatGroupName, i);
+            for (int i = deletedElement.getMultiplicity(); i < parentElement.getChildMultiplicity(repeatName); i++) {
+                TreeElement repeatInstance = parentElement.getChild(repeatName, i);
 
-                Set<QuickTriggerable> alreadyEvaluated = triggerTriggerables(mainInstance, evalContext, repeatGroup.getRef(), triggerablesOutside);
-                publishSummary("Deleted", repeatGroup.getRef(), alreadyEvaluated);
+                Set<QuickTriggerable> alreadyEvaluated = triggerTriggerables(mainInstance, evalContext, repeatInstance.getRef(), triggerablesOutside);
+                publishSummary("Deleted", repeatInstance.getRef(), alreadyEvaluated);
 
-                if (repeatGroup.getRef().equals(deleteRef)) {
+                if (repeatInstance.getRef().equals(deleteRef)) {
                     // Evaluate the children triggerables only for the deleted repeat instance.
                     //  Children of the deleted repeat instance have changed (they're gone) and thus calculations that depend
                     //  on them must be re-evaluated. The following repeat instances have been shifted along with their children.
@@ -202,7 +202,7 @@ public class TriggerableDag {
                     //  Unit test for this scenario:
                     //  TriggerableDagTest#deleteThirdRepeatGroup_evaluatesTriggerables_indirectlyDependentOnTheRepeatGroupsNumber
                     alreadyEvaluated.addAll(triggerablesOutside);
-                    evaluateChildrenTriggerables(mainInstance, evalContext, repeatGroup, false, alreadyEvaluated);
+                    evaluateChildrenTriggerables(mainInstance, evalContext, repeatInstance, false, alreadyEvaluated);
                 }
             }
 

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -200,7 +200,7 @@ public class TriggerableDag {
                     //  If there are calculations - regardless if inside the repeat or outside - that depend on the following
                     //  repeat group positions, they will be fired by the above code anyway.
                     //  Unit test for this scenario:
-                    //  Safe2014DagImplTest#deleteThirdRepeatGroup_evaluatesTriggerables_indirectlyDependentOnTheRepeatGroupsNumber
+                    //  TriggerableDagTest#deleteThirdRepeatGroup_evaluatesTriggerables_indirectlyDependentOnTheRepeatGroupsNumber
                     alreadyEvaluated.addAll(excluded);
                     evaluateChildrenTriggerables(mainInstance, evalContext, repeatGroup, false, alreadyEvaluated);
                 }

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -185,12 +185,12 @@ public class TriggerableDag {
         boolean lastRepeatGroup = deletedElement.getMultiplicity() == parentElement.getChildMultiplicity(repeatGroupName);
         if (!lastRepeatGroup) {
             // triggerables outside the repeat only need to be recomputed once, not for every repeat instance
-            Set<QuickTriggerable> excluded = getTriggerablesOutsideRepeat(deleteRef.genericize());
+            Set<QuickTriggerable> triggerablesOutside = getTriggerablesOutsideRepeat(deleteRef.genericize());
 
             for (int i = deletedElement.getMultiplicity(); i < parentElement.getChildMultiplicity(repeatGroupName); i++) {
                 TreeElement repeatGroup = parentElement.getChild(repeatGroupName, i);
 
-                Set<QuickTriggerable> alreadyEvaluated = triggerTriggerables(mainInstance, evalContext, repeatGroup.getRef(), excluded);
+                Set<QuickTriggerable> alreadyEvaluated = triggerTriggerables(mainInstance, evalContext, repeatGroup.getRef(), triggerablesOutside);
                 publishSummary("Deleted", repeatGroup.getRef(), alreadyEvaluated);
 
                 if (repeatGroup.getRef().equals(deleteRef)) {
@@ -201,12 +201,12 @@ public class TriggerableDag {
                     //  repeat group positions, they will be fired by the above code anyway.
                     //  Unit test for this scenario:
                     //  TriggerableDagTest#deleteThirdRepeatGroup_evaluatesTriggerables_indirectlyDependentOnTheRepeatGroupsNumber
-                    alreadyEvaluated.addAll(excluded);
+                    alreadyEvaluated.addAll(triggerablesOutside);
                     evaluateChildrenTriggerables(mainInstance, evalContext, repeatGroup, false, alreadyEvaluated);
                 }
             }
 
-            if (!excluded.isEmpty()) {
+            if (!triggerablesOutside.isEmpty()) {
                 triggerTriggerables(mainInstance, evalContext, deleteRef, new HashSet<>());
             }
         } else {

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -106,7 +106,7 @@ public class TriggerableDag {
      */
     private final Map<TreeReference, Set<QuickTriggerable>> triggerablesPerTrigger = new HashMap<>();
 
-    public TriggerableDag(EventNotifierAccessor accessor) {
+    TriggerableDag(EventNotifierAccessor accessor) {
         this.accessor = accessor;
     }
 
@@ -147,10 +147,6 @@ public class TriggerableDag {
             accessor.getEventNotifier().publishEvent(new Event(triggerable.isCondition() ? "Condition" : "Recalculate", evaluationResults));
     }
 
-    public QuickTriggerable getTriggerableForRepeatGroup(TreeReference repeatRef) {
-        return repeatConditionsPerTargets.get(repeatRef.genericize());
-    }
-
     private Set<QuickTriggerable> initializeTriggerables(FormInstance mainInstance, EvaluationContext evalContext, TreeReference rootRef, Set<QuickTriggerable> alreadyEvaluated) {
         TreeReference genericRoot = rootRef.genericize();
 
@@ -177,11 +173,11 @@ public class TriggerableDag {
      * @param ref The full contextualized unambiguous reference of the value
      *            that was changed.
      */
-    public Collection<QuickTriggerable> triggerTriggerables(FormInstance mainInstance, EvaluationContext evalContext, TreeReference ref) {
+    Collection<QuickTriggerable> triggerTriggerables(FormInstance mainInstance, EvaluationContext evalContext, TreeReference ref) {
         return this.triggerTriggerables(mainInstance, evalContext, ref, new HashSet<>(1));
     }
 
-    public void deleteRepeatGroup(FormInstance mainInstance, EvaluationContext evalContext, TreeReference deleteRef, TreeElement parentElement, TreeElement deletedElement) {
+    void deleteRepeatGroup(FormInstance mainInstance, EvaluationContext evalContext, TreeReference deleteRef, TreeElement parentElement, TreeElement deletedElement) {
         //After a repeat group has been deleted, the following repeat groups position has changed.
         //Evaluate triggerables which depend on the repeat group reference. Directly or indirectly.
         String repeatGroupName = deletedElement.getName();
@@ -210,7 +206,7 @@ public class TriggerableDag {
         }
     }
 
-    public void createRepeatGroup(FormInstance mainInstance, EvaluationContext evalContext, TreeReference createRef, TreeElement createdElement) {
+    void createRepeatGroup(FormInstance mainInstance, EvaluationContext evalContext, TreeReference createRef, TreeElement createdElement) {
         // trigger conditions that depend on the creation of this new node
         Set<QuickTriggerable> qtSet1 = triggerTriggerables(mainInstance, evalContext, createRef, new HashSet<>(0));
         publishSummary("Created (phase 1)", createRef, qtSet1);
@@ -236,7 +232,7 @@ public class TriggerableDag {
         }
     }
 
-    public void copyItemsetAnswer(FormInstance mainInstance, EvaluationContext evalContext, TreeReference copyRef, TreeElement copyToElement) {
+    void copyItemsetAnswer(FormInstance mainInstance, EvaluationContext evalContext, TreeReference copyRef, TreeElement copyToElement) {
         TreeReference targetRef = copyToElement.getRef();
 
         // trigger conditions that depend on the creation of these new nodes
@@ -303,7 +299,7 @@ public class TriggerableDag {
      * will create the appropriate ordering and dependencies to ensure the
      * conditions will be evaluated in the appropriate orders.
      */
-    public void finalizeTriggerables(FormInstance mainInstance, EvaluationContext ec) throws IllegalStateException {
+    void finalizeTriggerables(FormInstance mainInstance, EvaluationContext ec) throws IllegalStateException {
         triggerablesDAG = buildDag(allTriggerables, getDagEdges(mainInstance, ec));
         repeatConditionsPerTargets = getRepeatConditionsPerTargets(mainInstance, triggerablesDAG);
     }
@@ -521,7 +517,7 @@ public class TriggerableDag {
      * Walks the current set of conditions, and evaluates each of them with the
      * current context.
      */
-    public Collection<QuickTriggerable> initializeTriggerables(FormInstance mainInstance, EvaluationContext evalContext, TreeReference rootRef) {
+    Collection<QuickTriggerable> initializeTriggerables(FormInstance mainInstance, EvaluationContext evalContext, TreeReference rootRef) {
         return initializeTriggerables(mainInstance, evalContext, rootRef, new HashSet<>(1));
     }
 
@@ -571,7 +567,7 @@ public class TriggerableDag {
         return evaluateTriggerables(mainInstance, evalContext, triggeredCopy, ref, alreadyEvaluated);
     }
 
-    public boolean shouldTrustPreviouslyCommittedAnswer() {
+    boolean shouldTrustPreviouslyCommittedAnswer() {
         return false;
     }
 
@@ -579,7 +575,7 @@ public class TriggerableDag {
         accessor.getEventNotifier().publishEvent(new Event(lead + ": " + (ref != null ? ref.toShortString() + ": " : "") + quickTriggerables.size() + " triggerables were fired."));
     }
 
-    public void reportDependencyCycles() {
+    void reportDependencyCycles() {
         Set<TreeReference> vertices = new HashSet<>();
         List<TreeReference[]> edges = new ArrayList<>();
 
@@ -646,14 +642,14 @@ public class TriggerableDag {
 
     // region External Serialization
 
-    public void writeExternalTriggerables(DataOutputStream dos) throws IOException {
+    void writeExternalTriggerables(DataOutputStream dos) throws IOException {
         // Order of writes must match order of reads in readExternalTriggerables
         ExtUtil.write(dos, new ExtWrapList(getConditions()));
         ExtUtil.write(dos, new ExtWrapList(getRecalculates()));
     }
 
     @SuppressWarnings("unchecked")
-    public static List<Triggerable> readExternalTriggerables(DataInputStream dis, PrototypeFactory pf) throws IOException, DeserializationException {
+    static List<Triggerable> readExternalTriggerables(DataInputStream dis, PrototypeFactory pf) throws IOException, DeserializationException {
         // Order of reads must match order of writes in writeExternalTriggerables
         List<Triggerable> triggerables = new LinkedList<>();
         triggerables.addAll((List<Triggerable>) ExtUtil.read(dis, new ExtWrapList(Condition.class), pf));

--- a/src/main/java/org/javarosa/core/model/condition/Condition.java
+++ b/src/main/java/org/javarosa/core/model/condition/Condition.java
@@ -31,8 +31,8 @@ import org.javarosa.xpath.XPathConditional;
 import org.javarosa.xpath.XPathException;
 
 public class Condition extends Triggerable {
-    public ConditionAction trueAction;
-    public ConditionAction falseAction;
+    private ConditionAction trueAction;
+    private ConditionAction falseAction;
 
     /**
      * Constructor required for deserialization
@@ -41,7 +41,7 @@ public class Condition extends Triggerable {
     public Condition() {
     }
 
-    protected Condition(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, Set<TreeReference> targets, Set<QuickTriggerable> immediateCascades, ConditionAction trueAction, ConditionAction falseAction) {
+    Condition(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, Set<TreeReference> targets, Set<QuickTriggerable> immediateCascades, ConditionAction trueAction, ConditionAction falseAction) {
         super(expr, contextRef, originalContextRef, targets, immediateCascades);
         this.trueAction = trueAction;
         this.falseAction = falseAction;
@@ -52,7 +52,7 @@ public class Condition extends Triggerable {
         try {
             return expr.eval(model, evalContext);
         } catch (XPathException e) {
-            e.setSource("Condition expression for " + contextRef.toString(true));
+            e.setSource("Condition expression for " + getContext().toString(true));
             throw e;
         }
     }

--- a/src/main/java/org/javarosa/core/model/condition/Recalculate.java
+++ b/src/main/java/org/javarosa/core/model/condition/Recalculate.java
@@ -40,7 +40,7 @@ public class Recalculate extends Triggerable {
 
     }
 
-    protected Recalculate(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, Set<TreeReference> targets, Set<QuickTriggerable> immediateCascades) {
+    Recalculate(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, Set<TreeReference> targets, Set<QuickTriggerable> immediateCascades) {
         super(expr, contextRef, originalContextRef, targets, immediateCascades);
     }
 
@@ -49,7 +49,7 @@ public class Recalculate extends Triggerable {
         try {
             return expr.evalRaw(model, ec);
         } catch (XPathException e) {
-            e.setSource("Calculate expression for " + contextRef.toString(true));
+            e.setSource("Calculate expression for " + getContext().toString(true));
             throw e;
         }
     }

--- a/src/main/java/org/javarosa/core/model/condition/Triggerable.java
+++ b/src/main/java/org/javarosa/core/model/condition/Triggerable.java
@@ -57,28 +57,28 @@ public abstract class Triggerable implements Externalizable {
      * References to all of the (non-contextualized) nodes which should be
      * updated by the result of this triggerable
      */
-    protected Set<TreeReference> targets;
+    private Set<TreeReference> targets;
 
     /**
      * Current reference which is the "Basis" of the trigerrables being evaluated. This is the highest
      * common root of all of the targets being evaluated.
      */
-    protected TreeReference contextRef;  //generic ref used to turn triggers into absolute references
+    private TreeReference contextRef;  //generic ref used to turn triggers into absolute references
 
     // TODO Study why we really need this property. Looking at mutators, it should always equal the contextRef.
     /**
      * The first context provided to this triggerable before reducing to the common root.
      */
-    protected TreeReference originalContextRef;
+    private TreeReference originalContextRef;
 
     // TODO Move this into the DAG. This shouldn't be here.
-    protected Set<QuickTriggerable> immediateCascades = null;
+    private Set<QuickTriggerable> immediateCascades = null;
 
-    protected Triggerable() {
+    Triggerable() {
 
     }
 
-    protected Triggerable(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, Set<TreeReference> targets, Set<QuickTriggerable> immediateCascades) {
+    Triggerable(XPathConditional expr, TreeReference contextRef, TreeReference originalContextRef, Set<TreeReference> targets, Set<QuickTriggerable> immediateCascades) {
         this.expr = expr;
         this.targets = targets;
         this.contextRef = contextRef;
@@ -193,7 +193,7 @@ public abstract class Triggerable implements Externalizable {
         return true;
     }
 
-    protected String buildHumanReadableTargetList() {
+    String buildHumanReadableTargetList() {
         StringBuilder targetsBuilder = new StringBuilder();
         for (TreeReference t : getTargets())
             targetsBuilder.append(t.toString(true, true)).append(", ");

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -266,28 +266,23 @@ public class TriggerableDagTest {
         assertThat(scenario.answerOf("/data/summary"), is(intAnswer(45)));
         assertDagEvents(dagEvents,
             "Processing 'Recalculate' for number [3_1] (3.0)",
-            "Processing 'Recalculate' for summary [1] (51.0)",
-            "Processing 'Deleted: house [3]: 2 triggerables were fired.' for ",
+            "Processing 'Deleted: house [3]: 1 triggerables were fired.' for ",
             "Processing 'Deleted: number [3_1]: 0 triggerables were fired.' for ",
             "Processing 'Recalculate' for number [4_1] (4.0)",
-            "Processing 'Recalculate' for summary [1] (50.0)",
-            "Processing 'Deleted: house [4]: 2 triggerables were fired.' for ",
+            "Processing 'Deleted: house [4]: 1 triggerables were fired.' for ",
             "Processing 'Recalculate' for number [5_1] (5.0)",
-            "Processing 'Recalculate' for summary [1] (49.0)",
-            "Processing 'Deleted: house [5]: 2 triggerables were fired.' for ",
+            "Processing 'Deleted: house [5]: 1 triggerables were fired.' for ",
             "Processing 'Recalculate' for number [6_1] (6.0)",
-            "Processing 'Recalculate' for summary [1] (48.0)",
-            "Processing 'Deleted: house [6]: 2 triggerables were fired.' for ",
+            "Processing 'Deleted: house [6]: 1 triggerables were fired.' for ",
             "Processing 'Recalculate' for number [7_1] (7.0)",
-            "Processing 'Recalculate' for summary [1] (47.0)",
-            "Processing 'Deleted: house [7]: 2 triggerables were fired.' for ",
+            "Processing 'Deleted: house [7]: 1 triggerables were fired.' for ",
             "Processing 'Recalculate' for number [8_1] (8.0)",
-            "Processing 'Recalculate' for summary [1] (46.0)",
-            "Processing 'Deleted: house [8]: 2 triggerables were fired.' for ",
+            "Processing 'Deleted: house [8]: 1 triggerables were fired.' for ",
             "Processing 'Recalculate' for number [9_1] (9.0)",
-            "Processing 'Recalculate' for summary [1] (45.0)",
-            "Processing 'Deleted: house [9]: 2 triggerables were fired.' for "
-        );
+            "Processing 'Deleted: house [9]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [3_1] (3.0)",
+            "Processing 'Recalculate' for summary [1] (45.0)"
+            );
     }
 
     /**
@@ -1398,7 +1393,7 @@ public class TriggerableDagTest {
         ), body(inputs.toArray(new XFormsElement[]{})));
     }
 
-    // TODO Replace this test with a benchmark
+    @Ignore("Replace by benchmark")
     @Test
     public void deleteRepeatGroupWithCalculationsTimingTest() throws Exception {
         // Given

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -41,7 +41,6 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
-
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.core.model.instance.TreeElement;
@@ -76,506 +75,37 @@ public class TriggerableDagTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
-    public void deleteSecondRepeatGroup_evaluatesTriggerables_dependentOnPrecedingRepeatGroupSiblings() throws IOException {
+    public void order_of_the_DAG_is_ensured() throws IOException {
         Scenario scenario = Scenario.init("Some form", html(
             head(
                 title("Some form"),
                 model(
                     mainInstance(t("data id=\"some-form\"",
-                        t("house jr:template=\"\"", t("number"))
+                        t("a", "2"),
+                        t("b"),
+                        t("c")
                     )),
-                    bind("/data/house/number").type("int").calculate("position(..)")
+                    bind("/data/a").type("int"),
+                    bind("/data/b").type("int").calculate("/data/a * 3"),
+                    bind("/data/c").type("int").calculate("(/data/a + /data/b) * 5")
                 )
             ),
-            body(group("/data/house", repeat("/data/house", input("number"))))
-        )).onDagEvent(dagEvents::add);
-        range(0, 5).forEach(__ -> {
-            scenario.next();
-            scenario.createNewRepeat();
-            scenario.next();
-        });
-        assertThat(scenario.answerOf("/data/house[0]/number"), is(intAnswer(1)));
-        assertThat(scenario.answerOf("/data/house[1]/number"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/house[2]/number"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/house[3]/number"), is(intAnswer(4)));
-        assertThat(scenario.answerOf("/data/house[4]/number"), is(intAnswer(5)));
-
-        // Start recording DAG events now
-        dagEvents.clear();
-
-        scenario.removeRepeat("/data/house[1]");
-
-        assertThat(scenario.answerOf("/data/house[0]/number"), is(intAnswer(1)));
-        assertThat(scenario.answerOf("/data/house[1]/number"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/house[2]/number"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/house[3]/number"), is(intAnswer(4)));
-        assertThat(scenario.answerOf("/data/house[4]/number"), is(nullValue()));
-        assertDagEvents(dagEvents,
-            "Processing 'Recalculate' for number [2_1] (2.0)",
-            "Processing 'Deleted: house [2]: 1 triggerables were fired.' for ",
-            "Processing 'Deleted: number [2_1]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [3_1] (3.0)",
-            "Processing 'Deleted: house [3]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [4_1] (4.0)",
-            "Processing 'Deleted: house [4]: 1 triggerables were fired.' for "
-        );
-    }
-
-    @Test
-    public void deleteSecondRepeatGroup_evaluatesTriggerables_dependentOnTheParentPosition() throws IOException {
-        Scenario scenario = Scenario.init("Some form", html(
-            head(
-                title("Some form"),
-                model(
-                    mainInstance(t("data id=\"some-form\"",
-                        t("house jr:template=\"\"",
-                            t("number"),
-                            t("name"),
-                            t("name_and_number")
-                        )
-                    )),
-                    bind("/data/house/number").type("int").calculate("position(..)"),
-                    bind("/data/house/name").type("string").required(),
-                    bind("/data/house/name_and_number").type("string").calculate("concat(/data/house/name, /data/house/number)")
-                )
-            ),
-            body(group("/data/house", repeat("/data/house", input("/data/house/name"))))
-        )).onDagEvent(dagEvents::add);
-        range(0, 5).forEach(n -> {
-            scenario.next();
-            scenario.createNewRepeat();
-            scenario.next();
-            scenario.answer((char) (65 + n));
-        });
-        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("A1")));
-        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("B2")));
-        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("C3")));
-        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("D4")));
-        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(stringAnswer("E5")));
-
-        // Start recording DAG events now
-        dagEvents.clear();
-
-        scenario.removeRepeat("/data/house[1]");
-
-        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("A1")));
-        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("C2")));
-        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("D3")));
-        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("E4")));
-        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(nullValue()));
-        assertDagEvents(dagEvents,
-            "Processing 'Recalculate' for number [2_1] (2.0)",
-            "Processing 'Recalculate' for name_and_number [2_1] (C2)",
-            "Processing 'Deleted: house [2]: 2 triggerables were fired.' for ",
-            "Processing 'Deleted: number [2_1]: 0 triggerables were fired.' for ",
-            "Processing 'Deleted: name [2_1]: 0 triggerables were fired.' for ",
-            "Processing 'Deleted: name_and_number [2_1]: 2 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [3_1] (3.0)",
-            "Processing 'Recalculate' for name_and_number [3_1] (D3)",
-            "Processing 'Deleted: house [3]: 2 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [4_1] (4.0)",
-            "Processing 'Recalculate' for name_and_number [4_1] (E4)",
-            "Processing 'Deleted: house [4]: 2 triggerables were fired.' for "
-        );
-    }
-
-    @Test
-    public void deleteSecondRepeatGroup_doesNotEvaluateTriggerables_notDependentOnTheParentPosition() throws IOException {
-        Scenario scenario = Scenario.init("Some form", html(
-            head(
-                title("Some form"),
-                model(
-                    mainInstance(t("data id=\"some-form\"",
-                        t("house jr:template=\"\"",
-                            t("number"),
-                            t("name"),
-                            t("name_and_number")
-                        )
-                    )),
-                    bind("/data/house/number").type("int").calculate("position(..)"),
-                    bind("/data/house/name").type("string").required(),
-                    bind("/data/house/name_and_number").type("string").calculate("concat(/data/house/name, 'X')")
-                )
-            ),
-            body(group("/data/house", repeat("/data/house", input("/data/house/name"))))
-        )).onDagEvent(dagEvents::add);
-        range(0, 5).forEach(n -> {
-            scenario.next();
-            scenario.createNewRepeat();
-            scenario.next();
-            scenario.answer((char) (65 + n));
-        });
-        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("AX")));
-        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("BX")));
-        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("CX")));
-        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("DX")));
-        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(stringAnswer("EX")));
-
-        // Start recording DAG events now
-        dagEvents.clear();
-
-        scenario.removeRepeat("/data/house[1]");
-
-        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("AX")));
-        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("CX")));
-        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("DX")));
-        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("EX")));
-        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(nullValue()));
-        assertDagEvents(dagEvents,
-            "Processing 'Recalculate' for number [2_1] (2.0)",
-            "Processing 'Deleted: house [2]: 1 triggerables were fired.' for ",
-            "Processing 'Deleted: number [2_1]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for name_and_number [2_1] (CX)",
-            "Processing 'Deleted: name [2_1]: 1 triggerables were fired.' for ",
-            "Processing 'Deleted: name_and_number [2_1]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [3_1] (3.0)",
-            "Processing 'Deleted: house [3]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [4_1] (4.0)",
-            "Processing 'Deleted: house [4]: 1 triggerables were fired.' for "
-        );
-    }
-
-    @Test
-    public void deleteThirdRepeatGroup_evaluatesTriggerables_dependentOnTheRepeatGroupsNumber() throws IOException {
-        Scenario scenario = Scenario.init("Some form", html(
-            head(
-                title("Some form"),
-                model(
-                    mainInstance(t("data id=\"some-form\"",
-                        t("house jr:template=\"\"", t("number")),
-                        t("summary")
-                    )),
-                    bind("/data/house/number").type("int").calculate("position(..)"),
-                    bind("/data/summary").type("int").calculate("sum(/data/house/number)")
-                )
-            ),
-            body(group("/data/house", repeat("/data/house", input("number"))))
-        )).onDagEvent(dagEvents::add);
-        range(0, 10).forEach(n -> {
-            scenario.next();
-            scenario.createNewRepeat();
-            scenario.next();
-        });
-        assertThat(scenario.answerOf("/data/summary"), is(intAnswer(55)));
-
-        // Start recording DAG events now
-        dagEvents.clear();
-
-        scenario.removeRepeat("/data/house[2]");
-
-        assertThat(scenario.answerOf("/data/summary"), is(intAnswer(45)));
-        assertDagEvents(dagEvents,
-            "Processing 'Recalculate' for number [3_1] (3.0)",
-            "Processing 'Deleted: house [3]: 1 triggerables were fired.' for ",
-            "Processing 'Deleted: number [3_1]: 0 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [4_1] (4.0)",
-            "Processing 'Deleted: house [4]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [5_1] (5.0)",
-            "Processing 'Deleted: house [5]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [6_1] (6.0)",
-            "Processing 'Deleted: house [6]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [7_1] (7.0)",
-            "Processing 'Deleted: house [7]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [8_1] (8.0)",
-            "Processing 'Deleted: house [8]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [9_1] (9.0)",
-            "Processing 'Deleted: house [9]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [3_1] (3.0)",
-            "Processing 'Recalculate' for summary [1] (45.0)"
-            );
-    }
-
-    /**
-     * Indirectly means that the calculation - `concat(/data/house/name)` - does
-     * not take the
-     * `/data/house` nodeset (the repeat group) as an argument
-     * but since it takes one of its children (`name` children),
-     * the calculation must re-evaluated once after a repeat group deletion
-     * because one of the children
-     * has been deleted along with its parent (the repeat group instance).
-     */
-    @Test
-    public void deleteThirdRepeatGroup_evaluatesTriggerables_indirectlyDependentOnTheRepeatGroupsNumber() throws IOException {
-        Scenario scenario = Scenario.init("Some form", html(
-            head(
-                title("Some form"),
-                model(
-                    mainInstance(t("data id=\"some-form\"",
-                        t("house jr:template=\"\"", t("name")),
-                        t("summary")
-                    )),
-                    bind("/data/house/name").type("string").required(),
-                    bind("/data/summary").type("string").calculate("concat(/data/house/name)")
-                )
-            ),
-            body(group("/data/house", repeat("/data/house", input("/data/house/name"))))
-        )).onDagEvent(dagEvents::add);
-        range(0, 5).forEach(n -> {
-            scenario.next();
-            scenario.createNewRepeat();
-            scenario.next();
-            scenario.answer((char) (65 + n));
-        });
-        assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("ABCDE")));
-
-        // Start recording DAG events now
-        dagEvents.clear();
-
-        scenario.removeRepeat("/data/house[2]");
-
-        assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("ABDE")));
-        assertDagEvents(dagEvents,
-            "Processing 'Deleted: house [3]: 0 triggerables were fired.' for ",
-            "Processing 'Recalculate' for summary [1] (ABDE)",
-            "Processing 'Deleted: name [3_1]: 1 triggerables were fired.' for ",
-            "Processing 'Deleted: house [4]: 0 triggerables were fired.' for "
-        );
-
-    }
-
-    /**
-     * This test was inspired by the issue reported at https://code.google.com/archive/p/opendatakit/issues/888
-     * <p>
-     * We want to focus on the relationship between relevance and other calculations
-     * because relevance can be defined for fields **and groups**, which is a special
-     * case of expression evaluation in our DAG.
-     */
-    @Test
-    public void verify_relation_between_calculate_expressions_and_relevancy_conditions() throws IOException {
-        Scenario scenario = Scenario.init("Some form", html(
-            head(
-                title("Some form"),
-                model(
-                    mainInstance(
-                        t("data id=\"some-form\"",
-                            t("number1"),
-                            t("continue"),
-                            t("group", t("number1_x2"), t("number1_x2_x2"), t("number2"))
-                        )
-                    ),
-                    bind("/data/number1").type("int").constraint(". > 0").required(),
-                    bind("/data/continue").type("string").required(),
-                    bind("/data/group").relevant("/data/continue = '1'"),
-                    bind("/data/group/number1_x2").type("int").calculate("/data/number1 * 2"),
-                    bind("/data/group/number1_x2_x2").type("int").calculate("/data/group/number1_x2 * 2"),
-                    bind("/data/group/number2").type("int").relevant("/data/group/number1_x2 > 0").required()
-                )
-            ),
-            body(
-                input("/data/number1"),
-                select1("/data/continue",
-                    item(1, "Yes"),
-                    item(0, "No")
-                ),
-                group("/data/group",
-                    input("/data/group/number2")
-                )
-            )
-        ));
-        scenario.next();
-        scenario.answer(2);
-        assertThat(scenario.answerOf("/data/group/number1_x2"), is(intAnswer(4)));
-        // The expected value is null because the calculate expression uses a non-relevant field.
-        // Values of non-relevant fields are always null.
-        assertThat(scenario.answerOf("/data/group/number1_x2_x2"), is(nullValue()));
-        scenario.next();
-        scenario.answer("1"); // Label: "yes"
-        assertThat(scenario.answerOf("/data/group/number1_x2"), is(intAnswer(4)));
-        assertThat(scenario.answerOf("/data/group/number1_x2_x2"), is(intAnswer(8)));
-    }
-
-    @Test
-    public void issue_135_verify_that_counts_in_inner_repeats_work_as_expected() throws IOException {
-        Scenario scenario = Scenario.init("Some form", html(
-            head(
-                title("Some form"),
-                model(
-                    mainInstance(
-                        t("data id=\"some-form\"",
-                            t("outer-count", "0"),
-                            t("outer jr:template=\"\"",
-                                t("inner-count", "0"),
-                                t("inner jr:template=\"\"",
-                                    t("some-field")
-                                )
-                            )
-                        )
-                    ),
-                    bind("/data/outer-count").type("int"),
-                    bind("/data/outer/inner-count").type("int"),
-                    bind("/data/outer/inner/some-field").type("string")
-                )
-            ),
-            body(
-                input("/data/outer-count"),
-                group("/data/outer", repeat("/data/outer", "/data/outer-count",
-                    input("/data/outer/inner-count"),
-                    group("/data/outer/inner", repeat("/data/outer/inner", "../inner-count",
-                        input("/data/outer/inner/some-field")
-                    ))
-                ))
-            )
+            body(input("/data/a"))
         ));
 
-        scenario.next();
-        scenario.answer(2);
-        scenario.next();
-        scenario.next();
-        scenario.answer(3);
-        scenario.next();
-        scenario.next();
-        scenario.answer("Some field 0-0");
-        scenario.next();
-        scenario.next();
-        scenario.answer("Some field 0-1");
-        scenario.next();
-        scenario.next();
-        scenario.answer("Some field 0-2");
-        scenario.next();
-        scenario.next();
-        scenario.answer(2);
-        scenario.next();
-        scenario.next();
-        scenario.answer("Some field 1-0");
-        scenario.next();
-        scenario.next();
-        scenario.answer("Some field 1-1");
-        scenario.next();
-        assertThat(scenario.countRepeatInstancesOf("/data/outer[0]/inner"), is(3));
-        assertThat(scenario.countRepeatInstancesOf("/data/outer[1]/inner"), is(2));
+        assertThat(scenario.answerOf("/data/a"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/b"), is(intAnswer(6)));
+        assertThat(scenario.answerOf("/data/c"), is(intAnswer(40)));
+
+        scenario.answer("/data/a", 3);
+
+        assertThat(scenario.answerOf("/data/a"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/b"), is(intAnswer(9)));
+        // Verify that c gets computed using the updated value of b.
+        assertThat(scenario.answerOf("/data/c"), is(intAnswer(60)));
     }
 
-    /**
-     * Ignored because the assertions about non-null next-numbers will fail
-     * because our DAG
-     * doesn't evaluate calculations in repeat instances that are previous
-     * siblings to the
-     * one that has changed.
-     * <p>
-     * The expeculation is that, originally, only forward references might have
-     * been considered
-     * to speed up repeat group intance deletion because it was assumed that
-     * back references
-     * were a marginal use case.
-     * <p>
-     * This test explores how the issue affects to value changes too.
-     */
-    @Test
-    @Ignore
-    public void calculate_expressions_should_be_evaluated_on_previous_repeat_siblings() throws IOException {
-        Scenario scenario = Scenario.init("Some form", html(
-            head(
-                title("Some form"),
-                model(
-                    mainInstance(t("data id=\"some-form\"",
-                        t("group jr:template=\"\"",
-                            t("prev-number"),
-                            t("number"),
-                            t("next-number")
-                        )
-                    )),
-                    bind("/data/group/prev-number").type("int").calculate("/data/group[position() = (position(current()/..) - 1)]/number"),
-                    bind("/data/group/number").type("int").required(),
-                    bind("/data/group/next-number").type("int").calculate("/data/group[position() = (position(current()/..) + 1)]/number")
-                )
-            ),
-            body(group("/data/group", repeat("/data/group", input("/data/group/number"))))
-        ));
-
-        scenario.next();
-        scenario.createNewRepeat();
-        scenario.next();
-        scenario.answer(11);
-
-        assertThat(scenario.answerOf("/data/group[0]/prev-number"), is(nullValue()));
-
-        assertThat(scenario.answerOf("/data/group[0]/number"), is(intAnswer(11)));
-
-        assertThat(scenario.answerOf("/data/group[0]/next-number"), is(nullValue()));
-
-        scenario.next();
-        scenario.createNewRepeat();
-        scenario.next();
-        scenario.answer(22);
-
-        assertThat(scenario.answerOf("/data/group[0]/prev-number"), is(nullValue()));
-        assertThat(scenario.answerOf("/data/group[1]/prev-number"), is(intAnswer(11)));
-
-        assertThat(scenario.answerOf("/data/group[0]/number"), is(intAnswer(11)));
-        assertThat(scenario.answerOf("/data/group[1]/number"), is(intAnswer(22)));
-
-        // This assertion is the one that fails with the current implementation
-        assertThat(scenario.answerOf("/data/group[0]/next-number"), is(intAnswer(22)));
-        assertThat(scenario.answerOf("/data/group[1]/next-number"), is(nullValue()));
-
-        scenario.next();
-        scenario.createNewRepeat();
-        scenario.next();
-        scenario.answer(33);
-
-        assertThat(scenario.answerOf("/data/group[0]/prev-number"), is(nullValue()));
-        assertThat(scenario.answerOf("/data/group[1]/prev-number"), is(intAnswer(11)));
-        assertThat(scenario.answerOf("/data/group[2]/prev-number"), is(intAnswer(22)));
-
-        assertThat(scenario.answerOf("/data/group[0]/number"), is(intAnswer(11)));
-        assertThat(scenario.answerOf("/data/group[1]/number"), is(intAnswer(22)));
-        assertThat(scenario.answerOf("/data/group[2]/number"), is(intAnswer(33)));
-
-        // The following couple of assertions are the ones that fail with the current implementation
-        assertThat(scenario.answerOf("/data/group[0]/next-number"), is(intAnswer(22)));
-        assertThat(scenario.answerOf("/data/group[1]/next-number"), is(intAnswer(33)));
-        assertThat(scenario.answerOf("/data/group[2]/next-number"), is(nullValue()));
-    }
-
-    /**
-     * Ignored because the count() function inside the predicate of the result_2
-     * calculate
-     * expression isn't evaled correctly, as opposed to the predicate of the
-     * result_1 calculate
-     * that uses an interim field as a proxy for the same computation
-     */
-    @Test
-    @Ignore
-    public void equivalent_predicates_with_function_calls_should_produce_the_same_results() throws IOException {
-        Scenario scenario = Scenario.init("Some form", html(
-            head(
-                title("Some form"),
-                model(
-                    mainInstance(t("data id=\"some-form\"",
-                        t("group jr:template=\"\"", t("number")),
-                        t("count"),
-                        t("result_1"),
-                        t("result_2")
-                    )),
-                    bind("/data/group/number").type("int").required(),
-                    bind("/data/count").type("int").calculate("count(/data/group)"),
-                    bind("/data/result_1").type("int").calculate("10 + /data/group[position() = /data/count]/number"),
-                    bind("/data/result_2").type("int").calculate("10 + /data/group[position() = count(/data/group)]/number")
-                )
-            ),
-            body(group("/data/group", repeat("/data/group", input("/data/group/number"))))
-        ));
-        scenario.next();
-        scenario.createNewRepeat();
-        scenario.next();
-        scenario.answer(10);
-
-        assertThat(scenario.answerOf("/data/count"), is(intAnswer(1)));
-        assertThat(scenario.answerOf("/data/result_1"), is(intAnswer(20)));
-        assertThat(scenario.answerOf("/data/result_2"), is(intAnswer(20)));
-
-        scenario.next();
-        scenario.createNewRepeat();
-        scenario.next();
-        scenario.answer(20);
-
-        assertThat(scenario.answerOf("/data/count"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/result_1"), is(intAnswer(30)));
-        // The following assertion is the one that fails with the current implementation
-        // TODO Explore the difference between the calculations in result_1 and result_2 and unify them
-        assertThat(scenario.answerOf("/data/result_2"), is(intAnswer(30)));
-    }
-
+    //region Cycles
     @Test
     public void parsing_forms_with_cycles_by_self_reference_in_calculate_should_fail() throws IOException {
         exceptionRule.expect(XFormParseException.class);
@@ -841,226 +371,9 @@ public class TriggerableDagTest {
             )))
         ));
     }
+    //endregion
 
-    @Test
-    public void order_of_the_DAG_is_ensured() throws IOException {
-        Scenario scenario = Scenario.init("Some form", html(
-            head(
-                title("Some form"),
-                model(
-                    mainInstance(t("data id=\"some-form\"",
-                        t("a", "2"),
-                        t("b"),
-                        t("c")
-                    )),
-                    bind("/data/a").type("int"),
-                    bind("/data/b").type("int").calculate("/data/a * 3"),
-                    bind("/data/c").type("int").calculate("(/data/a + /data/b) * 5")
-                )
-            ),
-            body(input("/data/a"))
-        ));
-
-        assertThat(scenario.answerOf("/data/a"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/b"), is(intAnswer(6)));
-        assertThat(scenario.answerOf("/data/c"), is(intAnswer(40)));
-
-        scenario.answer("/data/a", 3);
-
-        assertThat(scenario.answerOf("/data/a"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/b"), is(intAnswer(9)));
-        // Verify that c gets computed using the updated value of b.
-        assertThat(scenario.answerOf("/data/c"), is(intAnswer(60)));
-    }
-
-    @Test
-    public void relative_paths_in_nested_repeats() throws IOException {
-        Scenario scenario = Scenario.init("Some form", html(
-            head(
-                title("Some form"),
-                model(
-                    mainInstance(t("data id=\"some-form\"",
-                        t("outer jr:template=\"\"",
-                            t("inner jr:template=\"\"",
-                                t("count"),
-                                t("some-field")
-                            ),
-                            t("count"),
-                            t("some-field")
-                        )
-                    )),
-                    bind("/data/outer/inner/count").type("int").calculate("count(../../inner)")
-                )
-            ),
-            body(
-                group("/data/outer", repeat("/data/outer",
-                    input("/data/outer/some-field"),
-                    group("/data/outer/inner", repeat("/data/outer/inner",
-                        input("/data/outer/inner/some-field")
-                    ))
-                ))
-            )));
-        scenario.createNewRepeat("/data/outer");
-        scenario.createNewRepeat("/data/outer[0]/inner");
-        scenario.createNewRepeat("/data/outer[0]/inner");
-        scenario.createNewRepeat("/data/outer[0]/inner");
-        scenario.createNewRepeat("/data/outer");
-        scenario.createNewRepeat("/data/outer[1]/inner");
-        scenario.createNewRepeat("/data/outer[1]/inner");
-
-        // The following assertions have incrementally greater count values because
-        // we currently evaluate triggerables bound to the new repeat group only. This
-        // means that the actual count value only takes into account the existing repeat
-        // groups when creating the new instance.
-        //
-        // To have the expected count of 3 for outer[0] and 2 for outer[1], we would have
-        // to change the sequence of evaluations when a new repeat group is created to
-        // evaluate the triggerables on all siblings (not just on the instance that has
-        // been created). This is currently driven by TriggerableDag.createRepeatGroup()
-        assertThat(scenario.answerOf("/data/outer[0]/inner[0]/count"), is(intAnswer(1)));
-        assertThat(scenario.answerOf("/data/outer[0]/inner[1]/count"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/outer[0]/inner[2]/count"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/outer[1]/inner[0]/count"), is(intAnswer(1)));
-        assertThat(scenario.answerOf("/data/outer[1]/inner[1]/count"), is(intAnswer(2)));
-    }
-
-    /**
-     * Excercises the triggerTriggerables call in createRepeatGroup.
-     */
-    @Test
-    public void adding_repeat_instance_triggers_triggerables_outside_repeat_that_reference_repeat_nodeset() throws IOException {
-        Scenario scenario = Scenario.init("Form", html(
-            head(
-                title("Form"),
-                model(
-                    mainInstance(t("data",
-                        t("count"),
-                        t("repeat jr:template=\"\"",
-                            t("string")
-                        )
-                    )),
-                    bind("/data/count").type("int").calculate("count(/data/repeat)"),
-                    bind("/data/repeat/string").type("string")
-                )
-            ),
-            body(
-                repeat("/data/repeat",
-                    input("/data/repeat/string")
-                )
-            )
-        ));
-
-        scenario.createNewRepeat("/data/repeat");
-        scenario.createNewRepeat("/data/repeat");
-
-        assertThat(scenario.answerOf("/data/count"), is(intAnswer(2)));
-    }
-
-    /**
-     * Excercises the initializeTriggerables call in createRepeatGroup.
-     */
-    @Test
-    public void adding_repeat_instance_triggers_descendant_node_triggerables() throws IOException {
-        Scenario scenario = Scenario.init("Form", html(
-            head(
-                title("Form"),
-                model(
-                    mainInstance(t("data",
-                        t("repeat jr:template=\"\"",
-                            t("string"),
-                            t("group",
-                                t("int")
-                            )
-                        )
-                    )),
-                    bind("/data/repeat/string").type("string"),
-                    bind("/data/repeat/group").relevant("0")
-                )
-            ),
-            body(
-                repeat("/data/repeat",
-                    input("/data/repeat/string"),
-                    input("/data/repeat/group/int")
-                )
-            )
-        ));
-
-        scenario.next();
-        scenario.createNewRepeat();
-        scenario.next();
-        scenario.next();
-        assertThat(scenario.getAnswerNode("/data/repeat[0]/group/int"), is(nonRelevant()));
-
-        scenario.createNewRepeat();
-        scenario.next();
-        scenario.next();
-        assertThat(scenario.getAnswerNode("/data/repeat[1]/group/int"), is(nonRelevant()));
-
-        scenario.createNewRepeat();
-        scenario.next();
-        scenario.next();
-        assertThat(scenario.getAnswerNode("/data/repeat[2]/group/int"), is(nonRelevant()));
-    }
-
-    /**
-     * This test documents some bugs:
-     *  * calling the count function with an absolute reference to a repeat should return the count of repeat instances
-     *  but instead it always returns 1
-     *  * a count inside of a repeat instance is not recomputed as new instances are added
-     *  * calculations that don't involve user input are not recomputed on form validation
-     */
-    @Test
-    public void validation_only_triggers_calculations_involving_user_visible_fields() throws IOException {
-        Scenario scenario = Scenario.init("Some form", html(
-            head(
-                title("Some form"),
-                model(
-                    mainInstance(t("data id=\"some-form\"",
-                        t("user-input", "1"),
-                        t("repeat jr:template=\"\"",
-                            t("count"),
-                            t("multiplied-count"),
-                            t("some-field")
-                        )
-                    )),
-                    bind("/data/user-input").type("int"),
-                    bind("/data/repeat/count").type("int").calculate("count(../../repeat)"), // both .. and /data/repeat always give a count of 1
-                    bind("/data/repeat/multiplied-count").type("int").calculate("/data/user-input * count(../../repeat)")
-                )
-            ),
-            body(
-                input("/data/user-input"),
-                repeat("/data/repeat",
-                    input("/data/repeat/some-field"))
-            )));
-
-        scenario.createNewRepeat("/data/repeat");
-        scenario.createNewRepeat("/data/repeat");
-        scenario.createNewRepeat("/data/repeat");
-
-        // All of these counts should be 3
-        assertThat(scenario.answerOf("/data/repeat[0]/count"), is(intAnswer(1)));
-        assertThat(scenario.answerOf("/data/repeat[1]/count"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/repeat[2]/count"), is(intAnswer(3)));
-
-        // The initial value of user-input is 1 so we expect the same values as the raw count
-        assertThat(scenario.answerOf("/data/repeat[0]/multiplied-count"), is(intAnswer(1)));
-        assertThat(scenario.answerOf("/data/repeat[1]/multiplied-count"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/repeat[2]/multiplied-count"), is(intAnswer(3)));
-
-        scenario.getValidationOutcome();
-
-        // None of these have been recalculated
-        assertThat(scenario.answerOf("/data/repeat[0]/count"), is(intAnswer(1)));
-        assertThat(scenario.answerOf("/data/repeat[1]/count"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/repeat[2]/count"), is(intAnswer(3)));
-
-        // All of these have been recalculated
-        assertThat(scenario.answerOf("/data/repeat[0]/multiplied-count"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/repeat[1]/multiplied-count"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/repeat[2]/multiplied-count"), is(intAnswer(3)));
-    }
-
+    //region Relevance
     /**
      * Non-relevance is inherited from ancestor nodes, as per the W3C XForms specs:
      * - https://www.w3.org/TR/xforms11/#model-prop-relevant
@@ -1191,6 +504,57 @@ public class TriggerableDagTest {
         assertThat(scenario.answerOf("/data/some-field"), is(intAnswer(42)));
     }
 
+    /**
+     * This test was inspired by the issue reported at https://code.google.com/archive/p/opendatakit/issues/888
+     * <p>
+     * We want to focus on the relationship between relevance and other calculations
+     * because relevance can be defined for fields **and groups**, which is a special
+     * case of expression evaluation in our DAG.
+     */
+    @Test
+    public void verify_relation_between_calculate_expressions_and_relevancy_conditions() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(
+                        t("data id=\"some-form\"",
+                            t("number1"),
+                            t("continue"),
+                            t("group", t("number1_x2"), t("number1_x2_x2"), t("number2"))
+                        )
+                    ),
+                    bind("/data/number1").type("int").constraint(". > 0").required(),
+                    bind("/data/continue").type("string").required(),
+                    bind("/data/group").relevant("/data/continue = '1'"),
+                    bind("/data/group/number1_x2").type("int").calculate("/data/number1 * 2"),
+                    bind("/data/group/number1_x2_x2").type("int").calculate("/data/group/number1_x2 * 2"),
+                    bind("/data/group/number2").type("int").relevant("/data/group/number1_x2 > 0").required()
+                )
+            ),
+            body(
+                input("/data/number1"),
+                select1("/data/continue",
+                    item(1, "Yes"),
+                    item(0, "No")
+                ),
+                group("/data/group",
+                    input("/data/group/number2")
+                )
+            )
+        ));
+        scenario.next();
+        scenario.answer(2);
+        assertThat(scenario.answerOf("/data/group/number1_x2"), is(intAnswer(4)));
+        // The expected value is null because the calculate expression uses a non-relevant field.
+        // Values of non-relevant fields are always null.
+        assertThat(scenario.answerOf("/data/group/number1_x2_x2"), is(nullValue()));
+        scenario.next();
+        scenario.answer("1"); // Label: "yes"
+        assertThat(scenario.answerOf("/data/group/number1_x2"), is(intAnswer(4)));
+        assertThat(scenario.answerOf("/data/group/number1_x2_x2"), is(intAnswer(8)));
+    }
+
     @Test
     public void issue_119_target_question_should_be_relevant() throws IOException {
         // This is a translation of the XML form in the issue to our DSL with some adaptations:
@@ -1249,7 +613,9 @@ public class TriggerableDagTest {
         assertThat(scenario.getAnswerNode("/data/outer/inner"), is(nonRelevant()));
         assertThat(scenario.getAnswerNode("/data/outer/inner/target_question"), is(nonRelevant()));
     }
+    //endregion
 
+    //region Required and constraint
     @Test
     public void constraints_of_fields_that_are_empty_are_always_satisfied() throws IOException {
         Scenario scenario = Scenario.init("Some form", html(
@@ -1348,6 +714,708 @@ public class TriggerableDagTest {
         assertThat(validate.failedPrompt, is(scenario.indexOf("/data/a")));
         assertThat(validate.outcome, is(ANSWER_CONSTRAINT_VIOLATED));
     }
+    //endregion
+
+    //region Deleting repeats
+    @Test
+    public void deleteSecondRepeatGroup_evaluatesTriggerables_dependentOnPrecedingRepeatGroupSiblings() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("house jr:template=\"\"", t("number"))
+                    )),
+                    bind("/data/house/number").type("int").calculate("position(..)")
+                )
+            ),
+            body(group("/data/house", repeat("/data/house", input("number"))))
+        )).onDagEvent(dagEvents::add);
+        range(0, 5).forEach(__ -> {
+            scenario.next();
+            scenario.createNewRepeat();
+            scenario.next();
+        });
+        assertThat(scenario.answerOf("/data/house[0]/number"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/house[1]/number"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/house[2]/number"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/house[3]/number"), is(intAnswer(4)));
+        assertThat(scenario.answerOf("/data/house[4]/number"), is(intAnswer(5)));
+
+        // Start recording DAG events now
+        dagEvents.clear();
+
+        scenario.removeRepeat("/data/house[1]");
+
+        assertThat(scenario.answerOf("/data/house[0]/number"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/house[1]/number"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/house[2]/number"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/house[3]/number"), is(intAnswer(4)));
+        assertThat(scenario.answerOf("/data/house[4]/number"), is(nullValue()));
+        assertDagEvents(dagEvents,
+            "Processing 'Recalculate' for number [2_1] (2.0)",
+            "Processing 'Deleted: house [2]: 1 triggerables were fired.' for ",
+            "Processing 'Deleted: number [2_1]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [3_1] (3.0)",
+            "Processing 'Deleted: house [3]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [4_1] (4.0)",
+            "Processing 'Deleted: house [4]: 1 triggerables were fired.' for "
+        );
+    }
+
+    @Test
+    public void deleteSecondRepeatGroup_evaluatesTriggerables_dependentOnTheParentPosition() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("house jr:template=\"\"",
+                            t("number"),
+                            t("name"),
+                            t("name_and_number")
+                        )
+                    )),
+                    bind("/data/house/number").type("int").calculate("position(..)"),
+                    bind("/data/house/name").type("string").required(),
+                    bind("/data/house/name_and_number").type("string").calculate("concat(/data/house/name, /data/house/number)")
+                )
+            ),
+            body(group("/data/house", repeat("/data/house", input("/data/house/name"))))
+        )).onDagEvent(dagEvents::add);
+        range(0, 5).forEach(n -> {
+            scenario.next();
+            scenario.createNewRepeat();
+            scenario.next();
+            scenario.answer((char) (65 + n));
+        });
+        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("A1")));
+        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("B2")));
+        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("C3")));
+        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("D4")));
+        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(stringAnswer("E5")));
+
+        // Start recording DAG events now
+        dagEvents.clear();
+
+        scenario.removeRepeat("/data/house[1]");
+
+        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("A1")));
+        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("C2")));
+        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("D3")));
+        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("E4")));
+        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(nullValue()));
+        assertDagEvents(dagEvents,
+            "Processing 'Recalculate' for number [2_1] (2.0)",
+            "Processing 'Recalculate' for name_and_number [2_1] (C2)",
+            "Processing 'Deleted: house [2]: 2 triggerables were fired.' for ",
+            "Processing 'Deleted: number [2_1]: 0 triggerables were fired.' for ",
+            "Processing 'Deleted: name [2_1]: 0 triggerables were fired.' for ",
+            "Processing 'Deleted: name_and_number [2_1]: 2 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [3_1] (3.0)",
+            "Processing 'Recalculate' for name_and_number [3_1] (D3)",
+            "Processing 'Deleted: house [3]: 2 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [4_1] (4.0)",
+            "Processing 'Recalculate' for name_and_number [4_1] (E4)",
+            "Processing 'Deleted: house [4]: 2 triggerables were fired.' for "
+        );
+    }
+
+    @Test
+    public void deleteSecondRepeatGroup_doesNotEvaluateTriggerables_notDependentOnTheParentPosition() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("house jr:template=\"\"",
+                            t("number"),
+                            t("name"),
+                            t("name_and_number")
+                        )
+                    )),
+                    bind("/data/house/number").type("int").calculate("position(..)"),
+                    bind("/data/house/name").type("string").required(),
+                    bind("/data/house/name_and_number").type("string").calculate("concat(/data/house/name, 'X')")
+                )
+            ),
+            body(group("/data/house", repeat("/data/house", input("/data/house/name"))))
+        )).onDagEvent(dagEvents::add);
+        range(0, 5).forEach(n -> {
+            scenario.next();
+            scenario.createNewRepeat();
+            scenario.next();
+            scenario.answer((char) (65 + n));
+        });
+        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("AX")));
+        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("BX")));
+        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("CX")));
+        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("DX")));
+        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(stringAnswer("EX")));
+
+        // Start recording DAG events now
+        dagEvents.clear();
+
+        scenario.removeRepeat("/data/house[1]");
+
+        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("AX")));
+        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("CX")));
+        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("DX")));
+        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("EX")));
+        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(nullValue()));
+        assertDagEvents(dagEvents,
+            "Processing 'Recalculate' for number [2_1] (2.0)",
+            "Processing 'Deleted: house [2]: 1 triggerables were fired.' for ",
+            "Processing 'Deleted: number [2_1]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for name_and_number [2_1] (CX)",
+            "Processing 'Deleted: name [2_1]: 1 triggerables were fired.' for ",
+            "Processing 'Deleted: name_and_number [2_1]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [3_1] (3.0)",
+            "Processing 'Deleted: house [3]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [4_1] (4.0)",
+            "Processing 'Deleted: house [4]: 1 triggerables were fired.' for "
+        );
+    }
+
+    @Test
+    public void deleteThirdRepeatGroup_evaluatesTriggerables_dependentOnTheRepeatGroupsNumber() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("house jr:template=\"\"", t("number")),
+                        t("summary")
+                    )),
+                    bind("/data/house/number").type("int").calculate("position(..)"),
+                    bind("/data/summary").type("int").calculate("sum(/data/house/number)")
+                )
+            ),
+            body(group("/data/house", repeat("/data/house", input("number"))))
+        )).onDagEvent(dagEvents::add);
+        range(0, 10).forEach(n -> {
+            scenario.next();
+            scenario.createNewRepeat();
+            scenario.next();
+        });
+        assertThat(scenario.answerOf("/data/summary"), is(intAnswer(55)));
+
+        // Start recording DAG events now
+        dagEvents.clear();
+
+        scenario.removeRepeat("/data/house[2]");
+
+        assertThat(scenario.answerOf("/data/summary"), is(intAnswer(45)));
+        assertDagEvents(dagEvents,
+            "Processing 'Recalculate' for number [3_1] (3.0)",
+            "Processing 'Deleted: house [3]: 1 triggerables were fired.' for ",
+            "Processing 'Deleted: number [3_1]: 0 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [4_1] (4.0)",
+            "Processing 'Deleted: house [4]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [5_1] (5.0)",
+            "Processing 'Deleted: house [5]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [6_1] (6.0)",
+            "Processing 'Deleted: house [6]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [7_1] (7.0)",
+            "Processing 'Deleted: house [7]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [8_1] (8.0)",
+            "Processing 'Deleted: house [8]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [9_1] (9.0)",
+            "Processing 'Deleted: house [9]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [3_1] (3.0)",
+            "Processing 'Recalculate' for summary [1] (45.0)"
+            );
+    }
+
+    /**
+     * Indirectly means that the calculation - `concat(/data/house/name)` - does
+     * not take the
+     * `/data/house` nodeset (the repeat group) as an argument
+     * but since it takes one of its children (`name` children),
+     * the calculation must re-evaluated once after a repeat group deletion
+     * because one of the children
+     * has been deleted along with its parent (the repeat group instance).
+     */
+    @Test
+    public void deleteThirdRepeatGroup_evaluatesTriggerables_indirectlyDependentOnTheRepeatGroupsNumber() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("house jr:template=\"\"", t("name")),
+                        t("summary")
+                    )),
+                    bind("/data/house/name").type("string").required(),
+                    bind("/data/summary").type("string").calculate("concat(/data/house/name)")
+                )
+            ),
+            body(group("/data/house", repeat("/data/house", input("/data/house/name"))))
+        )).onDagEvent(dagEvents::add);
+        range(0, 5).forEach(n -> {
+            scenario.next();
+            scenario.createNewRepeat();
+            scenario.next();
+            scenario.answer((char) (65 + n));
+        });
+        assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("ABCDE")));
+
+        // Start recording DAG events now
+        dagEvents.clear();
+
+        scenario.removeRepeat("/data/house[2]");
+
+        assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("ABDE")));
+        assertDagEvents(dagEvents,
+            "Processing 'Deleted: house [3]: 0 triggerables were fired.' for ",
+            "Processing 'Recalculate' for summary [1] (ABDE)",
+            "Processing 'Deleted: name [3_1]: 1 triggerables were fired.' for ",
+            "Processing 'Deleted: house [4]: 0 triggerables were fired.' for "
+        );
+    }
+
+    @Test
+    public void deleteLastRepeat_evaluatesTriggerables() throws IOException {
+        Scenario scenario = Scenario.init("Delete last repeat instance", html(
+            head(
+                title("Delete last repeat instance"),
+                model(
+                    mainInstance(t("data id=\"delete-last-repeat-instance\"",
+                        t("repeat-count"),
+
+                        t("repeat",
+                            t("question")),
+                        t("repeat",
+                            t("question")),
+                        t("repeat",
+                            t("question"))
+                    )),
+                    bind("/data/repeat-count").type("int").calculate("count(/data/repeat)")
+                ),
+                body(
+                    repeat("/data/repeat",
+                        input("question"))
+                ))));
+
+        assertThat(scenario.answerOf("/data/repeat-count"), is(intAnswer(3)));
+
+        scenario.removeRepeat("/data/repeat[2]");
+        assertThat(scenario.answerOf("/data/repeat-count"), is(intAnswer(2)));
+    }
+
+    @Test
+    public void deleteLastRepeat_evaluatesTriggerables_indirectlyDependentOnTheDeletedRepeat() throws IOException {
+        Scenario scenario = Scenario.init("Delete last repeat instance", html(
+            head(
+                title("Delete last repeat instance"),
+                model(
+                    mainInstance(t("data id=\"delete-last-repeat-instance\"",
+                        t("summary"),
+
+                        t("repeat",
+                            t("question", "a")),
+                        t("repeat",
+                            t("question", "b")),
+                        t("repeat",
+                            t("question", "c"))
+                    )),
+                    bind("/data/summary").type("string").calculate("concat(/data/repeat/question)")
+                ),
+                body(
+                    repeat("/data/repeat",
+                        input("question"))
+                ))));
+
+        assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("abc")));
+
+        scenario.removeRepeat("/data/repeat[2]");
+        assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("ab")));
+    }
+    //endregion
+
+    //region Adding repeats
+    /**
+     * Excercises the triggerTriggerables call in createRepeatGroup.
+     */
+    @Test
+    public void adding_repeat_instance_triggers_triggerables_outside_repeat_that_reference_repeat_nodeset() throws IOException {
+        Scenario scenario = Scenario.init("Form", html(
+            head(
+                title("Form"),
+                model(
+                    mainInstance(t("data",
+                        t("count"),
+                        t("repeat jr:template=\"\"",
+                            t("string")
+                        )
+                    )),
+                    bind("/data/count").type("int").calculate("count(/data/repeat)"),
+                    bind("/data/repeat/string").type("string")
+                )
+            ),
+            body(
+                repeat("/data/repeat",
+                    input("/data/repeat/string")
+                )
+            )
+        ));
+
+        scenario.createNewRepeat("/data/repeat");
+        scenario.createNewRepeat("/data/repeat");
+
+        assertThat(scenario.answerOf("/data/count"), is(intAnswer(2)));
+    }
+
+    /**
+     * Excercises the initializeTriggerables call in createRepeatGroup.
+     */
+    @Test
+    public void adding_repeat_instance_triggers_descendant_node_triggerables() throws IOException {
+        Scenario scenario = Scenario.init("Form", html(
+            head(
+                title("Form"),
+                model(
+                    mainInstance(t("data",
+                        t("repeat jr:template=\"\"",
+                            t("string"),
+                            t("group",
+                                t("int")
+                            )
+                        )
+                    )),
+                    bind("/data/repeat/string").type("string"),
+                    bind("/data/repeat/group").relevant("0")
+                )
+            ),
+            body(
+                repeat("/data/repeat",
+                    input("/data/repeat/string"),
+                    input("/data/repeat/group/int")
+                )
+            )
+        ));
+
+        scenario.next();
+        scenario.createNewRepeat();
+        scenario.next();
+        scenario.next();
+        assertThat(scenario.getAnswerNode("/data/repeat[0]/group/int"), is(nonRelevant()));
+
+        scenario.createNewRepeat();
+        scenario.next();
+        scenario.next();
+        assertThat(scenario.getAnswerNode("/data/repeat[1]/group/int"), is(nonRelevant()));
+
+        scenario.createNewRepeat();
+        scenario.next();
+        scenario.next();
+        assertThat(scenario.getAnswerNode("/data/repeat[2]/group/int"), is(nonRelevant()));
+    }
+    //endregion
+
+    //region Repeat misc
+    @Test
+    public void issue_135_verify_that_counts_in_inner_repeats_work_as_expected() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(
+                        t("data id=\"some-form\"",
+                            t("outer-count", "0"),
+                            t("outer jr:template=\"\"",
+                                t("inner-count", "0"),
+                                t("inner jr:template=\"\"",
+                                    t("some-field")
+                                )
+                            )
+                        )
+                    ),
+                    bind("/data/outer-count").type("int"),
+                    bind("/data/outer/inner-count").type("int"),
+                    bind("/data/outer/inner/some-field").type("string")
+                )
+            ),
+            body(
+                input("/data/outer-count"),
+                group("/data/outer", repeat("/data/outer", "/data/outer-count",
+                    input("/data/outer/inner-count"),
+                    group("/data/outer/inner", repeat("/data/outer/inner", "../inner-count",
+                        input("/data/outer/inner/some-field")
+                    ))
+                ))
+            )
+        ));
+
+        scenario.next();
+        scenario.answer(2);
+        scenario.next();
+        scenario.next();
+        scenario.answer(3);
+        scenario.next();
+        scenario.next();
+        scenario.answer("Some field 0-0");
+        scenario.next();
+        scenario.next();
+        scenario.answer("Some field 0-1");
+        scenario.next();
+        scenario.next();
+        scenario.answer("Some field 0-2");
+        scenario.next();
+        scenario.next();
+        scenario.answer(2);
+        scenario.next();
+        scenario.next();
+        scenario.answer("Some field 1-0");
+        scenario.next();
+        scenario.next();
+        scenario.answer("Some field 1-1");
+        scenario.next();
+        assertThat(scenario.countRepeatInstancesOf("/data/outer[0]/inner"), is(3));
+        assertThat(scenario.countRepeatInstancesOf("/data/outer[1]/inner"), is(2));
+    }
+
+    /**
+     * Ignored because the assertions about non-null next-numbers will fail
+     * because our DAG
+     * doesn't evaluate calculations in repeat instances that are previous
+     * siblings to the
+     * one that has changed.
+     * <p>
+     * The expeculation is that, originally, only forward references might have
+     * been considered
+     * to speed up repeat group intance deletion because it was assumed that
+     * back references
+     * were a marginal use case.
+     * <p>
+     * This test explores how the issue affects to value changes too.
+     */
+    @Test
+    @Ignore
+    public void calculate_expressions_should_be_evaluated_on_previous_repeat_siblings() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("group jr:template=\"\"",
+                            t("prev-number"),
+                            t("number"),
+                            t("next-number")
+                        )
+                    )),
+                    bind("/data/group/prev-number").type("int").calculate("/data/group[position() = (position(current()/..) - 1)]/number"),
+                    bind("/data/group/number").type("int").required(),
+                    bind("/data/group/next-number").type("int").calculate("/data/group[position() = (position(current()/..) + 1)]/number")
+                )
+            ),
+            body(group("/data/group", repeat("/data/group", input("/data/group/number"))))
+        ));
+
+        scenario.next();
+        scenario.createNewRepeat();
+        scenario.next();
+        scenario.answer(11);
+
+        assertThat(scenario.answerOf("/data/group[0]/prev-number"), is(nullValue()));
+
+        assertThat(scenario.answerOf("/data/group[0]/number"), is(intAnswer(11)));
+
+        assertThat(scenario.answerOf("/data/group[0]/next-number"), is(nullValue()));
+
+        scenario.next();
+        scenario.createNewRepeat();
+        scenario.next();
+        scenario.answer(22);
+
+        assertThat(scenario.answerOf("/data/group[0]/prev-number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/group[1]/prev-number"), is(intAnswer(11)));
+
+        assertThat(scenario.answerOf("/data/group[0]/number"), is(intAnswer(11)));
+        assertThat(scenario.answerOf("/data/group[1]/number"), is(intAnswer(22)));
+
+        // This assertion is the one that fails with the current implementation
+        assertThat(scenario.answerOf("/data/group[0]/next-number"), is(intAnswer(22)));
+        assertThat(scenario.answerOf("/data/group[1]/next-number"), is(nullValue()));
+
+        scenario.next();
+        scenario.createNewRepeat();
+        scenario.next();
+        scenario.answer(33);
+
+        assertThat(scenario.answerOf("/data/group[0]/prev-number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/group[1]/prev-number"), is(intAnswer(11)));
+        assertThat(scenario.answerOf("/data/group[2]/prev-number"), is(intAnswer(22)));
+
+        assertThat(scenario.answerOf("/data/group[0]/number"), is(intAnswer(11)));
+        assertThat(scenario.answerOf("/data/group[1]/number"), is(intAnswer(22)));
+        assertThat(scenario.answerOf("/data/group[2]/number"), is(intAnswer(33)));
+
+        // The following couple of assertions are the ones that fail with the current implementation
+        assertThat(scenario.answerOf("/data/group[0]/next-number"), is(intAnswer(22)));
+        assertThat(scenario.answerOf("/data/group[1]/next-number"), is(intAnswer(33)));
+        assertThat(scenario.answerOf("/data/group[2]/next-number"), is(nullValue()));
+    }
+
+    @Test
+    public void relative_paths_in_nested_repeats() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("outer jr:template=\"\"",
+                            t("inner jr:template=\"\"",
+                                t("count"),
+                                t("some-field")
+                            ),
+                            t("count"),
+                            t("some-field")
+                        )
+                    )),
+                    bind("/data/outer/inner/count").type("int").calculate("count(../../inner)")
+                )
+            ),
+            body(
+                group("/data/outer", repeat("/data/outer",
+                    input("/data/outer/some-field"),
+                    group("/data/outer/inner", repeat("/data/outer/inner",
+                        input("/data/outer/inner/some-field")
+                    ))
+                ))
+            )));
+        scenario.createNewRepeat("/data/outer");
+        scenario.createNewRepeat("/data/outer[0]/inner");
+        scenario.createNewRepeat("/data/outer[0]/inner");
+        scenario.createNewRepeat("/data/outer[0]/inner");
+        scenario.createNewRepeat("/data/outer");
+        scenario.createNewRepeat("/data/outer[1]/inner");
+        scenario.createNewRepeat("/data/outer[1]/inner");
+
+        // The following assertions have incrementally greater count values because
+        // we currently evaluate triggerables bound to the new repeat group only. This
+        // means that the actual count value only takes into account the existing repeat
+        // groups when creating the new instance.
+        //
+        // To have the expected count of 3 for outer[0] and 2 for outer[1], we would have
+        // to change the sequence of evaluations when a new repeat group is created to
+        // evaluate the triggerables on all siblings (not just on the instance that has
+        // been created). This is currently driven by TriggerableDag.createRepeatGroup()
+        assertThat(scenario.answerOf("/data/outer[0]/inner[0]/count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/outer[0]/inner[1]/count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/outer[0]/inner[2]/count"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[0]/count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[1]/count"), is(intAnswer(2)));
+    }
+    //endregion
+
+    /**
+     * Ignored because the count() function inside the predicate of the result_2
+     * calculate
+     * expression isn't evaled correctly, as opposed to the predicate of the
+     * result_1 calculate
+     * that uses an interim field as a proxy for the same computation
+     */
+    @Test
+    @Ignore
+    public void equivalent_predicates_with_function_calls_should_produce_the_same_results() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("group jr:template=\"\"", t("number")),
+                        t("count"),
+                        t("result_1"),
+                        t("result_2")
+                    )),
+                    bind("/data/group/number").type("int").required(),
+                    bind("/data/count").type("int").calculate("count(/data/group)"),
+                    bind("/data/result_1").type("int").calculate("10 + /data/group[position() = /data/count]/number"),
+                    bind("/data/result_2").type("int").calculate("10 + /data/group[position() = count(/data/group)]/number")
+                )
+            ),
+            body(group("/data/group", repeat("/data/group", input("/data/group/number"))))
+        ));
+        scenario.next();
+        scenario.createNewRepeat();
+        scenario.next();
+        scenario.answer(10);
+
+        assertThat(scenario.answerOf("/data/count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/result_1"), is(intAnswer(20)));
+        assertThat(scenario.answerOf("/data/result_2"), is(intAnswer(20)));
+
+        scenario.next();
+        scenario.createNewRepeat();
+        scenario.next();
+        scenario.answer(20);
+
+        assertThat(scenario.answerOf("/data/count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/result_1"), is(intAnswer(30)));
+        // The following assertion is the one that fails with the current implementation
+        // TODO Explore the difference between the calculations in result_1 and result_2 and unify them
+        assertThat(scenario.answerOf("/data/result_2"), is(intAnswer(30)));
+    }
+
+    /**
+     * This test documents some bugs:
+     *  * calling the count function with an absolute reference to a repeat should return the count of repeat instances
+     *  but instead it always returns 1
+     *  * a count inside of a repeat instance is not recomputed as new instances are added
+     *  * calculations that don't involve user input are not recomputed on form validation
+     */
+    @Test
+    public void validation_only_triggers_calculations_involving_user_visible_fields() throws IOException {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("user-input", "1"),
+                        t("repeat jr:template=\"\"",
+                            t("count"),
+                            t("multiplied-count"),
+                            t("some-field")
+                        )
+                    )),
+                    bind("/data/user-input").type("int"),
+                    bind("/data/repeat/count").type("int").calculate("count(../../repeat)"), // both .. and /data/repeat always give a count of 1
+                    bind("/data/repeat/multiplied-count").type("int").calculate("/data/user-input * count(../../repeat)")
+                )
+            ),
+            body(
+                input("/data/user-input"),
+                repeat("/data/repeat",
+                    input("/data/repeat/some-field"))
+            )));
+
+        scenario.createNewRepeat("/data/repeat");
+        scenario.createNewRepeat("/data/repeat");
+        scenario.createNewRepeat("/data/repeat");
+
+        // All of these counts should be 3
+        assertThat(scenario.answerOf("/data/repeat[0]/count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/repeat[1]/count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/repeat[2]/count"), is(intAnswer(3)));
+
+        // The initial value of user-input is 1 so we expect the same values as the raw count
+        assertThat(scenario.answerOf("/data/repeat[0]/multiplied-count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/repeat[1]/multiplied-count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/repeat[2]/multiplied-count"), is(intAnswer(3)));
+
+        scenario.getValidationOutcome();
+
+        // None of these have been recalculated
+        assertThat(scenario.answerOf("/data/repeat[0]/count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/repeat[1]/count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/repeat[2]/count"), is(intAnswer(3)));
+
+        // All of these have been recalculated
+        assertThat(scenario.answerOf("/data/repeat[0]/multiplied-count"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/repeat[1]/multiplied-count"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/repeat[2]/multiplied-count"), is(intAnswer(3)));
+    }
 
     private void assertDagEvents(List<Event> dagEvents, String... lines) {
         assertThat(dagEvents.stream().map(Event::getDisplayMessage).collect(joining("\n")), is(join("\n", lines)));
@@ -1431,63 +1499,5 @@ public class TriggerableDagTest {
         // Then
         LocalTime duration = LocalTime.fromMillisOfDay((System.nanoTime() - start) / 1_000_000);
         logger.info("Deletion of {} repeats took {}", numberOfRepeats, duration.toString());
-    }
-
-    @Test
-    public void deleteLastRepeat_evaluatesTriggerables() throws IOException {
-        Scenario scenario = Scenario.init("Delete last repeat instance", html(
-            head(
-                title("Delete last repeat instance"),
-                model(
-                    mainInstance(t("data id=\"delete-last-repeat-instance\"",
-                        t("repeat-count"),
-
-                        t("repeat",
-                            t("question")),
-                        t("repeat",
-                            t("question")),
-                        t("repeat",
-                            t("question"))
-                    )),
-                    bind("/data/repeat-count").type("int").calculate("count(/data/repeat)")
-                ),
-                body(
-                    repeat("/data/repeat",
-                        input("question"))
-                ))));
-
-        assertThat(scenario.answerOf("/data/repeat-count"), is(intAnswer(3)));
-
-        scenario.removeRepeat("/data/repeat[2]");
-        assertThat(scenario.answerOf("/data/repeat-count"), is(intAnswer(2)));
-    }
-
-    @Test
-    public void deleteLastRepeat_evaluatesTriggerables_indirectlyDependentOnTheDeletedRepeat() throws IOException {
-        Scenario scenario = Scenario.init("Delete last repeat instance", html(
-            head(
-                title("Delete last repeat instance"),
-                model(
-                    mainInstance(t("data id=\"delete-last-repeat-instance\"",
-                        t("summary"),
-
-                        t("repeat",
-                            t("question", "a")),
-                        t("repeat",
-                            t("question", "b")),
-                        t("repeat",
-                            t("question", "c"))
-                    )),
-                    bind("/data/summary").type("string").calculate("concat(/data/repeat/question)")
-                ),
-                body(
-                    repeat("/data/repeat",
-                        input("question"))
-                ))));
-
-        assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("abc")));
-
-        scenario.removeRepeat("/data/repeat[2]");
-        assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("ab")));
     }
 }


### PR DESCRIPTION
Closes #229

I highly recommend looking at this one commit by commit, especially since 
c137d73 reorders all the DAG tests.

#### What has been done to verify that this works as intended?
Worked out what DAG events `deleteThirdRepeatGroup_evaluatesTriggerables_dependentOnTheRepeatGroupsNumber` should emit and changed the test to match. Ran full test suite.

#### Why is this the best possible solution? Were any other approaches considered?
I reduced access to DAG methods since that whole section of the code has been heavily refactored recently. I know ODK clients don't (and shouldn't) access the DAG implementation directly.

This picks up @mdudzinski's proof of concept from #230. It's a relatively simple, isolated change that can make a big difference in the case of many repeat instances or multiple calculations outside the repeat. With 500 repeats, the rough deletion timing test goes from 52ms to 5ms on my machine.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should not result in any behavior change. The only intended change is better performance when a user deletes a repeat instance if the form has calculations that depend on the repeat outside of that repeat.

There will be useless work done for forms that only have calculations that depend on the repeat inside the repeat. But it's all using set operations so I the performance implications should be minimal.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.
