### PR TITLE
Stop HTML encoding unicode characters when serializing XForm

### DIFF
--- a/src/main/java/org/javarosa/xform/util/XFormSerializer.java
+++ b/src/main/java/org/javarosa/xform/util/XFormSerializer.java
@@ -19,14 +19,13 @@ package org.javarosa.xform.util;
 import org.kxml2.io.KXmlSerializer;
 import org.kxml2.kdom.Document;
 import org.kxml2.kdom.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
-import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
-import java.io.Writer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.nio.charset.StandardCharsets;
 
 /* this is just a big dump of serialization-related code */
 
@@ -88,8 +87,7 @@ public class XFormSerializer {
         KXmlSerializer serializer = new KXmlSerializer();
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try {
-            Writer osw = new OutputStreamWriter(bos, "UTF-8");
-            serializer.setOutput(osw);
+            serializer.setOutput(bos, StandardCharsets.UTF_8.name());
             doc.write(serializer);
             serializer.flush();
             return bos.toByteArray();

--- a/src/test/java/org/javarosa/model/xform/XFormSerializingVisitorTest.java
+++ b/src/test/java/org/javarosa/model/xform/XFormSerializingVisitorTest.java
@@ -1,0 +1,46 @@
+package org.javarosa.model.xform;
+
+import org.javarosa.core.test.Scenario;
+import org.javarosa.core.util.XFormsElement;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
+import static org.javarosa.core.util.XFormsElement.body;
+import static org.javarosa.core.util.XFormsElement.head;
+import static org.javarosa.core.util.XFormsElement.html;
+import static org.javarosa.core.util.XFormsElement.input;
+import static org.javarosa.core.util.XFormsElement.mainInstance;
+import static org.javarosa.core.util.XFormsElement.model;
+import static org.javarosa.core.util.XFormsElement.t;
+import static org.javarosa.core.util.XFormsElement.title;
+
+public class XFormSerializingVisitorTest {
+
+    @Test
+    public void serializeInstance_preservesUnicodeCharacters() throws IOException {
+        XFormsElement formDef = html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("text")
+                    )),
+                    bind("/data/text").type("string")
+                )
+            ),
+            body(input("/data/text"))
+        );
+
+        Scenario scenario = Scenario.init("Some form", formDef);
+        scenario.next();
+        scenario.answer("\uD83E\uDDDB");
+
+        XFormSerializingVisitor visitor = new XFormSerializingVisitor();
+        byte[] serializedInstance = visitor.serializeInstance(scenario.getFormDef().getMainInstance());
+        assertThat(new String(serializedInstance), containsString("<text>\uD83E\uDDDB</text>"));
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getodk/collect/issues/4554

#### What has been done to verify that this works as intended?

New test and verified it fixed the issue using Collect.

#### Why is this the best possible solution? Were any other approaches considered?

We could attempt to only stop HTML encoding for `formid` and `version`, but that would actually be more difficult as we'd have to change the way we serialize - `KXmlSerializer` only allows us to switch Unicode escaping on or off for the whole document (based on the desired output encoding). This solution also removes weirdness with Emoji (and other high digit Unciode characters) being encoded to two HTML characters which causes problems downstream for Central.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

People doing analysis on submission XML directly will be affected as they might expect HTML encoded files (although this wasn't the case for Enketo submissions anyway). There could be other unforeseen consequences, so I'd advocate for us getting this into an early Collect beta and then announcing the change on the forum.

#### Do we need any specific form for testing your changes? If so, please attach one.

Any form that has Unicode characters anywhere and also submissions that include Unicode characters (like an Emoji in a text question)
