### PR TITLE
Geojson improvements

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
+++ b/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
@@ -28,6 +28,8 @@ public class GeojsonFeature {
     private GeojsonGeometry geometry;
     private Map<String, String> properties;
 
+    private String id;
+
     public TreeElement toTreeElement(int multiplicity) throws IOException {
         if (!type.equals("Feature")) {
             throw new IOException("Item of type " + type + " found but expected item of type Feature");
@@ -43,6 +45,16 @@ public class GeojsonFeature {
             for (String property : properties.keySet()) {
                 TreeElement field = new TreeElement(property, 0);
                 field.setValue(new UncastData(properties.get(property)));
+                item.addChild(field);
+            }
+        }
+
+        if (id != null) {
+            if (!item.getChildrenWithName("id").isEmpty()) {
+                item.getChildrenWithName("id").get(0).setValue(new UncastData(id));
+            } else {
+                TreeElement field = new TreeElement("id", 0);
+                field.setValue(new UncastData(id));
                 item.addChild(field);
             }
         }

--- a/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
+++ b/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
@@ -39,10 +39,12 @@ public class GeojsonFeature {
         geoField.setValue(new UncastData(geometry.getOdkCoordinates()));
         item.addChild(geoField);
 
-        for (String property : properties.keySet()) {
-            TreeElement field = new TreeElement(property, 0);
-            field.setValue(new UncastData(properties.get(property)));
-            item.addChild(field);
+        if (properties != null) {
+            for (String property : properties.keySet()) {
+                TreeElement field = new TreeElement(property, 0);
+                field.setValue(new UncastData(properties.get(property)));
+                item.addChild(field);
+            }
         }
 
         return item;

--- a/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
+++ b/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
@@ -17,12 +17,14 @@
 package org.javarosa.core.model.instance.geojson;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.IOException;
 import java.util.Map;
 import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.instance.TreeElement;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class GeojsonFeature {
     private String type;
     private GeojsonGeometry geometry;

--- a/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
+++ b/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
@@ -29,18 +29,22 @@ public class GeojsonFeature {
     private Map<String, String> properties;
 
     public TreeElement toTreeElement(int multiplicity) throws IOException {
+        if (!type.equals("Feature")) {
+            throw new IOException("Item of type " + type + " found but expected item of type Feature");
+        }
+
         TreeElement item = new TreeElement("item", multiplicity);
 
         TreeElement geoField = new TreeElement("geometry", 0);
         geoField.setValue(new UncastData(geometry.getOdkCoordinates()));
         item.addChild(geoField);
 
-       for (String property : properties.keySet()) {
-           TreeElement field = new TreeElement(property, 0);
-           field.setValue(new UncastData(properties.get(property)));
-           item.addChild(field);
-       }
+        for (String property : properties.keySet()) {
+            TreeElement field = new TreeElement(property, 0);
+            field.setValue(new UncastData(properties.get(property)));
+            item.addChild(field);
+        }
 
-       return item;
+        return item;
     }
 }

--- a/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
@@ -99,7 +99,7 @@ public class GeoJsonExternalInstanceTest {
     public void parse_usesTopLevelId() throws IOException {
         TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-id-toplevel.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
-        assertThat(featureCollection.getChildAt(0).getChild("id", 0).getValue().getValue(), is("fs87b"));
+        assertThat(featureCollection.getChildAt(0).getChild("id", 0).getValue().getValue(), is("top-level-id"));
 
     }
 
@@ -107,7 +107,7 @@ public class GeoJsonExternalInstanceTest {
     public void parse_prioritizesTopLevelId() throws IOException {
         TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-id-twice.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
-        assertThat(featureCollection.getChildAt(0).getChild("id", 0).getValue().getValue(), is("fs87b"));
+        assertThat(featureCollection.getChildAt(0).getChild("id", 0).getValue().getValue(), is("top-level-id"));
     }
 
     @Test

--- a/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
@@ -95,6 +95,21 @@ public class GeoJsonExternalInstanceTest {
     }
 
     @Test
+    public void parse_usesTopLevelId() throws IOException {
+        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-id-toplevel.geojson").toString());
+        assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
+        assertThat(featureCollection.getChildAt(0).getChild("id", 0).getValue().getValue(), is("fs87b"));
+
+    }
+
+    @Test
+    public void parse_prioritizesTopLevelId() throws IOException {
+        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-id-twice.geojson").toString());
+        assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
+        assertThat(featureCollection.getChildAt(0).getChild("id", 0).getValue().getValue(), is("fs87b"));
+    }
+
+    @Test
     public void parse_addsFeaturesWithNoProperties() throws IOException {
         TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-no-properties.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(1));

--- a/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
@@ -17,6 +17,7 @@
 package org.javarosa.core.model.instance.geojson;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.fail;
@@ -107,6 +108,13 @@ public class GeoJsonExternalInstanceTest {
         TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-id-twice.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
         assertThat(featureCollection.getChildAt(0).getChild("id", 0).getValue().getValue(), is("fs87b"));
+    }
+
+    @Test
+    public void parse_ignoresUnknownToplevelProperties() throws IOException {
+        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-extra-toplevel.geojson").toString());
+        assertThat(featureCollection.getChildAt(0).getNumChildren(), is(3));
+        assertThat(featureCollection.getChildAt(0).getChild("ignored", 0), nullValue());
     }
 
     @Test

--- a/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
@@ -67,6 +67,16 @@ public class GeoJsonExternalInstanceTest {
     }
 
     @Test
+    public void parse_throwsException_ifSingleFeatureNotOfFeatureType() {
+        try {
+            GeoJsonExternalInstance.parse("id", r("bad-feature-not-feature.geojson").toString());
+            fail("Exception expected");
+        } catch (IOException e) {
+            // expected
+        }
+    }
+
+    @Test
     public void parse_addsGeometriesAsChildren_forMultipleFeatures() throws IOException {
         TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection.geojson").toString());
         assertThat(featureCollection.getNumChildren(), is(2));

--- a/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
@@ -95,6 +95,12 @@ public class GeoJsonExternalInstanceTest {
     }
 
     @Test
+    public void parse_addsFeaturesWithNoProperties() throws IOException {
+        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-no-properties.geojson").toString());
+        assertThat(featureCollection.getChildAt(0).getNumChildren(), is(1));
+    }
+
+    @Test
     public void parse_throwsException_whenGeometryNotPoint() {
         try {
             GeoJsonExternalInstance.parse("id", r("feature-collection-with-line.geojson").toString());

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/bad-feature-not-feature.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/bad-feature-not-feature.geojson
@@ -1,0 +1,18 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Bad",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    102,
+                    0.5
+                ]
+            },
+            "properties": {
+                "id": "fs87b"
+            }
+        }
+    ]
+}

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-extra-toplevel.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-extra-toplevel.geojson
@@ -1,0 +1,22 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    102,
+                    0.5
+                ]
+            },
+
+            "ignored": "ignored",
+
+            "properties": {
+                "id": "fs87b",
+                "title": "My cool point"
+            }
+        }
+    ]
+}

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-id-toplevel.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-id-toplevel.geojson
@@ -10,7 +10,7 @@
                     0.5
                 ]
             },
