### PR TITLE
Add test to demonstrate use of setvalue with literal value

### DIFF
--- a/src/test/java/org/javarosa/xform/parse/XFormParserTest.java
+++ b/src/test/java/org/javarosa/xform/parse/XFormParserTest.java
@@ -424,6 +424,14 @@ public class XFormParserTest {
         assertThat(g3Element.getBind(), is(g3AbsRef));
     }
 
+    @Test
+    public void testSetValueWithStrings() throws IOException {
+        
+        Scenario scenario = Scenario.init("default_test.xml");
+        assertEquals("string-value", scenario.getAnswerNode("/data/string_val").getValue().getValue().toString());
+        assertEquals("inline-value", scenario.getAnswerNode("/data/inline_val").getValue().getValue().toString());
+    }
+    
     private TreeElement findDepthFirst(TreeElement parent, String name) {
         int len = parent.getNumChildren();
         for (int i = 0; i < len; ++i) {

--- a/src/test/resources/default_test.xml
+++ b/src/test/resources/default_test.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+	xmlns:ev="http://www.w3.org/2001/xml-events"
+	xmlns:h="http://www.w3.org/1999/xhtml"
+	xmlns:jr="http://openrosa.org/javarosa"
+	xmlns:odk="http://www.opendatakit.org/xforms"
+	xmlns:orx="http://openrosa.org/xforms"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<h:head>
+		<h:title>Sum_test</h:title>
+		<model odk:xforms-version="1.0.0">
+			<instance>
+				<data id="Default_test">
+					<string_val />
+					<inline_val />
+					<meta>
+						<instanceID />
+						<instanceName />
+					</meta>
+				</data>
+			</instance>
+			<bind constraint="." nodeset="/data/string_val" type="string" />
+            <setvalue event="odk-instance-first-load"
+                ref="/data/string_val" value="&quot;string-value&quot;"/>
+            <bind constraint="." nodeset="/data/string_val" type="string" />
+            <setvalue event="odk-instance-first-load"
+                ref="/data/inline_val">inline-value</setvalue>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/string_val">
+			<label>StringVal</label>
+		</input>
+	</h:body>
+</h:html>


### PR DESCRIPTION
Added test to demonstrate how setval works with literal strings.

Closes #602 

#### What has been done to verify that this works as intended?
Added unit test

#### Why is this the best possible solution? Were any other approaches considered?
Just a test change to demonstrate existing behavior

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No code changes
#### Do we need any specific form for testing your changes? If so, please attach one.
No
#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Maybe update the docs for the tools that generate the forms to explain how to use setvalue with a literal