### PR TITLE
Support self-closing setvalue without value

### DIFF
--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -786,11 +786,12 @@ public class XFormParser implements IXFormParserFunctions {
 
         registerActionTarget(treeref);
         if (valueExpression == null) {
-            if (e.getChildCount() == 0 || !e.isText(0)) {
-                throw new XFormParseException("No 'value' attribute and no inner value set in <setvalue> associated with: " + treeref, e);
+            String value = "";
+            if (e.getChildCount() > 0 && e.isText(0)) {
+                value = e.getText(0);
             }
-            //Set expression
-            action = new SetValueAction(treeref, e.getText(0));
+
+            action = new SetValueAction(treeref, value);
         } else {
             try {
                 action = new SetValueAction(treeref, valueExpression.equals("") ? new XPathStringLiteral("")

--- a/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
@@ -203,7 +203,7 @@ public class SetValueActionTest {
                         t("a-field", "12")
                     )),
                     bind("/data/a-field").type("int"),
-                    setvalueLiteral("odk-instance-first-load", "/data/a-field", "")
+                    setvalue("odk-instance-first-load", "/data/a-field")
                 )
             ),
             body(

--- a/src/test/java/org/javarosa/core/util/XFormsElement.java
+++ b/src/test/java/org/javarosa/core/util/XFormsElement.java
@@ -131,6 +131,10 @@ public interface XFormsElement {
         return t("setvalue event=\"" + event + "\" ref=\"" + ref + "\" value=\"" + value + "\"");
     }
 
+    static XFormsElement setvalue(String event, String ref) {
+        return t("setvalue event=\"" + event + "\" ref=\"" + ref + "\"");
+    }
+
     static XFormsElement setvalueLiteral(String event, String ref, String innerHtml) {
         return t("setvalue event=\"" + event + "\" ref=\"" + ref + "\"", innerHtml);
     }


### PR DESCRIPTION
#564 added support for `setvalue` with an empty literal value or an empty `String` as the attribute value for `value`. However, it didn't add support for a self-closing `setvalue` tag without a `value` attribute which is what `pyxform` actually generates in the case of an empty `calculation`:
`<setvalue event="xforms-value-changed" ref="/data/malaria_age"/>`

#### What has been done to verify that this works as intended?
Added test and verified that the generated XML matches the one generated by `pyxform`.

#### Why is this the best possible solution? Were any other approaches considered?
This is such a small change that I don't think there really are alternatives. It gets the desired behavior -- if there isn't an explicit value for a `value` attribute or as a child, then we clear the target.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This loosens the requirements for `setvalue`. It could possibly allow more form design mistakes through but I think that risk is acceptable.

#### Do we need any specific form for testing your changes? If so, please attach one.
See test.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
https://github.com/getodk/docs/issues/1287