### PR TITLE
Add annotations to help Kotlin with select questions

### DIFF
--- a/src/main/java/org/javarosa/core/model/SelectChoice.java
+++ b/src/main/java/org/javarosa/core/model/SelectChoice.java
@@ -1,10 +1,5 @@
 package org.javarosa.core.model;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import kotlin.Pair;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.TreeElement;
@@ -15,9 +10,17 @@ import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xform.parse.XFormParseException;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SelectChoice implements Externalizable, Localizable {
-    /** The literal value from the child that is used as a value. For inline selects ("static"), this child always has
+    /**
+     * The literal value from the child that is used as a value. For inline selects ("static"), this child always has
      * the name "value". For selects from itemsets ("dynamic"), the child node to use is specified in the form definition
      * (e.g. country_code)
      */
@@ -111,6 +114,7 @@ public class SelectChoice implements Externalizable, Localizable {
         return value;
     }
 
+    @Nullable
     public String getChild(String childName) {
         if (item == null) {
             return null;

--- a/src/main/java/org/javarosa/core/model/data/BooleanData.java
+++ b/src/main/java/org/javarosa/core/model/data/BooleanData.java
@@ -16,11 +16,12 @@
 
 package org.javarosa.core.model.data;
 
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 /**
  * @author Clayton Sims
@@ -57,7 +58,7 @@ public class BooleanData implements IAnswerData {
     }
 
     @Override
-    public Object getValue() {
+    public @NotNull Object getValue() {
         return data;
     }
 

--- a/src/main/java/org/javarosa/core/model/data/DateData.java
+++ b/src/main/java/org/javarosa/core/model/data/DateData.java
@@ -16,14 +16,15 @@
 
 package org.javarosa.core.model.data;
 
+import org.javarosa.core.model.utils.DateUtils;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Date;
-
-import org.javarosa.core.model.utils.DateUtils;
-import org.javarosa.core.util.externalizable.ExtUtil;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 /**
  * A response to a question requesting a Date Value
@@ -70,7 +71,7 @@ public class DateData implements IAnswerData {
     }
 
     @Override
-    public Object getValue () {
+    public @NotNull Object getValue () {
         init();
         return new Date(d.getTime());
     }

--- a/src/main/java/org/javarosa/core/model/data/DateTimeData.java
+++ b/src/main/java/org/javarosa/core/model/data/DateTimeData.java
@@ -16,14 +16,15 @@
 
 package org.javarosa.core.model.data;
 
+import org.javarosa.core.model.utils.DateUtils;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Date;
-
-import org.javarosa.core.model.utils.DateUtils;
-import org.javarosa.core.util.externalizable.ExtUtil;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 /**
  * A response to a question requesting a DateTime Value
@@ -60,7 +61,7 @@ public class DateTimeData implements IAnswerData {
     }
 
     @Override
-    public Object getValue () {
+    public @NotNull Object getValue () {
         return new Date(d.getTime());
     }
 

--- a/src/main/java/org/javarosa/core/model/data/DecimalData.java
+++ b/src/main/java/org/javarosa/core/model/data/DecimalData.java
@@ -16,13 +16,14 @@
 
 package org.javarosa.core.model.data;
 
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-
 import java.util.Objects;
-import org.javarosa.core.util.externalizable.ExtUtil;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 
 /**
@@ -59,7 +60,7 @@ public class DecimalData implements IAnswerData {
     }
 
     @Override
-    public Object getValue() {
+    public @NotNull Object getValue() {
         return d;
     }
 

--- a/src/main/java/org/javarosa/core/model/data/GeoPointData.java
+++ b/src/main/java/org/javarosa/core/model/data/GeoPointData.java
@@ -16,15 +16,16 @@
 
 package org.javarosa.core.model.data;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.List;
-
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.IExprDataType;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
 
 
 /**
@@ -106,7 +107,7 @@ public class GeoPointData implements IAnswerData, IExprDataType {
 
 
     @Override
-    public Object getValue() {
+    public @NotNull Object getValue() {
         // clone()'ing to prevent some potential bad direct accesses
         // when these values are returned by GeoLine or GeoShape objects.
         return gp.clone();

--- a/src/main/java/org/javarosa/core/model/data/GeoShapeData.java
+++ b/src/main/java/org/javarosa/core/model/data/GeoShapeData.java
@@ -16,14 +16,15 @@
 
 package org.javarosa.core.model.data;
 
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.xpath.IExprDataType;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-
-import org.javarosa.core.util.externalizable.ExtUtil;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
-import org.javarosa.xpath.IExprDataType;
 
 
 /**
@@ -104,7 +105,7 @@ public class GeoShapeData implements IAnswerData, IExprDataType {
 
 
     @Override
-    public Object getValue() {
+    public @NotNull Object getValue() {
         ArrayList<double[]> pts = new ArrayList<>();
         for ( GeoPointData p : points ) {
             pts.add((double[])p.getValue());

--- a/src/main/java/org/javarosa/core/model/data/GeoTraceData.java
+++ b/src/main/java/org/javarosa/core/model/data/GeoTraceData.java
@@ -16,14 +16,15 @@
 
 package org.javarosa.core.model.data;
 
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.xpath.IExprDataType;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-
-import org.javarosa.core.util.externalizable.ExtUtil;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
-import org.javarosa.xpath.IExprDataType;
 
 /**
  * A response to a question requesting an GeoTrace Value.
@@ -109,7 +110,7 @@ public class GeoTraceData implements IAnswerData, IExprDataType {
 
 
     @Override
-    public Object getValue() {
+    public @NotNull Object getValue() {
         ArrayList<double[]> pts = new ArrayList<>();
         for ( GeoPointData p : points ) {
             pts.add((double[])p.getValue());

--- a/src/main/java/org/javarosa/core/model/data/IAnswerData.java
+++ b/src/main/java/org/javarosa/core/model/data/IAnswerData.java
@@ -16,6 +16,12 @@
 
 package org.javarosa.core.model.data;
 
+import org.javarosa.core.model.DataType;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Date;
+
 import static org.javarosa.core.model.DataType.BOOLEAN;
 import static org.javarosa.core.model.DataType.CHOICE;
 import static org.javarosa.core.model.DataType.DATE;
@@ -26,10 +32,6 @@ import static org.javarosa.core.model.DataType.INTEGER;
 import static org.javarosa.core.model.DataType.LONG;
 import static org.javarosa.core.model.DataType.MULTIPLE_ITEMS;
 import static org.javarosa.core.model.DataType.TIME;
-
-import java.util.Date;
-import org.javarosa.core.model.DataType;
-import org.javarosa.core.util.externalizable.Externalizable;
 
 /**
  * An IAnswerData object represents an answer to a question
@@ -128,6 +130,7 @@ public interface IAnswerData extends Externalizable {
      * @return The value of this answer, will never
      * be null
      */
+    @NotNull
     Object getValue ();       //will never be null
     /**
      * @return Gets a string representation of this

--- a/src/main/java/org/javarosa/core/model/data/IntegerData.java
+++ b/src/main/java/org/javarosa/core/model/data/IntegerData.java
@@ -16,13 +16,14 @@
 
 package org.javarosa.core.model.data;
 
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-
 import java.util.Objects;
-import org.javarosa.core.util.externalizable.ExtUtil;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 
 /**
@@ -59,7 +60,7 @@ public class IntegerData implements IAnswerData {
     }
 
     @Override
-    public Object getValue() {
+    public @NotNull Object getValue() {
         return n;
     }
 

--- a/src/main/java/org/javarosa/core/model/data/LongData.java
+++ b/src/main/java/org/javarosa/core/model/data/LongData.java
@@ -16,12 +16,13 @@
 
 package org.javarosa.core.model.data;
 
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-
-import org.javarosa.core.util.externalizable.ExtUtil;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 
 /**
@@ -58,7 +59,7 @@ public class LongData implements IAnswerData {
     }
 
     @Override
-    public Object getValue() {
+    public @NotNull Object getValue() {
         return n;
     }
 

--- a/src/main/java/org/javarosa/core/model/data/MultiPointerAnswerData.java
+++ b/src/main/java/org/javarosa/core/model/data/MultiPointerAnswerData.java
@@ -16,15 +16,16 @@
 
 package org.javarosa.core.model.data;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import org.javarosa.core.data.IDataPointer;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 
 /**
  * An answer data storing multiple pointers
@@ -59,7 +60,7 @@ public class MultiPointerAnswerData implements IAnswerData {
     }
 
     @Override
-    public Object getValue() {
+    public @NotNull Object getValue() {
         return data;
     }
 

--- a/src/main/java/org/javarosa/core/model/data/MultipleItemsData.java
+++ b/src/main/java/org/javarosa/core/model/data/MultipleItemsData.java
@@ -16,19 +16,20 @@
 
 package org.javarosa.core.model.data;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import java.util.Objects;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapList;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * A response to a question requesting a selection of
@@ -75,7 +76,7 @@ public class MultipleItemsData implements IAnswerData {
     }
 
     @Override
-    public Object getValue () {
+    public @NotNull Object getValue () {
         return new ArrayList<>(vs);
     }
 

--- a/src/main/java/org/javarosa/core/model/data/PointerAnswerData.java
+++ b/src/main/java/org/javarosa/core/model/data/PointerAnswerData.java
@@ -16,15 +16,16 @@
 
 package org.javarosa.core.model.data;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import org.javarosa.core.data.IDataPointer;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 
 /**
  * Answer data representing a pointer object.  The pointer is a reference to some
@@ -60,7 +61,7 @@ public class PointerAnswerData implements IAnswerData {
     }
 
     @Override
-    public Object getValue() {
+    public @NotNull Object getValue() {
         return data;
     }
 

--- a/src/main/java/org/javarosa/core/model/data/SelectOneData.java
+++ b/src/main/java/org/javarosa/core/model/data/SelectOneData.java
@@ -16,15 +16,16 @@
 
 package org.javarosa.core.model.data;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
-import java.util.Objects;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A response to a question requesting a selection
@@ -62,7 +63,7 @@ public class SelectOneData implements IAnswerData {
     }
 
     @Override
-    public Object getValue () {
+    public @NotNull Object getValue () {
         return s;
     }
 

--- a/src/main/java/org/javarosa/core/model/data/StringData.java
+++ b/src/main/java/org/javarosa/core/model/data/StringData.java
@@ -16,13 +16,14 @@
 
 package org.javarosa.core.model.data;
 
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-
 import java.util.Objects;
-import org.javarosa.core.util.externalizable.ExtUtil;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 /**
  * A response to a question requesting a String Value
@@ -59,7 +60,7 @@ public class StringData implements IAnswerData {
     }
 
     @Override
-    public Object getValue () {
+    public @NotNull Object getValue () {
         return s;
     }
 

--- a/src/main/java/org/javarosa/core/model/data/TimeData.java
+++ b/src/main/java/org/javarosa/core/model/data/TimeData.java
@@ -17,14 +17,15 @@
 package org.javarosa.core.model.data;
 
 
+import org.javarosa.core.model.utils.DateUtils;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Date;
-
-import org.javarosa.core.model.utils.DateUtils;
-import org.javarosa.core.util.externalizable.ExtUtil;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 public class TimeData implements IAnswerData {
     Date d;
@@ -55,7 +56,7 @@ public class TimeData implements IAnswerData {
     }
 
     @Override
-    public Object getValue () {
+    public @NotNull Object getValue () {
         return new Date(d.getTime());
     }
 

--- a/src/main/java/org/javarosa/core/model/data/UncastData.java
+++ b/src/main/java/org/javarosa/core/model/data/UncastData.java
@@ -1,11 +1,12 @@
 package org.javarosa.core.model.data;
 
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-
-import org.javarosa.core.util.externalizable.ExtUtil;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 /**
  * Uncast data values are those which are not assigned a particular
@@ -46,7 +47,7 @@ public class UncastData implements IAnswerData {
     }
 
     @Override
-    public Object getValue() {
+    public @NotNull Object getValue() {
         return value;
     }
 

--- a/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
@@ -16,9 +16,6 @@
 
 package org.javarosa.form.api;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
@@ -35,10 +32,15 @@ import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
-import org.slf4j.Logger; import org.slf4j.LoggerFactory;
 import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.core.util.UnregisteredLocaleException;
 import org.javarosa.formmanager.view.IQuestionWidget;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This class gives you all the information you need to display a question when
@@ -86,6 +88,7 @@ public class FormEntryPrompt extends FormEntryCaption {
     }
 
     //note: code overlap with FormDef.copyItemsetAnswer
+    @Nullable
     public IAnswerData getAnswerValue() {
         QuestionDef q = getQuestion();
 


### PR DESCRIPTION
While working on the Select One From Map widget in Collect I ran into some frustrating cases where I didn't get warnings/compile errors around nullable values. These annotations help with every kind of question, but I specifically targeted problems I ran into when working with select questions.

#### What has been done to verify that this works as intended?

Used `installLocal` to verify that I saw the right errors and smart cast highlights in Collect (specifically in Kotlin).

#### Why is this the best possible solution? Were any other approaches considered?

I could have converted the code to Kotlin... but this felt like a lighter touch for the moment.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No changes to check here. Just adds information for editors/compilers using JavaRosa.
