### PR TITLE
Evaluate triggerables for all repeat instances where needed

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -502,7 +502,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             }
         }
 
-        dagImpl.deleteRepeatGroup(getMainInstance(), getEvaluationContext(), deleteRef, parentElement, deleteElement);
+        dagImpl.deleteRepeatInstance(getMainInstance(), getEvaluationContext(), deleteRef, parentElement, deleteElement);
 
         return newIndex;
     }
@@ -523,7 +523,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         // Trigger actions nested in the new repeat
         getChild(index).getActionController().triggerActionsFromEvent(Action.EVENT_ODK_NEW_REPEAT, this, repeatContextRef, this);
 
-        dagImpl.createRepeatGroup(getMainInstance(), getEvaluationContext(), repeatContextRef, newNode);
+        dagImpl.createRepeatInstance(getMainInstance(), getEvaluationContext(), repeatContextRef, newNode);
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -499,7 +499,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             }
         }
 
-        dagImpl.deleteRepeatInstance(getMainInstance(), getEvaluationContext(), deleteRef, parentElement, deleteElement);
+        dagImpl.deleteRepeatInstance(getMainInstance(), getEvaluationContext(), deleteRef, deleteElement);
 
         return newIndex;
     }

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -393,9 +393,6 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         boolean valueChanged = !objectEquals(answerDataSerializer.serializeAnswerData(oldValue),
             answerDataSerializer.serializeAnswerData(data));
 
-        if (midSurvey && dagImpl.shouldTrustPreviouslyCommittedAnswer() && !valueChanged) {
-            return;
-        }
         setAnswer(data, node);
 
         QuestionDef currentQuestion = findQuestionByRef(ref, this);

--- a/src/main/java/org/javarosa/core/model/QuickTriggerable.java
+++ b/src/main/java/org/javarosa/core/model/QuickTriggerable.java
@@ -37,10 +37,6 @@ public final class QuickTriggerable {
         return triggerable instanceof Recalculate;
     }
 
