### PR TITLE
Clean up resources

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
@@ -9,27 +9,30 @@ public class CsvExternalInstance {
     public static TreeElement parse(String instanceId, String path) throws IOException {
         TreeElement root = new TreeElement("root", 0);
         root.setInstanceName(instanceId);
-        BufferedReader br = new BufferedReader(new FileReader(path));
-        String csvLine = br.readLine();
 
-        if (csvLine != null) {
-            String[] fieldNames = csvLine.split(",");
-            int multiplicity = 0;
+        try (BufferedReader br = new BufferedReader(new FileReader(path))) {
+            String csvLine = br.readLine();
 
-            while ((csvLine = br.readLine()) != null) {
-                TreeElement item = new TreeElement("item", multiplicity);
-                String[] data = csvLine.split(",");
-                for (int i = 0; i < fieldNames.length; ++i) {
-                    TreeElement field = new TreeElement(fieldNames[i], 0);
-                    field.setValue(new UncastData(i < data.length ? data[i] : ""));
+            if (csvLine != null) {
+                String[] fieldNames = csvLine.split(",");
+                int multiplicity = 0;
 
-                    item.addChild(field);
+                while ((csvLine = br.readLine()) != null) {
+                    TreeElement item = new TreeElement("item", multiplicity);
+                    String[] data = csvLine.split(",");
+                    for (int i = 0; i < fieldNames.length; ++i) {
+                        TreeElement field = new TreeElement(fieldNames[i], 0);
+                        field.setValue(new UncastData(i < data.length ? data[i] : ""));
+
+                        item.addChild(field);
+                    }
+
+                    root.addChild(item);
+                    multiplicity++;
                 }
-
-                root.addChild(item);
-                multiplicity++;
             }
         }
+
         return root;
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/XmlExternalInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/XmlExternalInstance.java
@@ -12,9 +12,10 @@ import org.xmlpull.v1.XmlPullParserException;
 
 public class XmlExternalInstance {
     public static TreeElement parse(String instanceId, String path) throws IOException, InvalidStructureException, XmlPullParserException, UnfullfilledRequirementsException {
-        InputStream inputStream = new FileInputStream(path);
-        KXmlParser xmlParser = ElementParser.instantiateParser(inputStream);
-        TreeElementParser treeElementParser = new TreeElementParser(xmlParser, 0, instanceId);
-        return treeElementParser.parse();
+        try (InputStream inputStream = new FileInputStream(path)) {
+            KXmlParser xmlParser = ElementParser.instantiateParser(inputStream);
+            TreeElementParser treeElementParser = new TreeElementParser(xmlParser, 0, instanceId);
+            return treeElementParser.parse();
+        }
     }
 }


### PR DESCRIPTION
When parsing an external secondary instance, don't leave stream objects lying around.

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
