### PR TITLE
Increase robustness of geojson parsing by allowing extra properties and null values

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
+++ b/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
@@ -47,7 +47,11 @@ public class GeojsonFeature {
         if (properties != null) {
             for (String property : properties.keySet()) {
                 TreeElement field = new TreeElement(property, 0);
-                field.setValue(new UncastData(properties.get(property)));
+                if (properties.get(property) != null) {
+                    field.setValue(new UncastData(properties.get(property)));
+                } else {
+                    field.setValue(new UncastData(""));
+                }
                 item.addChild(field);
             }
         }

--- a/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
@@ -146,8 +146,8 @@ public class GeoJsonExternalInstanceTest {
     }
 
     @Test
-    public void parse_allowsNulls() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-with-nulls.geojson").toString());
+    public void parse_allowsNullFeaturePropertyValues() throws IOException {
+        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-with-null.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
         assertThat(featureCollection.getChildAt(0).getChild("extra", 0).getValue().getDisplayText(), is(""));
     }

--- a/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
@@ -144,4 +144,11 @@ public class GeoJsonExternalInstanceTest {
             // expected
         }
     }
+
+    @Test
+    public void parse_allowsNulls() throws IOException {
+        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-with-nulls.geojson").toString());
+        assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
+        assertThat(featureCollection.getChildAt(0).getChild("extra", 0).getValue().getDisplayText(), is(""));
+    }
 }

--- a/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
@@ -48,6 +48,18 @@ public class GeoJsonExternalInstanceTest {
     }
 
     @Test
+    public void parse_ignoresExtraTopLevelProperties() throws IOException {
+        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-extra-toplevel.geojson").toString());
+        assertThat(featureCollection.getChildAt(0).getNumChildren(), is(3));
+    }
+
+    @Test
+    public void parse_acceptsAnyToplevelPropertyOrder() throws IOException {
+        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-toplevel-order.geojson").toString());
+        assertThat(featureCollection.getChildAt(0).getNumChildren(), is(3));
+    }
+
+    @Test
     public void parse_throwsException_ifNoFeaturesArray() {
         try {
             GeoJsonExternalInstance.parse("id", r("bad-futures-collection.geojson").toString());
@@ -112,7 +124,7 @@ public class GeoJsonExternalInstanceTest {
 
     @Test
     public void parse_ignoresUnknownToplevelProperties() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-extra-toplevel.geojson").toString());
+        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-extra-feature-toplevel.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(3));
         assertThat(featureCollection.getChildAt(0).getChild("ignored", 0), nullValue());
     }

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-extra-feature-toplevel.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-extra-feature-toplevel.geojson
@@ -1,0 +1,22 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    102,
+                    0.5
+                ]
+            },
+
+            "ignored": "ignored",
+
+            "properties": {
+                "id": "fs87b",
+                "title": "My cool point"
+            }
+        }
+    ]
+}

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-extra-toplevel.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-extra-toplevel.geojson
@@ -1,8 +1,26 @@
 {
     "type": "FeatureCollection",
     "name": "things_with_layer_attributes",
-    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+    "ignored": {
+        "type": "name",
+        "properties": {
+            "name": "urn:ogc:def:crs:OGC:1.3:CRS84"
+        }
+    },
     "features": [
-        { "type": "Feature", "properties": { "gid": 1, "visited": "yes" }, "geometry": { "type": "Point", "coordinates": [ 130.559803472160752, 31.580360584438704 ] } }
+        {
+            "type": "Feature",
+            "properties": {
+                "gid": 1,
+                "visited": "yes"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    130.559803472160752,
+                    31.580360584438704
+                ]
+            }
+        }
     ]
 }

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-toplevel-order.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-toplevel-order.geojson
@@ -1,8 +1,8 @@
 {
-    "type": "FeatureCollection",
-    "name": "things_with_layer_attributes",
-    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
     "features": [
         { "type": "Feature", "properties": { "gid": 1, "visited": "yes" }, "geometry": { "type": "Point", "coordinates": [ 130.559803472160752, 31.580360584438704 ] } }
-    ]
+    ],
+    "name": "things_with_layer_attributes",
+    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+    "type": "FeatureCollection"
 }

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-with-null.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-with-null.geojson
@@ -1,10 +1,12 @@
 {
+    "type": "FeatureCollection",
     "features": [
         {
             "type": "Feature",
             "properties": {
                 "gid": 1,
-                "visited": "yes"
+                "visited": "yes",
+                "extra": null
             },
             "geometry": {
                 "type": "Point",
@@ -14,13 +16,5 @@
                 ]
             }
         }
-    ],
-    "name": "things_with_layer_attributes",
-    "ignored": {
-        "type": "name",
-        "properties": {
-            "name": "urn:ogc:def:crs:OGC:1.3:CRS84"
-        }
-    },
-    "type": "FeatureCollection"
+    ]
 }

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-with-nulls.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-with-nulls.geojson
@@ -1,7 +1,0 @@
-{
-    "type": "FeatureCollection",
-    "extra": null,
-    "features": [
-        { "type": "Feature", "properties": { "gid": 1, "visited": "yes", "extra": null }, "geometry": { "type": "Point", "coordinates": [ 130.559803472160752, 31.580360584438704 ] } }
-    ]
-}

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-with-nulls.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/feature-collection-with-nulls.geojson
@@ -1,0 +1,7 @@
+{
+    "type": "FeatureCollection",
+    "extra": null,
+    "features": [
+        { "type": "Feature", "properties": { "gid": 1, "visited": "yes", "extra": null }, "geometry": { "type": "Point", "coordinates": [ 130.559803472160752, 31.580360584438704 ] } }
+    ]
+}


### PR DESCRIPTION
Closes issues described on forum starting [here](https://forum.getodk.org/t/odk-collect-v2022-2-beta-select-from-map-geojson-datasets/36913/17?u=ln). The existing code naively assumed that the geojson top level object would have just a `type` followed by `features` in that order and with no other properties.

#### What has been done to verify that this works as intended?
Added tests based on forum reports. Note that the test case provided includes another nested property with name `type` which was a really good inclusion. One thing to think about in review is whether there are other tricky structures like that which we should test for.

#### Why is this the best possible solution? Were any other approaches considered?
I briefly considered using an `ObjectMapper` instead of the parser. But I do think it's better to be able to stream the parsing. I think this is much more robust but it's possible there are still cases I haven't thought of.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This does change the geojson parsing strategy quite a bit so there's risk. Our test coverage is good, though, so I don't think it's high.

#### Do we need any specific form for testing your changes? If so, please attach one.
See tests.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.
