### PR TITLE
Set instance name to null when deserializing main instance

### DIFF
--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -2178,6 +2178,11 @@ public class XFormParser implements IXFormParserFunctions {
         tr.add(templateRoot.getName(), TreeReference.INDEX_UNBOUND);
         templateRoot.populate(savedRoot, f);
 
+        // FormInstanceParser.parseInstance is responsible for initial creation of instances. It explicitly sets the
+        // main instance name to null so we force this again on deserialization because some code paths rely on the main
+        // instance not having a name.
+        f.getMainInstance().setName(null);
+
         // populated model to current form
         f.getMainInstance().setRoot(templateRoot);
 


### PR DESCRIPTION
Related to https://github.com/getodk/collect/pull/4182

This is really more for documentation purposes than anything else because we don't know of any clients of `XFormParser.loadXmlInstance`. Collect copies it in order to add special hooks for search(). I think that since we know there's a bug there, we should fix it, and that the test is very useful for documenting the case.