### PR TITLE
Trigger xforms-value-changed after recomputation

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -394,12 +394,13 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         setAnswer(data, node);
 
         QuestionDef currentQuestion = findQuestionByRef(ref, this);
+
+        Collection<QuickTriggerable> qts = triggerTriggerables(ref);
+
         if (valueChanged && currentQuestion != null) {
             currentQuestion.getActionController().triggerActionsFromEvent(Actions.EVENT_QUESTION_VALUE_CHANGED, this,
                 ref.getParentRef(), null);
         }
-
-        Collection<QuickTriggerable> qts = triggerTriggerables(ref);
         dagImpl.publishSummary("New value", ref, qts);
         // TODO: pre-populate fix-count repeats here?
     }

--- a/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
@@ -258,4 +258,28 @@ public class SetValueActionTest {
         assertThat(scenario.answerOf("/data/destination1"), is(intAnswer(7)));
         assertThat(scenario.answerOf("/data/destination2"), is(intAnswer(11)));
     }
+
+    @Test
+    public void xformsValueChanged_triggeredAfterRecomputation() throws IOException {
+        Scenario scenario = Scenario.init("xforms-value-changed-event", html(
+            head(
+                title("Value changed event"),
+                model(
+                    mainInstance(t("data id=\"xforms-value-changed-event\"",
+                        t("source"),
+                        t("calculate"),
+                        t("destination")
+                    )),
+                    bind("/data/calculate").type("int").calculate("/data/source * 2"),
+                    bind("/data/destination").type("int")
+                )
+            ),
+            body(
+                input("/data/source",
+                    setvalue("xforms-value-changed", "/data/destination", "/data/calculate")
+            ))));
+
+        scenario.answer("/data/source", 12);
+        assertThat(scenario.answerOf("/data/destination"), is(intAnswer(24)));
+    }
 }


### PR DESCRIPTION
Closes #668

#### What has been done to verify that this works as intended?
Tests.

#### Why is this the best possible solution? Were any other approaches considered?
I don't see any alternatives without a big change in the structure of the code.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think this is low risk? It is a change in behavior but I don't think the current behavior is usable.

#### Do we need any specific form for testing your changes? If so, please attach one.
In [this form](https://docs.google.com/spreadsheets/d/1ZFE7aLMrQ7FJ8kjH1oN-41p8EsYGTA4Rpo82RFGl92k/edit#gid=0), change the triggered calculations for the text fields to use `point_name` and `point_type`.