### PR TITLE
Set version to 3.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ jar {
     // Be sure to update version in pom.xml to match
     // snapshot release = x.x.x-SNAPSHOT
     // production release = x.x.x
-    version = '3.3.0-SNAPSHOT'
+    version = '3.3.0'
     archiveName = baseName + '-' + version + '.jar'
 
     manifest {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <!-- Be sure to update version in build.gradle to match -->
   <!-- snapshot release = x.x.x-SNAPSHOT -->
   <!-- production release = x.x.x -->
-  <version>3.3.0-SNAPSHOT</version>
+  <version>3.3.0</version>
   <packaging>jar</packaging>
   <name>javarosa</name>
   <description>A Java library for rendering forms that are compliant with ODK XForms spec</description>


### PR DESCRIPTION
Prepare for 3.3.0 release. This has gone through QA but was not actually part of the beta. The biggest risk would be that the issues addressed aren't fully. We can follow up with a point release if needed.