### PR TITLE
Add script to install "local" version to local maven repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ out
 # mvn
 target
 secrets.xml
+pom-local.xml
 
 # logging
 logback.xml

--- a/install-local-version.sh
+++ b/install-local-version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -e
+
+cp pom.xml pom-local.xml
+
+# Replace version with "local" (but don't replace version tags after depdendencies tag)
+sed -i '' '0,/<dependencies>/s/<version>.*<\/version>/<version>local<\/version>/' pom-local.xml
+
+mvn -f pom-local.xml -Dgpg.skip install


### PR DESCRIPTION
This allows you to deploy JavaRosa to your local maven repo (`~/.m2/repository`) with the version `local`. This allows downstream dependencies to define a dependency constant (`local`) they can switch to.

#### What has been done to verify that this works as intended?

Tried this out with Collect (changes in getodk/collect#4846).

#### Why is this the best possible solution? Were any other approaches considered?

In my mind, using `mvn install` over building a jar and including in libs/as a file dependency has a couple of advantages over the exiting process for debugging:

* The downstream project can fetch transitive dependencies through Gradle/Maven rather than having to specify them like they would with a JAR
* It avoids mistakes where different versions of dependencies (with different behaviour) are used in a downstream project than in JavaRosa - the build tooling will catch conflicts
* It means going through our maven build locally during development rather than it getting avoided

I initially wanted to just have this work by overriding the version at the command line using a property. This doesn't work because maven then weirdly copies the `pom.xml` as is to wherever it's deploying which results in  the local repo using whatever the default of the property is. Sigh.

This solution with `sed` is potentially too over the top, so we could fallback to Collect instructions just being "change the version in the `pom.xml` to `local`" rather than running the script.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should only affect development so no reason for QA here.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

I think updating the docs on the Collect side makes more sense. One thing we could add here is an update to our release process so that there is no `project.version` specified in the `pom.xml` and we just always specify it. I'm not sure if that's desirable or not though.