### PR TITLE
Fix for Collect #4059

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -506,7 +506,8 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         TreeReference repeatContextRef = getChildInstanceRef(index);
         TreeElement template = mainInstance.getTemplate(repeatContextRef);
 
-        mainInstance.copyNode(template, repeatContextRef);
+        //For #4059 fix
+        mainInstance.copyNode(template.deepCopyForRepeat(), repeatContextRef);
 
         TreeElement newNode = mainInstance.resolveReference(repeatContextRef);
         preloadInstance(newNode);

--- a/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -344,6 +344,18 @@ import org.javarosa.xpath.expr.XPathStringLiteral;
         return newNode;
     }
 
+    //For #4059 fix
+    public TreeElement deepCopyForRepeat() {
+        TreeElement newNode = shallowCopy();
+
+        newNode.children.clear();
+        for (TreeElement child : children) {
+            child.setMult(TreeReference.DEFAULT_MULTIPLICITY);
+            newNode.addChild(child.deepCopyForRepeat());
+        }
+        return newNode;
+    }
+
     /* ==== MODEL PROPERTIES ==== */
 
     // factoring inheritance rules

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -1831,11 +1831,12 @@ public class TriggerableDagTest {
         scenario.createNewRepeat("/data/outer[1]/inner");
         scenario.createNewRepeat("/data/outer[1]/inner");
 
-        assertThat(scenario.answerOf("/data/outer[0]/inner[0]/count"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/outer[0]/inner[1]/count"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/outer[0]/inner[2]/count"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/outer[1]/inner[0]/count"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/outer[1]/inner[1]/count"), is(intAnswer(2)));
+        //For #4059 fix
+        assertThat(scenario.answerOf("/data/outer[0]/inner[0]/count"), is(intAnswer(4)));
+        assertThat(scenario.answerOf("/data/outer[0]/inner[1]/count"), is(intAnswer(4)));
+        assertThat(scenario.answerOf("/data/outer[0]/inner[2]/count"), is(intAnswer(4)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[0]/count"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[1]/count"), is(intAnswer(3)));
     }
 
     @Test

--- a/src/test/java/org/javarosa/form/api/FormNavigationTestCase.java
+++ b/src/test/java/org/javarosa/form/api/FormNavigationTestCase.java
@@ -14,8 +14,8 @@ import static org.junit.Assert.assertEquals;
 @RunWith(Parameterized.class)
 public class FormNavigationTestCase {
 
-    private String formName;
-    private String[] expectedIndices;
+    private final String formName;
+    private final String[] expectedIndices;
 
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<Object[]> data() {
@@ -36,7 +36,9 @@ public class FormNavigationTestCase {
 
                 ei("twoNestedRepeatGroups.xml",
                         "-1, ", "0_0, ", "0_0, 0_0, ", "0_0, 0_0, 0, ", "0_0, 0_0, 1, ", "0_0, 0_1, ",
-                        "0_0, 0_1, 0, ", "0_0, 0_1, 1, ", "0_0, 0_2, ", "0_1, ", "-1, "),
+                        "0_0, 0_1, 0, ", "0_0, 0_1, 1, ", "0_0, 0_2, ",
+                        //For #4059 fix
+                        "0_0, 0_2, 0, ", "0_0, 0_2, 1, ", "0_0, 0_3, ", "0_1, ", "-1, "),
 
                 ei("simpleFormWithThreeQuestions.xml",
                         "-1, ", "0, ", "1, ", "2, ", "-1, ")


### PR DESCRIPTION
Addresses [Collect #4059](https://github.com/getodk/collect/issues/4059)

#### What has been done to verify that this works as intended?
Verified in Collect as described in (closed) [#4797](https://github.com/getodk/collect/pull/4797). Tests `FormNavigationTestCase` and `TriggerableDagTest` have been updated to match the improvement.

#### Why is this the best possible solution? Were any other approaches considered?
Offers a straightforward resolution of the issue raised, there's no evident fix in Collect.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Now behaves as a user would naturally expect; code changes have been deliberately isolated (see below) to avoid regression risk.

#### Do we need any specific form for testing your changes? If so, please attach one.

Defined in _[NestedRepeats.xlsx](https://github.com/getodk/collect/files/7000892/NestedRepeats.xlsx)_ (derived from @seadowg form in [#4059](https://github.com/getodk/collect/issues/4059))

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No update needed?
### The issue
Tracing the state of the form instance as repeats are added shows that the key code is in JR. The initial instance is created with nested repeat(s), but subsequent repeats are empty to start with. 

Stepping through adding a repeat shows that in `FormDef` the template tree acquired in `createNewRepeat` has the appropriate members. However when this is passed to `FormInstance.copyNode`, `TreeElement.deepCopy` fails to include them because their multiplicities are all `INDEX_TEMPLATE` ie -2. Even if it did copy them, their multiplicities would stop them being indexable. 

### The fix
The obvious solution is to copy the whole template and set multiplicities to `DEFAULT_MULTIPLICITY` ie 0. This will be correct for all nested repeats and the appropriate value for the repeat root is set in `copyNode`.

Both `copyNode` and `deepCopy` have multiple call sites, so modifying either will most likely result in regression.

However in `createNewRepeat` we can pass to `copyNode` a clone of the template with adjusted multiplicities, created using an analogue in `TreeElement` of `deepCopy`. (The subsequent copying in `copyNode` will then be harmlessly redundant.)

This small change has the desired effect and should be safe from regression