### PR TITLE
Update the model even when a cached choice list can be used

### DIFF
--- a/src/test/java/org/javarosa/core/model/SelectOneChoiceFilterTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectOneChoiceFilterTest.java
@@ -131,6 +131,7 @@ public class SelectOneChoiceFilterTest {
         // If we set level2 to "aa", form validation passes. Currently, clearing a choice only updates filter expressions
         // that directly depend on it. With this form, we could force clearing the third level when the first level is cleared
         // by making the level3 filter expression in the form definition reference level1 AND level2.
+        scenario.answer("/data/level1", "b");
         scenario.answer("/data/level2", "bb");
 
         validate = scenario.getValidationOutcome();


### PR DESCRIPTION
Closes #642, replaces #643

#643 re-introduced performance issues. See https://github.com/getodk/javarosa/pull/643#issuecomment-923601362 for a description of when performance would matter.

This solution is similar to https://github.com/getodk/javarosa/commit/7d483f14153b5bb9b26e20b7c7fdc3e4f2093bc1 but with a narrower slice of work when cached choices are returned.

#### What has been done to verify that this works as intended?
Added and ran a test. Verified that all other tests pass, in particular those that ensure performance in cases with repeats (the ones that failed in #643).

#### Why is this the best possible solution? Were any other approaches considered?
Conceptually, there are two things we need to do for any select: 
- make sure that the answer doesn't contain choices that are no longer available
- make sure the answer is bound to the corresponding choice objects so that we can display the selected choice using its label
We don't want to do this on e.g. form load because it would mean having to iterate through all of the choices which we may never need to do. Doing this binding as late as possible is good for performance.

Semantically it feels like making sure the answer is synced with the choice list should happen any time the answer is requested. However, I don't think that's practical because the answers are represented as `SelectOneData` and `SelectMultipleData` objects which have no connection to the form definition or the currently filtered list of choices. I can't think of a way to kick off that syncing. What we've been doing which is updating the answer when the choice list is requested seems like the next best thing.

@grzesiek2010 says at https://github.com/getodk/javarosa/pull/643#issuecomment-912543031

> it's kind of strange that a method called getChoices() not only returns a list of choices but also performs such an additional operations.

True, but caching is inherently stateful. We don't want clients of `getChoices` to have to keep track of caching, we want all the right updates to be triggered by choices being requested. We could do some kind of hook or listener but fundamentally I think the result would be the same and it's not worth a huge refactor at this time.

I briefly explored doing the update when the answer label is requested (currently in `getSelectItemText`). But that's not quite right, there are cases such as in validation where the choice list would be requested but the answer label would not.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The intent is to narrowly fix the issue with editing forms with filtered selects in repeats. This feels like a quite safe change. It does mean that select answers are now updated any time a choice list is requested so there's risk there. We have very high test coverage, though.

#### Do we need any specific form for testing your changes? If so, please attach one.
See issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.