-    TreeReference contextualizeContextRef(TreeReference anchorRef) {
-        return triggerable.contextualizeContextRef(anchorRef);
-    }
-
     public List<EvaluationResult> apply(FormInstance mainInstance, EvaluationContext ec, TreeReference qualified) {
         return triggerable.apply(mainInstance, ec, qualified);
     }

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -583,7 +583,7 @@ public class TriggerableDag {
      * Returns triggerables with expressions that will need to be updated for every instance of the
      * repeat at the given reference. There are two cases considered:
      * <ul>
-     *   <li>triggerables in the context of the given repeat and are triggered directly by that repeat or are in a cascade
+     *   <li>triggerables in the context of the given repeat that are triggered directly by that repeat or are in a cascade
      *       triggered directly by the repeat. For example, if the repeat reference is /data/repeat, a triggerable representing
      *       a calculate at /data/repeat/calc with an expression such as position(..) would be included.
      *   </li>

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -645,10 +645,6 @@ public class TriggerableDag {
         // step, but i think it's supposed to work
     }
 
-    boolean shouldTrustPreviouslyCommittedAnswer() {
-        return false;
-    }
-
     final void publishSummary(String lead, TreeReference ref, Collection<QuickTriggerable> quickTriggerables) {
         accessor.getEventNotifier().publishEvent(new Event(lead + ": " + (ref != null ? ref.toShortString() + ": " : "") + quickTriggerables.size() + " triggerables were fired."));
     }

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -523,6 +523,8 @@ public class TriggerableDag {
      * Step 3 in DAG cascade. Evaluate the individual triggerable expressions.
      */
     private void evaluateTriggerable(FormInstance mainInstance, EvaluationContext evalContext, QuickTriggerable toTrigger, TreeReference changedRef) {
+        // For addition or removal of repeat instances, contextualizing against the changed ref ensures that triggerables with triggers and targets inside
+        // the repeat are only triggered for the changed instance. This is important for performance.
         TreeReference contextRef = toTrigger.getContext().contextualize(changedRef);
 
         List<EvaluationResult> evaluationResults = new ArrayList<>(0);

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -81,22 +81,6 @@ public class TriggerableDag {
      */
     private Set<QuickTriggerable> triggerablesDAG = emptySet();
 
-    // TODO Make this member fit the expected behavior on calling sites by containing only relevance conditions
-    /**
-     * Stores an index for conditions (triggerables declared in
-     * <code>readonly</code>, <code>required</code>, or <code>relevant</code>
-     * attributes) belonging to repeat groups.
-     * <p>
-     * This index is used to determine whether a repeat group instance is
-     * relevant or not.
-     * <p>
-     * <b>Warning</b>: Calling site assumes that a repeat group would only have
-     * one object stored for its reference in this map. This is because, so
-     * far, <code>relevant</code> is the only attribute that makes sense adding
-     * to a repeat group, but a form could declare other conditions as well,
-     * leading to an unexpected scenario.
-     */
-    private Map<TreeReference, QuickTriggerable> repeatConditionsPerTargets = new HashMap<>();
     /**
      * Stores an index to resolve triggerables by their corresponding trigger's
      * reference.
@@ -165,7 +149,6 @@ public class TriggerableDag {
      */
     void finalizeTriggerables(FormInstance mainInstance, EvaluationContext ec) throws IllegalStateException {
         triggerablesDAG = buildDag(allTriggerables, getDagEdges(mainInstance, ec));
-        repeatConditionsPerTargets = getRepeatConditionsPerTargets(mainInstance, triggerablesDAG);
     }
 
     /**
@@ -660,16 +643,6 @@ public class TriggerableDag {
         publishSummary("Copied itemset answer (phase 2)", targetRef, qtSet2);
         // not 100% sure this will work since destRef is ambiguous as the last
         // step, but i think it's supposed to work
-    }
-
-    private static Map<TreeReference, QuickTriggerable> getRepeatConditionsPerTargets(FormInstance mainInstance, Set<QuickTriggerable> triggerables) {
-        Map<TreeReference, QuickTriggerable> repeatConditionsPerTargets = new HashMap<>();
-        for (QuickTriggerable triggerable : triggerables)
-            if (triggerable.isCondition())
-                for (TreeReference target : triggerable.getTargets())
-                    if (mainInstance.getTemplate(target) != null)
-                        repeatConditionsPerTargets.put(target, triggerable);
-        return repeatConditionsPerTargets;
     }
 
     boolean shouldTrustPreviouslyCommittedAnswer() {

--- a/src/main/java/org/javarosa/core/model/condition/Triggerable.java
+++ b/src/main/java/org/javarosa/core/model/condition/Triggerable.java
@@ -106,12 +106,6 @@ public abstract class Triggerable implements Externalizable {
         return expr.getTriggers(originalContextRef);
     }
 
-    public TreeReference contextualizeContextRef(TreeReference anchorRef) {
-        // Contextualize the reference used by the triggerable against
-        // the anchor
-        return contextRef.contextualize(anchorRef);
-    }
-
     /**
      * Dispatches all of the evaluation
      */

--- a/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -321,10 +321,14 @@ public class TreeReference implements Externalizable, Serializable {
             }
 
             if (contextRef.getName(i).equals(newRef.getName(i))) {
-                if (newRef.getPredicate(i) == null) {
+                if (newRef.getPredicate(i) == null && contextRef.getPredicate(i) != null) {
+                    // Positive integer multiplicity is equivalent to a predicate with a position expression so a
+                    // reference level shouldn't have both. If there's an explicit predicate on either reference, always
+                    // favor that and clear out multiplicity on the contextualized node.
                     newRef.addPredicate(i, contextRef.getPredicate(i));
+                    newRef.setMultiplicity(i, INDEX_UNBOUND);
                 }
-                if (i + refLevel <= newRef.size()) {
+                if (newRef.getPredicate(i) == null && i + refLevel <= newRef.size()) {
                     newRef.setMultiplicity(i, contextRef.getMultiplicity(i));
                 }
             } else {

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -1469,7 +1469,7 @@ public class TriggerableDagTest {
     }
 
     @Test
-    public void relative_paths_in_nested_repeats() throws IOException {
+    public void addingNestedRepeatInstance_updatesExpressionTriggeredByGenericRef_forAllRepeatInstances() throws IOException {
         Scenario scenario = Scenario.init("Some form", html(
             head(
                 title("Some form"),
@@ -1480,7 +1480,6 @@ public class TriggerableDagTest {
                                 t("count"),
                                 t("some-field")
                             ),
-                            t("count"),
                             t("some-field")
                         )
                     )),
@@ -1503,19 +1502,10 @@ public class TriggerableDagTest {
         scenario.createNewRepeat("/data/outer[1]/inner");
         scenario.createNewRepeat("/data/outer[1]/inner");
 
-        // The following assertions have incrementally greater count values because
-        // we currently evaluate triggerables bound to the new repeat group only. This
-        // means that the actual count value only takes into account the existing repeat
-        // groups when creating the new instance.
-        //
-        // To have the expected count of 3 for outer[0] and 2 for outer[1], we would have
-        // to change the sequence of evaluations when a new repeat group is created to
-        // evaluate the triggerables on all siblings (not just on the instance that has
-        // been created). This is currently driven by TriggerableDag.createRepeatInstance()
-        assertThat(scenario.answerOf("/data/outer[0]/inner[0]/count"), is(intAnswer(1)));
-        assertThat(scenario.answerOf("/data/outer[0]/inner[1]/count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/outer[0]/inner[0]/count"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/outer[0]/inner[1]/count"), is(intAnswer(3)));
         assertThat(scenario.answerOf("/data/outer[0]/inner[2]/count"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/outer[1]/inner[0]/count"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[0]/count"), is(intAnswer(2)));
         assertThat(scenario.answerOf("/data/outer[1]/inner[1]/count"), is(intAnswer(2)));
     }
     //endregion

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -757,6 +757,9 @@ public class TriggerableDagTest {
         range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
     }
 
+    // In this case, the count(/data/repeat) expression is represented by a single triggerable. The expression gets
+    // evaluated once and it's the expandReference call in Triggerable.apply which ensures the result is updated for
+    // every repeat instance.
     @Test
     public void addingOrRemovingRepeatInstance_updatesRepeatCount_insideAndOutsideRepeat() throws IOException {
         Scenario scenario = Scenario.init("Count outside repeat used inside", html(
@@ -793,6 +796,8 @@ public class TriggerableDagTest {
         range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
     }
 
+    // In this case, /data/repeat in the count(/data/repeat) expression is given the context of the current repeat so the
+    // count always evaluates to 1. See contrast with addingOrRemovingRepeatInstance_updatesRepeatCount_insideAndOutsideRepeat.
     @Ignore("Highlights issue with de-duplicating refs and different contexts")
     @Test
     public void addingOrRemovingRepeatInstance_updatesRepeatCount_insideRepeat() throws IOException {

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -1508,18 +1508,9 @@ public class TriggerableDagTest {
         assertThat(scenario.answerOf("/data/outer[1]/inner[0]/count"), is(intAnswer(2)));
         assertThat(scenario.answerOf("/data/outer[1]/inner[1]/count"), is(intAnswer(2)));
     }
-    //endregion
 
-    /**
-     * Ignored because the count() function inside the predicate of the result_2
-     * calculate
-     * expression isn't evaled correctly, as opposed to the predicate of the
-     * result_1 calculate
-     * that uses an interim field as a proxy for the same computation
-     */
     @Test
-    @Ignore
-    public void equivalent_predicates_with_function_calls_should_produce_the_same_results() throws IOException {
+    public void addingRepeatInstance_updatesReferenceToLastInstance_usingPositionPredicate() throws IOException {
         Scenario scenario = Scenario.init("Some form", html(
             head(
                 title("Some form"),
@@ -1554,10 +1545,10 @@ public class TriggerableDagTest {
 
         assertThat(scenario.answerOf("/data/count"), is(intAnswer(2)));
         assertThat(scenario.answerOf("/data/result_1"), is(intAnswer(30)));
-        // The following assertion is the one that fails with the current implementation
-        // TODO Explore the difference between the calculations in result_1 and result_2 and unify them
-        assertThat(scenario.answerOf("/data/result_2"), is(intAnswer(30)));
+        // The following assertion fails because /data/group gets contextualized such that the count is always 1.
+        // assertThat(scenario.answerOf("/data/result_2"), is(intAnswer(30)));
     }
+    //endregion
 
     /**
      * This test documents some bugs:

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -75,186 +75,6 @@ public class TriggerableDagTest {
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
 
-    // Illustrates the second case in TriggerableDAG.getTriggerablesAffectingAllInstances
-    @Test
-    public void addingOrRemovingRepeatInstance_withCalculatedCountOutsideRepeat_updatesReferenceToCountInside() throws IOException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
-            head(
-                title("Count outside repeat used inside"),
-                model(
-                    mainInstance(t("data id=\"outside-used-inside\"",
-                        t("count"),
-
-                        t("repeat jr:template=\"\"",
-                            t("question"),
-                            t("inner-count"))
-                    )),
-                    bind("/data/count").type("int").calculate("count(/data/repeat)"),
-                    bind("/data/repeat/inner-count").type("int").calculate("/data/count")),
-
-                body(
-                    repeat("/data/repeat",
-                        input("/data/repeat/question")
-                    )
-                )))).onDagEvent(dagEvents::add);
-
-        dagEvents.clear();
-
-        range(0, 5).forEach(n -> {
-            scenario.next();
-            scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/count"), CoreMatchers.is(intAnswer(n + 1)));
-            scenario.next();
-        });
-
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
-
-        scenario.removeRepeat("/data/repeat[3]");
-
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
-    }
-
-    @Test
-    public void addingOrRemovingRepeatInstance_updatesRepeatCount_insideAndOutsideRepeat() throws IOException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
-            head(
-                title("Count outside repeat used inside"),
-                model(
-                    mainInstance(t("data id=\"outside-used-inside\"",
-                        t("count"),
-
-                        t("repeat jr:template=\"\"",
-                            t("question"),
-                            t("inner-count"))
-                    )),
-                    bind("/data/count").type("int").calculate("count(/data/repeat)"),
-                    bind("/data/repeat/inner-count").type("int").calculate("count(/data/repeat)")),
-
-                body(
-                    repeat("/data/repeat",
-                        input("/data/repeat/question")
-                    )
-                ))));
-
-        range(0, 5).forEach(n -> {
-            scenario.next();
-            scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n + 1)));
-            scenario.next();
-        });
-
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
-
-        scenario.removeRepeat("/data/repeat[3]");
-
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
-    }
-
-    @Ignore("Highlights issue with de-duplicating refs and different contexts")
-    @Test
-    public void addingOrRemovingRepeatInstance_updatesRepeatCount_insideRepeat() throws IOException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
-            head(
-                title("Count outside repeat used inside"),
-                model(
-                    mainInstance(t("data id=\"outside-used-inside\"",
-                        t("repeat jr:template=\"\"",
-                            t("question"),
-                            t("inner-count"))
-                    )),
-                    bind("/data/repeat/inner-count").type("int").calculate("count(/data/repeat)")),
-
-                body(
-                    repeat("/data/repeat",
-                        input("/data/repeat/question")
-                    )
-                ))));
-
-        range(0, 5).forEach(n -> {
-            scenario.next();
-            scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n + 1)));
-            scenario.next();
-        });
-
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
-
-        scenario.removeRepeat("/data/repeat[3]");
-
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
-    }
-
-    @Test
-    public void addingOrRemovingRepeatInstance_updatesRelativeRepeatCount_insideRepeat() throws IOException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
-            head(
-                title("Count outside repeat used inside"),
-                model(
-                    mainInstance(t("data id=\"outside-used-inside\"",
-                        t("repeat jr:template=\"\"",
-                            t("question"),
-                            t("inner-count"))
-                    )),
-                    bind("/data/repeat/inner-count").type("int").calculate("count(../../repeat)")),
-
-                body(
-                    repeat("/data/repeat",
-                        input("/data/repeat/question")
-                    )
-                ))));
-
-        range(0, 5).forEach(n -> {
-            scenario.next();
-            scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n + 1)));
-            scenario.next();
-        });
-
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
-
-        scenario.removeRepeat("/data/repeat[3]");
-
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
-    }
-
-    @Test
-    public void addingOrRemovingRepeatInstance_withReferenceToRepeatInRepeat_andOuterSum_updates() throws IOException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
-            head(
-                title("Count outside repeat used inside"),
-                model(
-                    mainInstance(t("data id=\"outside-used-inside\"",
-                        t("sum"),
-
-                        t("repeat jr:template=\"\"",
-                            t("question"),
-                            t("position1"),
-                            t("position2"))
-                    )),
-                    bind("/data/sum").type("int").calculate("sum(/data/repeat/position1)"),
-                    bind("/data/repeat/position1").type("int").calculate("position(..)"),
-                    bind("/data/repeat/position2").type("int").calculate("/data/repeat/position1")),
-
-                body(
-                    repeat("/data/repeat",
-                        input("/data/repeat/position1")
-                    )
-                ))));
-
-        range(0, 5).forEach(n -> {
-            scenario.next();
-            scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/sum"), CoreMatchers.is(intAnswer((n + 1) * (n + 2) / 2)));
-            scenario.next();
-        });
-
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/position1"), CoreMatchers.is(intAnswer(n + 1))));
-
-        scenario.removeRepeat("/data/repeat[3]");
-
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/position2"), CoreMatchers.is(intAnswer(n + 1))));
-    }
-
     @Test
     public void order_of_the_DAG_is_ensured() throws IOException {
         Scenario scenario = Scenario.init("Some form", html(
@@ -894,6 +714,188 @@ public class TriggerableDagTest {
         ValidateOutcome validate = scenario.getValidationOutcome();
         assertThat(validate.failedPrompt, is(scenario.indexOf("/data/a")));
         assertThat(validate.outcome, is(ANSWER_CONSTRAINT_VIOLATED));
+    }
+    //endregion
+
+    //region Adding or deleting repeats
+    // Illustrates the second case in TriggerableDAG.getTriggerablesAffectingAllInstances
+    @Test
+    public void addingOrRemovingRepeatInstance_withCalculatedCountOutsideRepeat_updatesReferenceToCountInside() throws IOException {
+        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+            head(
+                title("Count outside repeat used inside"),
+                model(
+                    mainInstance(t("data id=\"outside-used-inside\"",
+                        t("count"),
+
+                        t("repeat jr:template=\"\"",
+                            t("question"),
+                            t("inner-count"))
+                    )),
+                    bind("/data/count").type("int").calculate("count(/data/repeat)"),
+                    bind("/data/repeat/inner-count").type("int").calculate("/data/count")),
+
+                body(
+                    repeat("/data/repeat",
+                        input("/data/repeat/question")
+                    )
+                )))).onDagEvent(dagEvents::add);
+
+        dagEvents.clear();
+
+        range(0, 5).forEach(n -> {
+            scenario.next();
+            scenario.createNewRepeat();
+            assertThat(scenario.answerOf("/data/count"), CoreMatchers.is(intAnswer(n + 1)));
+            scenario.next();
+        });
+
+        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
+
+        scenario.removeRepeat("/data/repeat[3]");
+
+        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
+    }
+
+    @Test
+    public void addingOrRemovingRepeatInstance_updatesRepeatCount_insideAndOutsideRepeat() throws IOException {
+        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+            head(
+                title("Count outside repeat used inside"),
+                model(
+                    mainInstance(t("data id=\"outside-used-inside\"",
+                        t("count"),
+
+                        t("repeat jr:template=\"\"",
+                            t("question"),
+                            t("inner-count"))
+                    )),
+                    bind("/data/count").type("int").calculate("count(/data/repeat)"),
+                    bind("/data/repeat/inner-count").type("int").calculate("count(/data/repeat)")),
+
+                body(
+                    repeat("/data/repeat",
+                        input("/data/repeat/question")
+                    )
+                ))));
+
+        range(0, 5).forEach(n -> {
+            scenario.next();
+            scenario.createNewRepeat();
+            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n + 1)));
+            scenario.next();
+        });
+
+        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
+
+        scenario.removeRepeat("/data/repeat[3]");
+
+        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
+    }
+
+    @Ignore("Highlights issue with de-duplicating refs and different contexts")
+    @Test
+    public void addingOrRemovingRepeatInstance_updatesRepeatCount_insideRepeat() throws IOException {
+        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+            head(
+                title("Count outside repeat used inside"),
+                model(
+                    mainInstance(t("data id=\"outside-used-inside\"",
+                        t("repeat jr:template=\"\"",
+                            t("question"),
+                            t("inner-count"))
+                    )),
+                    bind("/data/repeat/inner-count").type("int").calculate("count(/data/repeat)")),
+
+                body(
+                    repeat("/data/repeat",
+                        input("/data/repeat/question")
+                    )
+                ))));
+
+        range(0, 5).forEach(n -> {
+            scenario.next();
+            scenario.createNewRepeat();
+            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n + 1)));
+            scenario.next();
+        });
+
+        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
+
+        scenario.removeRepeat("/data/repeat[3]");
+
+        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
+    }
+
+    @Test
+    public void addingOrRemovingRepeatInstance_updatesRelativeRepeatCount_insideRepeat() throws IOException {
+        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+            head(
+                title("Count outside repeat used inside"),
+                model(
+                    mainInstance(t("data id=\"outside-used-inside\"",
+                        t("repeat jr:template=\"\"",
+                            t("question"),
+                            t("inner-count"))
+                    )),
+                    bind("/data/repeat/inner-count").type("int").calculate("count(../../repeat)")),
+
+                body(
+                    repeat("/data/repeat",
+                        input("/data/repeat/question")
+                    )
+                ))));
+
+        range(0, 5).forEach(n -> {
+            scenario.next();
+            scenario.createNewRepeat();
+            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n + 1)));
+            scenario.next();
+        });
+
+        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
+
+        scenario.removeRepeat("/data/repeat[3]");
+
+        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
+    }
+
+    @Test
+    public void addingOrRemovingRepeatInstance_withReferenceToRepeatInRepeat_andOuterSum_updates() throws IOException {
+        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+            head(
+                title("Count outside repeat used inside"),
+                model(
+                    mainInstance(t("data id=\"outside-used-inside\"",
+                        t("sum"),
+
+                        t("repeat jr:template=\"\"",
+                            t("question"),
+                            t("position1"),
+                            t("position2"))
+                    )),
+                    bind("/data/sum").type("int").calculate("sum(/data/repeat/position1)"),
+                    bind("/data/repeat/position1").type("int").calculate("position(..)"),
+                    bind("/data/repeat/position2").type("int").calculate("/data/repeat/position1")),
+
+                body(
+                    repeat("/data/repeat",
+                        input("/data/repeat/position1")
+                    )
+                ))));
+
+        range(0, 5).forEach(n -> {
+            scenario.next();
+            scenario.createNewRepeat();
+            assertThat(scenario.answerOf("/data/sum"), CoreMatchers.is(intAnswer((n + 1) * (n + 2) / 2)));
+            scenario.next();
+        });
+
+        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/position1"), CoreMatchers.is(intAnswer(n + 1))));
+
+        scenario.removeRepeat("/data/repeat[3]");
+
+        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/position2"), CoreMatchers.is(intAnswer(n + 1))));
     }
     //endregion
 

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -1567,7 +1567,8 @@ public class TriggerableDagTest {
 
         assertThat(scenario.answerOf("/data/count"), is(intAnswer(2)));
         assertThat(scenario.answerOf("/data/result_1"), is(intAnswer(30)));
-        // The following assertion fails because /data/group gets contextualized such that the count is always 1.
+        // The following assertion fails because /data/group gets contextualized such that the count is always 1. There's
+        // probably a use of originalContext missing somewhere.
         // assertThat(scenario.answerOf("/data/result_2"), is(intAnswer(30)));
     }
 

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -935,13 +935,8 @@ public class TriggerableDagTest {
         assertThat(scenario.answerOf("/data/house[3]/number"), is(intAnswer(4)));
         assertThat(scenario.answerOf("/data/house[4]/number"), is(nullValue()));
         assertDagEvents(dagEvents,
-            "Processing 'Recalculate' for number [2_1] (2.0)",
-            "Processing 'Deleted: house [2]: 1 triggerables were fired.' for ",
-            "Processing 'Deleted: number [2_1]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [3_1] (3.0)",
-            "Processing 'Deleted: house [3]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [4_1] (4.0)",
-            "Processing 'Deleted: house [4]: 1 triggerables were fired.' for "
+            "Processing 'Recalculate' for number [1_1] (1.0), number [2_1] (2.0), number [3_1] (3.0), number [4_1] (4.0)",
+            "Processing 'Deleted: number [2_1]: 1 triggerables were fired.' for "
         );
     }
 
@@ -988,18 +983,11 @@ public class TriggerableDagTest {
         assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("E4")));
         assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(nullValue()));
         assertDagEvents(dagEvents,
-            "Processing 'Recalculate' for number [2_1] (2.0)",
-            "Processing 'Recalculate' for name_and_number [2_1] (C2)",
-            "Processing 'Deleted: house [2]: 2 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [1_1] (1.0), number [2_1] (2.0), number [3_1] (3.0), number [4_1] (4.0)",
+            "Processing 'Recalculate' for name_and_number [1_1] (A1), name_and_number [2_1] (C2), name_and_number [3_1] (D3), name_and_number [4_1] (E4)",
             "Processing 'Deleted: number [2_1]: 0 triggerables were fired.' for ",
             "Processing 'Deleted: name [2_1]: 0 triggerables were fired.' for ",
-            "Processing 'Deleted: name_and_number [2_1]: 2 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [3_1] (3.0)",
-            "Processing 'Recalculate' for name_and_number [3_1] (D3)",
-            "Processing 'Deleted: house [3]: 2 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [4_1] (4.0)",
-            "Processing 'Recalculate' for name_and_number [4_1] (E4)",
-            "Processing 'Deleted: house [4]: 2 triggerables were fired.' for "
+            "Processing 'Deleted: name_and_number [2_1]: 2 triggerables were fired.' for "
         );
     }
 
@@ -1046,16 +1034,11 @@ public class TriggerableDagTest {
         assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("EX")));
         assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(nullValue()));
         assertDagEvents(dagEvents,
-            "Processing 'Recalculate' for number [2_1] (2.0)",
-            "Processing 'Deleted: house [2]: 1 triggerables were fired.' for ",
+            "Processing 'Recalculate' for number [1_1] (1.0), number [2_1] (2.0), number [3_1] (3.0), number [4_1] (4.0)",
             "Processing 'Deleted: number [2_1]: 1 triggerables were fired.' for ",
             "Processing 'Recalculate' for name_and_number [2_1] (CX)",
             "Processing 'Deleted: name [2_1]: 1 triggerables were fired.' for ",
-            "Processing 'Deleted: name_and_number [2_1]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [3_1] (3.0)",
-            "Processing 'Deleted: house [3]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [4_1] (4.0)",
-            "Processing 'Deleted: house [4]: 1 triggerables were fired.' for "
+            "Processing 'Deleted: name_and_number [2_1]: 1 triggerables were fired.' for "
         );
     }
 
@@ -1118,23 +1101,9 @@ public class TriggerableDagTest {
 
         assertThat(scenario.answerOf("/data/summary"), is(intAnswer(45)));
         assertDagEvents(dagEvents,
-            "Processing 'Recalculate' for number [3_1] (3.0)",
-            "Processing 'Deleted: house [3]: 1 triggerables were fired.' for ",
-            "Processing 'Deleted: number [3_1]: 0 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [4_1] (4.0)",
-            "Processing 'Deleted: house [4]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [5_1] (5.0)",
-            "Processing 'Deleted: house [5]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [6_1] (6.0)",
-            "Processing 'Deleted: house [6]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [7_1] (7.0)",
-            "Processing 'Deleted: house [7]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [8_1] (8.0)",
-            "Processing 'Deleted: house [8]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [9_1] (9.0)",
-            "Processing 'Deleted: house [9]: 1 triggerables were fired.' for ",
-            "Processing 'Recalculate' for number [3_1] (3.0)",
-            "Processing 'Recalculate' for summary [1] (45.0)" // this calculation is outside the repeat and is only computed once
+            "Processing 'Recalculate' for number [1_1] (1.0), number [2_1] (2.0), number [3_1] (3.0), number [4_1] (4.0), number [5_1] (5.0), number [6_1] (6.0), number [7_1] (7.0), number [8_1] (8.0), number [9_1] (9.0)",
+            "Processing 'Recalculate' for summary [1] (45.0)",
+            "Processing 'Deleted: number [3_1]: 0 triggerables were fired.' for "
         );
     }
 
@@ -1178,10 +1147,8 @@ public class TriggerableDagTest {
 
         assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("ABDE")));
         assertDagEvents(dagEvents,
-            "Processing 'Deleted: house [3]: 0 triggerables were fired.' for ",
             "Processing 'Recalculate' for summary [1] (ABDE)",
-            "Processing 'Deleted: name [3_1]: 1 triggerables were fired.' for ",
-            "Processing 'Deleted: house [4]: 0 triggerables were fired.' for "
+                "Processing 'Deleted: name [3_1]: 1 triggerables were fired.' for "
         );
     }
 

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -75,8 +75,9 @@ public class TriggerableDagTest {
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
 
+    // Illustrates the second case in TriggerableDAG.getTriggerablesAffectingAllInstances
     @Test
-    public void referenceToCalculatedRepeatCount_insideRepeat_updatesWhenCountChanges() throws IOException {
+    public void addingOrRemovingRepeatInstance_withCalculatedCountOutsideRepeat_updatesReferenceToCountInside() throws IOException {
         Scenario scenario = Scenario.init("Count outside repeat used inside", html(
             head(
                 title("Count outside repeat used inside"),
@@ -114,7 +115,7 @@ public class TriggerableDagTest {
     }
 
     @Test
-    public void repeatCount_insideAndOutsideRepeat_updatesWhenCountChanges() throws IOException {
+    public void addingOrRemovingRepeatInstance_updatesRepeatCount_insideAndOutsideRepeat() throws IOException {
         Scenario scenario = Scenario.init("Count outside repeat used inside", html(
             head(
                 title("Count outside repeat used inside"),
@@ -151,7 +152,7 @@ public class TriggerableDagTest {
 
     @Ignore("Highlights issue with de-duplicating refs and different contexts")
     @Test
-    public void repeatCount_insideRepeat_updatesWhenCountChanges() throws IOException {
+    public void addingOrRemovingRepeatInstance_updatesRepeatCount_insideRepeat() throws IOException {
         Scenario scenario = Scenario.init("Count outside repeat used inside", html(
             head(
                 title("Count outside repeat used inside"),
@@ -184,7 +185,7 @@ public class TriggerableDagTest {
     }
 
     @Test
-    public void repeatCount_insideRepeatWithRelativeRef_updatesWhenCountChanges() throws IOException {
+    public void addingOrRemovingRepeatInstance_updatesRelativeRepeatCount_insideRepeat() throws IOException {
         Scenario scenario = Scenario.init("Count outside repeat used inside", html(
             head(
                 title("Count outside repeat used inside"),
@@ -217,7 +218,7 @@ public class TriggerableDagTest {
     }
 
     @Test
-    public void cascadeStartingInRepeat_withOuterComponent() throws IOException {
+    public void addingOrRemovingRepeatInstance_withReferenceToRepeatInRepeat_andOuterSum_updates() throws IOException {
         Scenario scenario = Scenario.init("Count outside repeat used inside", html(
             head(
                 title("Count outside repeat used inside"),
@@ -238,9 +239,7 @@ public class TriggerableDagTest {
                     repeat("/data/repeat",
                         input("/data/repeat/position1")
                     )
-                )))).onDagEvent(dagEvents::add);
-
-        dagEvents.clear();
+                ))));
 
         range(0, 5).forEach(n -> {
             scenario.next();

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -1246,7 +1246,7 @@ public class TriggerableDagTest {
 
     //region Adding repeats
     /**
-     * Excercises the triggerTriggerables call in createRepeatGroup.
+     * Excercises the triggerTriggerables call in createRepeatInstance.
      */
     @Test
     public void adding_repeat_instance_triggers_triggerables_outside_repeat_that_reference_repeat_nodeset() throws IOException {
@@ -1278,7 +1278,7 @@ public class TriggerableDagTest {
     }
 
     /**
-     * Excercises the initializeTriggerables call in createRepeatGroup.
+     * Excercises the initializeTriggerables call in createRepeatInstance.
      */
     @Test
     public void adding_repeat_instance_triggers_descendant_node_triggerables() throws IOException {
@@ -1511,7 +1511,7 @@ public class TriggerableDagTest {
         // To have the expected count of 3 for outer[0] and 2 for outer[1], we would have
         // to change the sequence of evaluations when a new repeat group is created to
         // evaluate the triggerables on all siblings (not just on the instance that has
-        // been created). This is currently driven by TriggerableDag.createRepeatGroup()
+        // been created). This is currently driven by TriggerableDag.createRepeatInstance()
         assertThat(scenario.answerOf("/data/outer[0]/inner[0]/count"), is(intAnswer(1)));
         assertThat(scenario.answerOf("/data/outer[0]/inner[1]/count"), is(intAnswer(2)));
         assertThat(scenario.answerOf("/data/outer[0]/inner[2]/count"), is(intAnswer(3)));

--- a/src/test/java/org/javarosa/core/model/instance/TreeReferenceContextualizeTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeReferenceContextualizeTest.java
@@ -67,7 +67,7 @@ public class TreeReferenceContextualizeTest {
             {"Predicates #2", getRef("bar[@foo = 'baz']"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'bar']/bar[@foo = 'baz']")},
             {"Predicates #3", getRef("bar[@foo = 'baz']"), getRef("/foo"), getRef("/foo/bar[@foo = 'baz']")},
             {"Predicates #4", getRef("/foo[@foo = 'foo']"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'foo']")},
-            
+
             {"Parent refs in nested repeats", getRef("../../inner"), getRef("/data/outer[0]/inner[1]/count[0]"), getRef("/data/outer[0]/inner")}
         });
     }

--- a/src/test/java/org/javarosa/core/model/instance/TreeReferenceContextualizeTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeReferenceContextualizeTest.java
@@ -44,23 +44,30 @@ public class TreeReferenceContextualizeTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            // Self references
             {"Relative context ref", getRef("bar"), getRef("foo"), null},
             {"Non-matching absolute refs", getRef("/foo"), getRef("/bar"), getRef("/foo")},
+
             {"Contextualizing a ref with itself and multiplicity #1", getRef("/foo"), getRef("/foo[2]"), getRef("/foo[2]")},
             {"Contextualizing a ref with itself and multiplicity #2", getRef("/foo[-1]"), getRef("/foo[2]"), getRef("/foo[2]")},
             {"Contextualizing a ref with itself and multiplicity #3", getRef("/foo[0]"), getRef("/foo[2]"), getRef("/foo[2]")},
             {"Contextualizing a ref with itself and multiplicity #4", getRef("/foo[3]"), getRef("/foo[2]"), getRef("/foo[2]")},
+
             {"Contextualizing a ref with itself and predicate #1", getRef("/foo"), getRef("/foo[position() = 3]"), getRef("/foo[position() = 3]")},
             {"Contextualizing a ref with itself and predicate #2", getRef("/foo[position() = 2]"), getRef("/foo[position() = 3]"), getRef("/foo[position() = 2]")},
+
+            {"Contextualizing a ref with predicate with itself and multiplicity", getRef("/foo[position() = 2]"), getRef("/foo[1]"), getRef("/foo[position() = 2]")},
+            {"Contextualizing a ref with multiplicity with itself and predicate", getRef("/foo[1]"), getRef("/foo[position() = 2]"), getRef("/foo[position() = 2]")},
+
             {"Wildcards #1", getRef("bar"), getRef("/foo/*"), getRef("/foo/*/bar")},
             {"Wildcards #2", getRef("../baz"), getRef("/foo/*/bar"), getRef("/foo/*/baz")},
             {"Wildcards #3", getRef("*/baz"), getRef("/foo/*/bar"), getRef("/foo/*/bar/*/baz")},
             {"Wildcards #4", getRef("*/bar"), getRef("/foo"), getRef("/foo/*/bar")},
+
             {"Predicates #1", getRef("bar"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'bar']/bar")},
             {"Predicates #2", getRef("bar[@foo = 'baz']"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'bar']/bar[@foo = 'baz']")},
             {"Predicates #3", getRef("bar[@foo = 'baz']"), getRef("/foo"), getRef("/foo/bar[@foo = 'baz']")},
             {"Predicates #4", getRef("/foo[@foo = 'foo']"), getRef("/foo[@foo = 'bar']"), getRef("/foo[@foo = 'foo']")},
+            
             {"Parent refs in nested repeats", getRef("../../inner"), getRef("/data/outer[0]/inner[1]/count[0]"), getRef("/data/outer[0]/inner")}
         });
     }


### PR DESCRIPTION
Closes #584 

* d7593de removed a map that was used to keep track of expanded repeat references for triggerables that need to be evaluated across repeat instances. This PR introduces an alternate approach.
* There used to be a special case for repeat instance deletion where all triggerables for instances following the removed instance were evaluated. This bypassed the DAG and resulted in a lot of unnecessary computations. This PR removes the custom code and lets repeat deletion use the DAG to identify which expressions need to be recomputed.
* 26cdfa2 led to a regression in evaluation of expressions in repeats with references across repeat instances. Prior to that commit, multiplicity was only added during contextualization if the target reference level didn't already have a predicate. This PR re-establishes that condition and adds tests to support it.

Remaining questions:
- Does `initializeTriggerables` need to consider triggerables that affect all instances? `addingRepeatInstance_withInnerCalculateDependentOnOuterSum_updatesInnerSumForAllInstances()` gets at something related.

#### What has been done to verify that this works as intended?
Ensured that all tests that passed on v2.17.0 still pass. I analyzed the different types of triggerable cascades and wrote tests for them.

#### Why is this the best possible solution? Were any other approaches considered?
The alternative we have considered is bringing back the previous map (https://github.com/getodk/javarosa/compare/master...ggalmazor:firedAnchors_exploration). Neither @ggalmazor nor I can explain with confidence what cases that approach covered or why it was a good design. We know it didn't cover cases that we have tests for. Because the map both gets updated as triggerables are triggered and also feeds into which triggerables are triggered, it's hard to reason about. Additionally, it ends up bypassing the `expandReference` call in `evaluateTriggerable` in certain cases where every repeat instance must be updated which is also very confusing.

This PR proposes a different approach where the triggerables that need to be updated across repeat instances are identified on creation or removal of repeat. This makes it very clear that reference expansion is only relevant to repeats. It also makes it possible to have a single method (`getTriggerablesAffectingAllInstances`) that does all that work. We can then rely on a check on the set it produces when evaluating individual triggerables.

I considered using the existing iteration over all the cascades triggered by the changed repeat in `getAllToTrigger` to identify triggerables that affect all repeat instance but I found that I couldn't efficiently look up whether the changedRef is a repeat instance so I would have had to pass that in. I am confident that the DAG traversal is not a major bottleneck so I went with the clearer approach.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only intentional changes are bug fixes. There are three big types of risk: someone was relying on one of those bugs, there's a regression in behavior we don't have test coverage for, performance has degraded.

The big change in behavior compared to v2.17.0 is that adding a repeat instance will trigger recomputation of any calculation inside that repeat which refers to the generic repeat such as `count(../../repeat)` or `position(..)`. I don't think anyone could have been relying on that bad behavior. I think there is a performance implication for `position(..)` but I haven't had a chance to investigate yet.

For performance, here is the `ChildVaccination` benchmark:
**this code**
Benchmark                               Mode  Cnt  Score   Error  Units
ChildVaccinationBenchmark.run_1_times  thrpt   25  1.405 ± 0.107  ops/s
ChildVaccinationBenchmark.run_2_times  thrpt   25  0.685 ± 0.036  ops/s
ChildVaccinationBenchmark.run_3_times  thrpt   25  0.472 ± 0.027  ops/s

**v2.17.0 (last released)**
ChildVaccinationBenchmark.run_1_times  thrpt   25  1.121 ± 0.015  ops/s
ChildVaccinationBenchmark.run_2_times  thrpt   25  0.564 ± 0.012  ops/s
ChildVaccinationBenchmark.run_3_times  thrpt   25  0.372 ± 0.006  ops/s

**master**
Benchmark                               Mode  Cnt  Score   Error  Units
ChildVaccinationBenchmark.run_1_times  thrpt   25  1.432 ± 0.179  ops/s
ChildVaccinationBenchmark.run_2_times  thrpt   25  0.709 ± 0.101  ops/s
ChildVaccinationBenchmark.run_3_times  thrpt   25  0.540 ± 0.104  ops/s

**Guillermo firedAnchors revert**
Benchmark                               Mode  Cnt  Score   Error  Units                                                                                         
ChildVaccinationBenchmark.run_1_times  thrpt   25  1.217 ± 0.060  ops/s                                                                                         
ChildVaccinationBenchmark.run_2_times  thrpt   25  0.625 ± 0.015  ops/s                                                                                         
ChildVaccinationBenchmark.run_3_times  thrpt   25  0.413 ± 0.006  ops/s

This unambiguously is faster than v2.17.0 for the cases in ChildVaccination. It compares favorably to bringing back `firedAnchors`.

One case I know will be slower is when there's a `position(..)` expression and a new repeat instance is added. Previously this would only be evaluated for the newly-created repeat. Now it will be evaluated for every repeat instance. This has a non-negligible impact when we get to hundreds of repeats and it would be more significant if there's a long cascade based on position. The tradeoff is that we don't need a special approach for deletes (where position does change for nodes after the deleted one) and that count/sum from inside the repeat updates correctly (modulo issues contextualizing absolute refs illustrated by tests). I think that tradeoff is worth it because I haven't seen many forms with hundreds of repeat instances or many forms that use position. Naturally, there are some that do both and that's one thing to get user feedback on. If it is a big problem, we can remove the first case in `getTriggerablesAffectingAllInstances` and match the `v2.17.0` behavior.

I think that the worst case would be that `firedAnchors` covers some case we haven't identified. Even then I'd say the possible user impact isn't huge because there are more forms without repeats than with repeats. We now have fairly significant test coverage so it seems unlikely that we've missed a common case.

#### Do we need any specific form for testing your changes? If so, please attach one.
No. Tests capture the interesting cases that I can think of. Ideally a reviewer would do another pass thinking of cases I might have missed.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Yes, I will follow up with updated DAG documentation.