### PR TITLE
Group repeat relevance

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -531,16 +531,25 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     }
 
     public boolean isRepeatRelevant(TreeReference repeatRef) {
-        TreeElement repeatNode = mainInstance.resolveReference(repeatRef);
+        boolean relev = true;
 
-        if (repeatNode != null) {
-            return repeatNode.isRelevant();
-        } else {
-            // We are dealing with a repeat that doesn't exist yet so get
-            // relevance from the template
-            TreeElement template = mainInstance.getTemplate(repeatRef);
-            return template.isRelevant();
+        QuickTriggerable qc = dagImpl.getRelevanceForRepeat(repeatRef.genericize());
+        if (qc != null) {
+            relev = (boolean) qc.eval(mainInstance, new EvaluationContext(exprEvalContext, repeatRef));
         }
+
+        if (relev) {
+            // Must check the template in case of static relevance expressions that wouldn't be in the DAG (e.g. false()).
+            TreeElement templNode = mainInstance.getTemplate(repeatRef);
+            // Check the relevancy of the immediate parent. Unclear whether this is needed because in a normal form-filling
+            // flow the child would not be accessible if its parent is irrelevant.
+            TreeReference parentPath = templNode.getParent().getRef().genericize();
+            TreeElement parentNode = mainInstance
+                .resolveReference(parentPath.contextualize(repeatRef));
+            relev = parentNode.isRelevant() && templNode.isRelevant();
+        }
+
+        return relev;
     }
 
     public boolean canCreateRepeat(TreeReference repeatRef, FormIndex repeatIndex) {

--- a/src/main/java/org/javarosa/core/model/condition/Triggerable.java
+++ b/src/main/java/org/javarosa/core/model/condition/Triggerable.java
@@ -65,9 +65,10 @@ public abstract class Triggerable implements Externalizable {
      */
     private TreeReference contextRef;  //generic ref used to turn triggers into absolute references
 
-    // TODO Study why we really need this property. Looking at mutators, it should always equal the contextRef.
     /**
-     * The first context provided to this triggerable before reducing to the common root.
+     * The first context provided to this triggerable before reducing to the common root (see Triggerable.intersectContextWith).
+     * This is just the first bind encountered with the expression represented by this Triggerable so it's not clear how
+     * it's useful (and bind order for the same form definition affects its value).
      */
     private TreeReference originalContextRef;
 

--- a/src/test/java/org/javarosa/core/model/RepeatTest.java
+++ b/src/test/java/org/javarosa/core/model/RepeatTest.java
@@ -1,9 +1,5 @@
 package org.javarosa.core.model;
 
-import org.javarosa.core.test.Scenario;
-import org.javarosa.form.api.FormEntryController;
-import org.junit.Test;
-
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
 import static org.javarosa.core.util.XFormsElement.body;
@@ -18,6 +14,10 @@ import static org.javarosa.core.util.XFormsElement.select1;
 import static org.javarosa.core.util.XFormsElement.t;
 import static org.javarosa.core.util.XFormsElement.title;
 import static org.junit.Assert.assertThat;
+
+import org.javarosa.core.test.Scenario;
+import org.javarosa.form.api.FormEntryController;
+import org.junit.Test;
 
 public class RepeatTest {
 
@@ -71,6 +71,37 @@ public class RepeatTest {
         scenario.answer("/data/selectYesNo", "no");
 
         int event = scenario.next();
+        assertThat(event, is(FormEntryController.EVENT_END_OF_FORM));
+    }
+
+    @Test
+    public void whenRepeatAndTopLevelNodeHaveSameRelevanceExpression_andExpressionEvaluatesToFalse_repeatPromptIsSkipped() throws Exception {
+        Scenario scenario = Scenario.init("Repeat relevance same as other", html(
+            head(
+                title("Repeat relevance same as other"),
+                model(
+                    mainInstance(t("data id=\"repeat_relevance_same_as_other\"",
+                        t("selectYesNo", "no"),
+                        t("repeat1",
+                            t("q1")),
+                        t("q0")
+                    )),
+                    bind("/data/q0").relevant("/data/selectYesNo = 'yes'"),
+                    bind("/data/repeat1").relevant("/data/selectYesNo = 'yes'")
+                ),
+                body(
+                    select1("/data/selectYesNo",
+                        item("yes", "Yes"),
+                        item("no", "No")),
+                    repeat("/data/repeat1",
+                        input("/data/repeat1/q1")
+                    )
+                ))));
+
+        scenario.jumpToBeginningOfForm();
+        scenario.next();
+        int event = scenario.next();
+
         assertThat(event, is(FormEntryController.EVENT_END_OF_FORM));
     }
 }


### PR DESCRIPTION
Closes #603

It is certainly possible to figure out the right contexts to fix #603 without separately caching repeat relevance but I don't think it's worth it. We now understand the purpose of that cache and have tests for the behavior it provides which is great. That has in turn given us insights into categories of forms we don't have enough test coverage around -- ones with shared expressions at different levels of the tree. I will be following up with some tests around that and am expecting there will be some more bugs found in that process.

This incorporates @grzesiek2010's change in #570 which tests the repeat template's relevance in the case of a static expression.

#### What has been done to verify that this works as intended?
Verified in Collect with the form at https://github.com/getodk/collect/issues/4090. Added a test that demonstrates the issue that form uncovered.

#### Why is this the best possible solution? Were any other approaches considered?
I believe that all code removed by #581 to walk up the tree checking for parent relevance is redundant (taken care of by DAG updates). However, I don't feel confident enough to remove it for the `isRepeatRelevant` case and I've brought it back with a comment.

I went back and forth on the code at https://github.com/getodk/javarosa/pull/581/files#diff-1cf9266e21581c3fdea78db8d579c7ebL395 which explicitly walks the tree for non-repeat notes. I really tried to write a test that would show this is necessary but I can't do it. It still feels relatively safe to me but can bring it back if we don't want to take the risk.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The intentional change is fixing the bug described in #603. This brings back code that has been in production for a long time and that we now have extensive test coverage for so it should be low-risk. I think the highest risk decision is not to walk the tree for non-repeat nodes.

#### Do we need any specific form for testing your changes? If so, please attach one.
See issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.
