### PR TITLE
Do not use cached choices if the cached list comes from a different repeat

### DIFF
--- a/src/main/java/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/main/java/org/javarosa/core/model/ItemsetBinding.java
@@ -46,6 +46,7 @@ public class ItemsetBinding implements Externalizable, Localizable {
     // Values needed to determine whether the cached list should be expired (not serialized)
     private Map<TreeReference, IAnswerData> cachedTriggerValues;
     private Long cachedRandomizeSeed;
+    private TreeReference cachedRef;
 
     /**
      * note that storing both the ref and expr for everything is kind of redundant, but we're forced
@@ -91,7 +92,8 @@ public class ItemsetBinding implements Externalizable, Localizable {
 
         // Return cached list if possible
         if (cachedFilteredChoiceList != null && allTriggerRefsBound && Objects.equals(currentTriggerValues, cachedTriggerValues)
-            && Objects.equals(currentRandomizeSeed, cachedRandomizeSeed)) {
+            && Objects.equals(currentRandomizeSeed, cachedRandomizeSeed)
+            && Objects.equals(curQRef, cachedRef)) {
             return randomize && cachedRandomizeSeed == null ? shuffle(cachedFilteredChoiceList) : cachedFilteredChoiceList;
         }
 
@@ -148,6 +150,7 @@ public class ItemsetBinding implements Externalizable, Localizable {
 
         cachedTriggerValues = currentTriggerValues;
         cachedRandomizeSeed = currentRandomizeSeed;
+        cachedRef = curQRef;
 
         return cachedFilteredChoiceList;
     }


### PR DESCRIPTION
Closes #642 

#### What has been done to verify that this works as intended?
I tested this change with ODK Collect.

#### Why is this the best possible solution? Were any other approaches considered?
My understanding of the issue is:
- in `Cache and reuse dynamic choice lists` https://github.com/getodk/javarosa/pull/619 https://github.com/getodk/javarosa/pull/626 we implemented caching choices to make the process of loading them faster
- the responsibility of the method that does it [ItemsetBinding.getChoices()](https://github.com/getodk/javarosa/blob/master/src/main/java/org/javarosa/core/model/ItemsetBinding.java#L86) is also updating answers in model [ItemsetBinding.updateQuestionAnswerInModel()](https://github.com/getodk/javarosa/blob/master/src/main/java/org/javarosa/core/model/ItemsetBinding.java#L129)
- if we already have a list of cached choices it is [returned](https://github.com/getodk/javarosa/blob/master/src/main/java/org/javarosa/core/model/ItemsetBinding.java#L95) and updating that answer in model does not take place
- everything works fine if we have normal questions (not in repeatable groups) because then the answer is always the same
- if we have a question in repeatable group then despite the fact it's the same question with exactly the same choices we can have different answers so we can't just return the cached list of choices and skip [ItemsetBinding.updateQuestionAnswerInModel()](https://github.com/getodk/javarosa/blob/master/src/main/java/org/javarosa/core/model/ItemsetBinding.java#L129)

so to solve the issue I also added caching `cachedRef` to avoid using the same cached choices for all repeatable groups.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just handle the case where dynamic choices are used in repeatable groups. Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.
