### PR TITLE
Get additional children

### DIFF
--- a/src/main/java/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/main/java/org/javarosa/core/model/ItemsetBinding.java
@@ -210,7 +210,8 @@ public class ItemsetBinding implements Externalizable, Localizable {
             labelIsItext,
             item.getInstanceName() != null
                 ? (TreeElement) formDef.getNonMainInstance(item.getInstanceName()).resolveReference(item)
-                : formDef.getMainInstance().resolveReference(item));
+                : formDef.getMainInstance().resolveReference(item),
+            labelRef.getNameLast());
 
         choice.setIndex(i);
 

--- a/src/main/java/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/main/java/org/javarosa/core/model/ItemsetBinding.java
@@ -55,16 +55,13 @@ public class ItemsetBinding implements Externalizable, Localizable {
     public TreeReference nodesetRef;   //absolute ref of itemset source nodes
     public IConditionExpr nodesetExpr; //path expression for source nodes; may be relative, may contain predicates
     public TreeReference contextRef;   //context ref for nodesetExpr; ref of the control parent (group/formdef) of itemset question
-       //note: this is only here because its currently impossible to both (a) get a form control's parent, and (b)
+       //note: this is only here because it's currently impossible to both (a) get a form control's parent, and (b)
        //convert expressions into refs while preserving predicates. once these are fixed, this field can go away
 
     public TreeReference labelRef;     //absolute ref of label
     public IConditionExpr labelExpr;   //path expression for label; may be relative, no predicates
     public boolean labelIsItext;       //if true, content of 'label' is an itext id
 
-    public boolean copyMode;           //true = copy subtree; false = copy string value
-    public IConditionExpr copyExpr;    // path expression for copy; may be relative, no predicates
-    public TreeReference copyRef;      //absolute ref to copy
     public TreeReference valueRef;     //absolute ref to value
     public IConditionExpr valueExpr;   //path expression for value; may be relative, no predicates (must be relative if copy mode)
 
@@ -74,6 +71,22 @@ public class ItemsetBinding implements Externalizable, Localizable {
     public boolean randomize = false;
     public XPathNumericLiteral randomSeedNumericExpr = null;
     public XPathPathExpr randomSeedPathExpr = null;
+
+    /**
+     * @deprecated No tests and no evidence it's used.
+     */
+    @Deprecated
+    public boolean copyMode;           //true = copy subtree; false = copy string value
+    /**
+     * @deprecated No tests and no evidence it's used.
+     */
+    @Deprecated
+    public IConditionExpr copyExpr;    // path expression for copy; may be relative, no predicates
+    /**
+     * @deprecated No tests and no evidence it's used.
+     */
+    @Deprecated
+    public TreeReference copyRef;      //absolute ref to copy
 
     /**
      * Returns a list of <code>SelectChoice</code> objects based on the data in the model. If any of the itemset expression

--- a/src/main/java/org/javarosa/core/model/SelectChoice.java
+++ b/src/main/java/org/javarosa/core/model/SelectChoice.java
@@ -42,7 +42,10 @@ public class SelectChoice implements Externalizable, Localizable {
      * 'copy' answer mode, this points to the node to be copied if this
      * selection is chosen this field only has meaning for dynamic choices, thus
      * is unserialized
+     *
+     * @deprecated No tests and no evidence it's used.
      */
+    @Deprecated
     public TreeElement copyNode;
 
     /**
@@ -122,7 +125,6 @@ public class SelectChoice implements Externalizable, Localizable {
 
         return index;
     }
-
 
     public void localeChanged(String locale, Localizer localizer) {
         // TODO Review this commented block

--- a/src/main/java/org/javarosa/core/model/SelectChoice.java
+++ b/src/main/java/org/javarosa/core/model/SelectChoice.java
@@ -1,5 +1,8 @@
 package org.javarosa.core.model;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.services.locale.Localizable;
@@ -10,16 +13,28 @@ import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xform.parse.XFormParseException;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 public class SelectChoice implements Externalizable, Localizable {
-
-    private String labelInnerText;
-    private String textID;
-    private boolean isLocalizable;
+    /** The literal value from the child that is used as a value. For inline selects ("static"), this child always has
+     * the name "value". For selects from itemsets ("dynamic"), the child node to use is specified in the form definition
+     * (e.g. country_code)
+     */
     private String value;
+
+    /**
+     * If this choice is from a non-localizable item, the literal value from the child that is used as a label.
+     * For inline selects ("static"), this child always has the name "label". For selects from itemsets ("dynamic"), the
+     * child node to use is specified in the form definition (e.g. the_human_friendly_name)
+     */
+    private String labelInnerText;
+
+    /**
+     * If this choice is from a localizable item, the literal text from the child that is used as a label. This will be
+     * used to look up the localized label based on the current language.
+     */
+    private String textID;
+
+    private boolean isLocalizable;
+
     private int index = -1;
 
     /**
@@ -31,7 +46,7 @@ public class SelectChoice implements Externalizable, Localizable {
     public TreeElement copyNode;
 
     /**
-     * The node that this choice represents. Not serialized.
+     * For selects from itemsets ("dynamic"), the node that this choice represents. Not serialized.
      */
     private TreeElement item;
 

--- a/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
+++ b/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
@@ -26,6 +26,7 @@ import org.javarosa.core.model.instance.TreeElement;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GeojsonFeature {
+    public static final String GEOMETRY_CHILD_NAME = "geometry";
     private String type;
     private GeojsonGeometry geometry;
     private Map<String, String> properties;
@@ -39,7 +40,7 @@ public class GeojsonFeature {
 
         TreeElement item = new TreeElement("item", multiplicity);
 
-        TreeElement geoField = new TreeElement("geometry", 0);
+        TreeElement geoField = new TreeElement(GEOMETRY_CHILD_NAME, 0);
         geoField.setValue(new UncastData(geometry.getOdkCoordinates()));
         item.addChild(geoField);
 

--- a/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
@@ -98,7 +98,6 @@ public class FormEntryPrompt extends FormEntryCaption {
                     // The call to get a list of choices filters out answer options that don't exist anymore.
                     return mTreeElement.getValue();
                 } else {
-                    // TODO: add tests for copy mode
                     List<String> preselectedValues = new ArrayList<String>();
 
                     TreeReference destRef = itemset.getDestRef().contextualize(mTreeElement.getRef());


### PR DESCRIPTION
Adds access to additional children from an itemset item in support of https://github.com/getodk/collect/issues/4948

#### What has been done to verify that this works as intended?
Tests!

#### Why is this the best possible solution? Were any other approaches considered?
Comments inline for a few alternatives I considered.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Additive change. 

I did put all the `copyNode` stuff on a deprecation path. It's not documented. If ever we have a use case for it we can bring it back with tests.

#### Do we need any specific form for testing your changes? If so, please attach one.
See tests.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Not user-facing so no.