### PR TITLE
Update version for v3 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ jar {
     // Be sure to update version in pom.xml to match
     // snapshot release = x.x.x-SNAPSHOT
     // production release = x.x.x
-    version = '2.18.0-SNAPSHOT'
+    version = '3.0.0'
     archiveName = baseName + '-' + version + '.jar'
 
     manifest {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <!-- Be sure to update version in build.gradle to match -->
   <!-- snapshot release = x.x.x-SNAPSHOT -->
   <!-- production release = x.x.x -->
-  <version>2.18.0-SNAPSHOT</version>
+  <version>3.0.0</version>
   <packaging>jar</packaging>
   <name>javarosa</name>
   <description>A Java library for rendering forms that are compliant with ODK XForms spec</description>


### PR DESCRIPTION
As discussed in Slack, we're going to release `master` as v3 because there are some breaking API changes and the DAG changes are internally significant and have some performance implications (though there shouldn't be behavior changes).