-            "id": "fs87b",
+            "id": "top-level-id",
             "properties": {
                 "name": "My cool point",
                 "foo": "bar"

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-id-toplevel.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-id-toplevel.geojson
@@ -1,0 +1,20 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    102,
+                    0.5
+                ]
+            },
+            "id": "fs87b",
+            "properties": {
+                "name": "My cool point",
+                "foo": "bar"
+            }
+        }
+    ]
+}

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-id-twice.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-id-twice.geojson
@@ -1,0 +1,21 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    104,
+                    0.5
+                ]
+            },
+            "id": "fs87b",
+            "properties": {
+                "id": "67abie",
+                "name": "Your cool point",
+                "foo": "quux"
+            }
+        }
+    ]
+}

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-id-twice.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-id-twice.geojson
@@ -10,9 +10,9 @@
                     0.5
                 ]
             },
-            "id": "fs87b",
+            "id": "top-level-id",
             "properties": {
-                "id": "67abie",
+                "id": "property-id",
                 "name": "Your cool point",
                 "foo": "quux"
             }

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-no-properties.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-no-properties.geojson
@@ -1,0 +1,15 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    102,
+                    0.5
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
- Closes https://github.com/getodk/collect/issues/5051
- Adds support for toplevel `id` if it exists. Toplevel `id` is mentioned in the GeoJSON spec so it takes precedence over an `id` property.
- Adds additional flexibility: ignore unknown toplevel elements and accept no explicit properties (though it won't work as choices for a select)

#### What has been done to verify that this works as intended?
Added tests.

#### Why is this the best possible solution? Were any other approaches considered?
I was initially going to address the issue with a proguard rule in Collect but I realized that really we should be validating the `type` as we do other similar validations.

While validating the type, I realized that properties could be empty. This won't work for selects because we need properties for label and underlying value but we shouldn't crash. While I was there, I implemented support for toplevel `id` which we'd marked as an extension.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is isolated to the geojson secondary instance implementation so the only regression risks are there. Test coverage is high so it should be quite safe.

#### Do we need any specific form for testing your changes? If so, please attach one.
See tests.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
https://github.com/getodk/docs/issues/1423
