### PR TITLE
Add test for <output> with relative ref

### DIFF
--- a/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -249,4 +249,44 @@ public class FormDefTest {
         caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
         MatcherAssert.assertThat(caption.getQuestionText(), is("Position: 2"));
     }
+
+    @Test
+    public void fillTemplateString_resolvesRelativeReferences_inItext() throws IOException {
+        Scenario scenario = Scenario.init("<output> with relative ref in translation", html(
+            head(
+                title("output with relative ref in translation"),
+                model(
+                    t("itext", t("translation lang=\"Français\"",
+                        t("text id=\"/data/repeat/position_in_label:label",
+                            t("value", "Position: <output value=\"../position\"/>"))
+                    )),
+                    mainInstance(t("data id=\"relative-output\"",
+                        t("repeat jr:template=\"\"",
+                            t("position"),
+                            t("position_in_label")
+                        )
+                    )),
+                    bind("/data/repeat/position").type("int").calculate("position(..)"),
+                    bind("/data/repeat/position_in_label").type("int")
+                )
+            ),
+            body(
+                repeat("/data/repeat",
+                    input("/data/repeat/position_in_label", label("Position: <output value=\" ../position \"/>"))))
+        ));
+
+        scenario.next();
+        scenario.createNewRepeat();
+        scenario.next();
+
+        FormEntryCaption caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
+        MatcherAssert.assertThat(caption.getQuestionText(), is("Position: 1"));
+
+        scenario.next();
+        scenario.createNewRepeat();
+        scenario.next();
+
+        caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
+        MatcherAssert.assertThat(caption.getQuestionText(), is("Position: 2"));
+    }
 }

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -154,6 +154,10 @@ public class Scenario {
         return getIndexOf(expandSingle(getRef(xPath)));
     }
 
+    public FormIndex getCurrentIndex() {
+        return model.getFormIndex();
+    }
+
     public ValidateOutcome getValidationOutcome() {
         return formDef.validate(true);
     }


### PR DESCRIPTION
Looking at https://github.com/XLSForm/pyxform/pull/450/files, I realized we have no dedicated tests for the `<output>` behavior. This adds such a test.

#### What has been done to verify that this works as intended?
Ran test.

#### Why is this the best possible solution? Were any other approaches considered?
No code change. I tried to make the smallest form that tests the behavior.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No code change so no risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.