### PR TITLE
Add path to error for any hope of troubleshooting

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -150,7 +150,8 @@ public class XPathPathExpr extends XPathExpression {
                     }
                 } else {
                     //We only support expression root contexts for instance refs, everything else is an illegal filter
-                    throw new XPathUnsupportedException("filter expression");
+                    // We can end up here for a variety of reasons including missing a boolean operator.
+                    throw new XPathUnsupportedException("filter expression: " + this.toString());
                 }
 
                 break;


### PR DESCRIPTION
A user form hit this branch because it was missing an or in a boolean expression. This cheap addition should at least make it possible to figure out what's going on without debugging.