### PR TITLE
Re-evaluate calculates that may have multiple dependencies

### DIFF
--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -574,12 +574,13 @@ public class TriggerableDag {
         publishSummary("Created (phase 1)", createdRef, qtSet1);
 
         // initialize conditions for the node (and sub-nodes)
-        Set<QuickTriggerable> qtSet2 = initializeTriggerables(mainInstance, evalContext, createdRef, qtSet1);
+        Set<QuickTriggerable> qtSet2 = initializeTriggerables(mainInstance, evalContext, createdRef, new HashSet<>());
         publishSummary("Created (phase 2)", createdRef, qtSet2);
 
         Set<QuickTriggerable> alreadyEvaluated = new HashSet<>(qtSet1);
         alreadyEvaluated.addAll(qtSet2);
 
+        // TODO: add a test that fails without this or remove (all tests on v2.17 pre-DAG simplification pass)
         evaluateChildrenTriggerables(mainInstance, evalContext, createdElement, true, alreadyEvaluated);
     }
 


### PR DESCRIPTION
Closes #611

#### What has been done to verify that this works as intended?
Added automated tests, verified with the form at https://forum.getodk.org/t/repeats-and-calculations-inside-nested-repeats-behaving-differently-in-odk-1-27-3-vs-1-28-2/30694. I debugged the DAG creation process to make sure everything was in the expected order. I debugged the test with v2.17 and the change with the triggered set and confirmed that the behavior was the same.

#### Why is this the best possible solution? Were any other approaches considered?
Once I saw that this was a change from v2.17, I did not consider any other approaches. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Since this is bringing back old behavior, the risk is low.

#### Do we need any specific form for testing your changes? If so, please attach one.
See test.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.