### PR TITLE
Fix namespaced TreeElements

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import java.util.Objects;
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormElementStateListener;
@@ -36,6 +37,7 @@ import org.javarosa.core.model.instance.utils.DefaultAnswerResolver;
 import org.javarosa.core.model.instance.utils.IAnswerResolver;
 import org.javarosa.core.model.instance.utils.ITreeVisitor;
 import org.javarosa.core.model.instance.utils.TreeElementChildrenList;
+import org.javarosa.core.model.instance.utils.TreeElementNameComparator;
 import org.javarosa.core.model.util.restorable.RestoreUtils;
 import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -137,7 +139,7 @@ import org.jetbrains.annotations.Nullable;
     public static TreeElement constructAttributeElement(String namespace, String name, String value) {
         TreeElement element = new TreeElement(name);
         element.setIsAttribute(true);
-        element.namespace = (namespace == null) ? "" : namespace;
+        element.namespace = namespace;
         element.multiplicity = TreeReference.INDEX_ATTRIBUTE;
         element.value = new UncastData(value);
         return element;
@@ -161,8 +163,15 @@ import org.jetbrains.annotations.Nullable;
      */
     public static TreeElement getAttribute(List<TreeElement> attributes, String namespace, String name) {
         for (TreeElement attribute : attributes) {
-            if(attribute.getName().equals(name) && (namespace == null || namespace.equals(attribute.namespace))) {
-                return attribute;
+            if (name.contains(":")) {
+                if (TreeElementNameComparator.elementMatchesName(attribute, name)) {
+                    return attribute;
+                }
+            } else {
+                if (attribute.getName().equals(name) && (Objects.equals(namespace, attribute.namespace)
+                    || (Objects.equals(attribute.namespace, "") && namespace == null))) {
+                    return attribute;
+                }
             }
         }
         return null;

--- a/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -127,19 +127,15 @@ import org.jetbrains.annotations.Nullable;
         attributes = new ArrayList<TreeElement>(0);
     }
 
-    /**
-     * Construct a TreeElement which represents an attribute with the provided
-     * namespace and name.
-     *
-     * @param namespace - if null will be converted to empty string
-     * @param name
-     * @param value
-     * @return A new instance of a TreeElement
-     */
     public static TreeElement constructAttributeElement(String namespace, String name, String value) {
+        return constructAttributeElement(namespace, null, name, value);
+    }
+
+    public static TreeElement constructAttributeElement(String namespace, String namespacePrefix, String name, String value) {
         TreeElement element = new TreeElement(name);
         element.setIsAttribute(true);
-        element.namespace = namespace;
+        element.setNamespace(namespace);
+        element.setNamespacePrefix(namespacePrefix);
         element.multiplicity = TreeReference.INDEX_ATTRIBUTE;
         element.value = new UncastData(value);
         return element;
@@ -176,9 +172,11 @@ import org.jetbrains.annotations.Nullable;
         }
         return null;
     }
-
     public static void setAttribute(TreeElement parent, List<TreeElement> attrs, String namespace, String name, String value) {
+        setAttribute(parent, attrs, namespace, null, name, value);
+    }
 
+    public static void setAttribute(TreeElement parent, List<TreeElement> attrs, String namespace, String namespacePrefix, String name, String value) {
         TreeElement attribut = getAttribute(attrs, namespace, name);
         if ( attribut != null ) {
             if (value == null) {
@@ -193,7 +191,7 @@ import org.jetbrains.annotations.Nullable;
         if ( value == null ) return;
 
         // create an attribute...
-        TreeElement attr = TreeElement.constructAttributeElement(namespace, name, value);
+        TreeElement attr = TreeElement.constructAttributeElement(namespace, namespacePrefix, name, value);
         attr.setParent(parent);
 
         attrs.add(attr);
@@ -349,7 +347,7 @@ import org.jetbrains.annotations.Nullable;
 
         newNode.attributes = new ArrayList<>(attributes.size());
         for (TreeElement attr : attributes) {
-            newNode.setAttribute(attr.getNamespace(), attr.getName(), attr.getAttributeValue());
+            newNode.setAttribute(attr.getNamespace(), attr.getNamespacePrefix(), attr.getName(), attr.getAttributeValue());
         }
 
         if (value != null) {
@@ -446,7 +444,7 @@ import org.jetbrains.annotations.Nullable;
     public void setBindAttributes(List<TreeElement> bindAttributes ) {
         // create new tree elements for all the bind definitions...
         for ( TreeElement ref : bindAttributes ) {
-            setBindAttribute(ref.getNamespace(), ref.getName(), ref.getAttributeValue());
+            setBindAttribute(ref.getNamespace(), ref.getNamespacePrefix(), ref.getName(), ref.getAttributeValue());
         }
     }
 
@@ -485,8 +483,8 @@ import org.jetbrains.annotations.Nullable;
         return element == null ? null: getAttributeValue(element);
     }
 
-    public void setBindAttribute(String namespace, String name, String value) {
-        setAttribute(this, bindAttributes, namespace, name, value);
+    public void setBindAttribute(String namespace, String namespacePrefix, String name, String value) {
+        setAttribute(this, bindAttributes, namespace, namespacePrefix, name, value);
     }
 
     public void setEnabled(boolean enabled) {
@@ -565,6 +563,10 @@ import org.jetbrains.annotations.Nullable;
         return attributes.get(index).namespace;
     }
 
+    public String getAttributeNamespacePrefix(int index) {
+        return attributes.get(index).namespacePrefix;
+    }
+
     @Override
     public String getAttributeName(int index) {
         return attributes.get(index).name;
@@ -609,6 +611,10 @@ import org.jetbrains.annotations.Nullable;
 
     public void setAttribute(String namespace, String name, String value) {
         setAttribute(this, attributes, namespace, name, value);
+    }
+
+    public void setAttribute(String namespace, String namespacePrefix, String name, String value) {
+        setAttribute(this, attributes, namespace, namespacePrefix, name, value);
     }
 
     /* ==== SERIALIZATION ==== */
@@ -841,9 +847,10 @@ import org.jetbrains.annotations.Nullable;
         for (int i = 0; i < incoming.getAttributeCount(); i++) {
             String name = incoming.getAttributeName(i);
             String ns = incoming.getAttributeNamespace(i);
+            String nsPrefix = incoming.getAttributeNamespacePrefix(i);
             String value = incoming.getAttributeValue(i);
 
-            this.setAttribute(ns, name, value);
+            this.setAttribute(ns, nsPrefix, name, value);
         }
     }
 

--- a/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -677,6 +677,8 @@ import org.jetbrains.annotations.Nullable;
         bindAttributes = ExtUtil.readAttributes(in, this);
 
         attributes = ExtUtil.readAttributes(in, this);
+
+        namespacePrefix = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
     }
 
     @Override
@@ -731,6 +733,8 @@ import org.jetbrains.annotations.Nullable;
         ExtUtil.writeAttributes(out, bindAttributes);
 
         ExtUtil.writeAttributes(out, attributes);
+
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(namespacePrefix));
     }
 
     //rebuilding a node from an imported instance

--- a/src/main/java/org/javarosa/core/model/instance/utils/TreeElementChildrenList.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/TreeElementChildrenList.java
@@ -1,14 +1,13 @@
 package org.javarosa.core.model.instance.utils;
 
-import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.core.model.instance.TreeReference;
-import org.jetbrains.annotations.Nullable;
+import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import static org.javarosa.core.model.instance.TreeReference.DEFAULT_MULTIPLICITY;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.TreeReference;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A collection of {@link TreeElement} children. They are stored in an {@link ArrayList}.
@@ -100,7 +99,7 @@ public class TreeElementChildrenList implements Iterable<TreeElement> {
      */
     private boolean sameNameAndNormalMult(String name, int mult) {
         return allHaveSameNameAndNormalMult && mult >= 0 &&
-                (children.isEmpty() || name.equals(children.get(0).getName()));
+            (children.isEmpty() || TreeElementNameComparator.elementMatchesName(children.get(0), name));
     }
 
     /**
@@ -190,7 +189,7 @@ public class TreeElementChildrenList implements Iterable<TreeElement> {
 
         for (int i = 0; i < children.size(); i++) {
             TreeElement child = children.get(i);
-            if (name.equals(child.getName()) && child.getMult() == multiplicity) {
+            if (TreeElementNameComparator.elementMatchesName(child, name) && child.getMult() == multiplicity) {
                 return new ElementAndLoc(child, i);
             }
         }

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -16,6 +16,48 @@
 
 package org.javarosa.xform.parse;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+import static org.javarosa.core.model.Constants.CONTROL_AUDIO_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_FILE_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_IMAGE_CHOOSE;
+import static org.javarosa.core.model.Constants.CONTROL_INPUT;
+import static org.javarosa.core.model.Constants.CONTROL_OSM_CAPTURE;
+import static org.javarosa.core.model.Constants.CONTROL_RANGE;
+import static org.javarosa.core.model.Constants.CONTROL_RANK;
+import static org.javarosa.core.model.Constants.CONTROL_SECRET;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_MULTI;
+import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
+import static org.javarosa.core.model.Constants.CONTROL_TRIGGER;
+import static org.javarosa.core.model.Constants.CONTROL_UPLOAD;
+import static org.javarosa.core.model.Constants.CONTROL_VIDEO_CAPTURE;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
+import static org.javarosa.core.model.Constants.DATATYPE_MULTIPLE_ITEMS;
+import static org.javarosa.core.model.Constants.XFTAG_UPLOAD;
+import static org.javarosa.core.services.ProgramFlow.die;
+import static org.javarosa.xform.parse.Constants.ID_ATTR;
+import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
+import static org.javarosa.xform.parse.Constants.RANK;
+import static org.javarosa.xform.parse.Constants.SELECT;
+import static org.javarosa.xform.parse.Constants.SELECTONE;
+import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
+import static org.javarosa.xform.parse.RandomizeHelper.cleanSeedDefinition;
+import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import kotlin.Pair;
 import org.javarosa.core.model.DataBinding;
 import org.javarosa.core.model.FormDef;
@@ -72,49 +114,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableSet;
-import static org.javarosa.core.model.Constants.CONTROL_AUDIO_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_FILE_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_IMAGE_CHOOSE;
-import static org.javarosa.core.model.Constants.CONTROL_INPUT;
-import static org.javarosa.core.model.Constants.CONTROL_OSM_CAPTURE;
-import static org.javarosa.core.model.Constants.CONTROL_RANGE;
-import static org.javarosa.core.model.Constants.CONTROL_RANK;
-import static org.javarosa.core.model.Constants.CONTROL_SECRET;
-import static org.javarosa.core.model.Constants.CONTROL_SELECT_MULTI;
-import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
-import static org.javarosa.core.model.Constants.CONTROL_TRIGGER;
-import static org.javarosa.core.model.Constants.CONTROL_UPLOAD;
-import static org.javarosa.core.model.Constants.CONTROL_VIDEO_CAPTURE;
-import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
-import static org.javarosa.core.model.Constants.DATATYPE_MULTIPLE_ITEMS;
-import static org.javarosa.core.model.Constants.XFTAG_UPLOAD;
-import static org.javarosa.core.services.ProgramFlow.die;
-import static org.javarosa.xform.parse.Constants.ID_ATTR;
-import static org.javarosa.xform.parse.Constants.NODESET_ATTR;
-import static org.javarosa.xform.parse.Constants.RANK;
-import static org.javarosa.xform.parse.Constants.SELECT;
-import static org.javarosa.xform.parse.Constants.SELECTONE;
-import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
-import static org.javarosa.xform.parse.RandomizeHelper.cleanSeedDefinition;
-import static org.javarosa.xform.parse.RangeParser.populateQuestionWithRangeAttributes;
 
 /* droos: i think we need to start storing the contents of the <bind>s in the formdef again */
 
@@ -2108,6 +2107,7 @@ public class XFormParser implements IXFormParserFunctions {
         if (node.getAttributeCount() > 0) {
             for (int i = 0; i < node.getAttributeCount(); i++) {
                 String attrNamespace = node.getAttributeNamespace(i);
+                String attrNamespacePrefix = namespacePrefixesByUri.get(attrNamespace);
                 String attrName = node.getAttributeName(i);
                 if (attrNamespace.equals(NAMESPACE_JAVAROSA) && attrName.equals("template")) {
                     continue;
@@ -2116,7 +2116,7 @@ public class XFormParser implements IXFormParserFunctions {
                     continue;
                 }
 
-                element.setAttribute(attrNamespace, attrName, node.getAttributeValue(i));
+                element.setAttribute(attrNamespace, attrNamespacePrefix, attrName, node.getAttributeValue(i));
             }
         }
 

--- a/src/test/java/org/javarosa/core/model/instance/TreeElementNamespacedTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeElementNamespacedTest.java
@@ -3,6 +3,7 @@ package org.javarosa.core.model.instance;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.model.instance.TreeReference.INDEX_ATTRIBUTE;
 import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
 import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
 import static org.javarosa.core.util.XFormsElement.body;
@@ -68,5 +69,52 @@ public class TreeElementNamespacedTest {
         Scenario cachedScenario = scenario.serializeAndDeserializeForm();
 
         assertThat(cachedScenario.answerOf("/data/example:calculate"), is(stringAnswer("foo")));
+    }
+
+    @Test
+    public void getAttribute_getsNamespacedAttribute() {
+        TreeElement e1 = new TreeElement("a", INDEX_ATTRIBUTE);
+        TreeElement e2 = new TreeElement("a", INDEX_ATTRIBUTE);
+        e2.setNamespace("https://fake.fake");
+        e2.setNamespacePrefix("example");
+        TreeElement result = TreeElement.getAttribute(asList(e1, e2), "https://fake.fake", "a");
+
+        assertThat(result, is(e2));
+    }
+
+    @Test
+    // This is what happens when evaluating an XPath expression
+    public void getAttribute_getsNamespacedAttribute_usingPrefix() {
+        TreeElement e1 = new TreeElement("a", INDEX_ATTRIBUTE);
+        TreeElement e2 = new TreeElement("a", INDEX_ATTRIBUTE);
+        e2.setNamespace("https://fake.fake");
+        e2.setNamespacePrefix("example");
+        TreeElement result = TreeElement.getAttribute(asList(e1, e2), null, "example:a");
+
+        assertThat(result, is(e2));
+    }
+
+    @Test
+    public void getAttribute_getsDefaultNamespaceAttribute() {
+        TreeElement e1 = new TreeElement("a", INDEX_ATTRIBUTE);
+        e1.setNamespace("https://fake.fake");
+        e1.setNamespacePrefix("example");
+        TreeElement e2 = new TreeElement("a", INDEX_ATTRIBUTE);
+        TreeElement result = TreeElement.getAttribute(asList(e1, e2), null, "a");
+
+        assertThat(result, is(e2));
+    }
+
+    @Test
+    // Attributes in the main instance without a custom namespace have empty string namespace
+    public void getAttribute_getsDefaultNamespaceAttribute_withBlankNamespace() {
+        TreeElement e1 = new TreeElement("a", INDEX_ATTRIBUTE);
+        e1.setNamespace("https://fake.fake");
+        e1.setNamespacePrefix("example");
+        TreeElement e2 = new TreeElement("a", INDEX_ATTRIBUTE);
+        e2.setNamespace("");
+        TreeElement result = TreeElement.getAttribute(asList(e1, e2), null, "a");
+
+        assertThat(result, is(e2));
     }
 }

--- a/src/test/java/org/javarosa/core/model/instance/TreeElementNamespacedTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeElementNamespacedTest.java
@@ -17,6 +17,7 @@ import static org.javarosa.core.util.XFormsElement.title;
 import java.io.IOException;
 import kotlin.Pair;
 import org.javarosa.core.test.Scenario;
+import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.xform.parse.XFormParser;
 import org.junit.Test;
 
@@ -24,10 +25,10 @@ public class TreeElementNamespacedTest {
 
     @Test
     public void namespacedElement_canBeQueried() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Entity creation", html(
+        Scenario scenario = Scenario.init("Namespaced element", html(
             asList(new Pair<>("example", "http://example.fake")),
             head(
-                title("Entity creation"),
+                title("Namespaced element"),
                 model(
                     mainInstance(t("data id=\"entity-creation\"",
                         t("question"),
@@ -42,5 +43,30 @@ public class TreeElementNamespacedTest {
 
         scenario.answer("/data/question", "foo");
         assertThat(scenario.answerOf("/data/example:calculate"), is(stringAnswer("foo")));
+    }
+
+    @Test
+    public void namespacedElement_canBeQueried_afterSerializationDeserialization() throws IOException, XFormParser.ParseException, DeserializationException {
+        Scenario scenario = Scenario.init("Namespaced element", html(
+            asList(new Pair<>("example", "http://example.fake")),
+            head(
+                title("Namespaced element"),
+                model(
+                    mainInstance(t("data id=\"entity-creation\"",
+                        t("question"),
+                        t("example:calculate")
+                    )),
+                    bind("/data/example:calculate").calculate("/data/question")
+                )
+            ),
+            body(
+                input("/data/question")
+            )));
+
+        scenario.answer("/data/question", "foo");
+
+        Scenario cachedScenario = scenario.serializeAndDeserializeForm();
+
+        assertThat(cachedScenario.answerOf("/data/example:calculate"), is(stringAnswer("foo")));
     }
 }

--- a/src/test/java/org/javarosa/core/model/instance/TreeElementNamespacedTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeElementNamespacedTest.java
@@ -1,0 +1,46 @@
+package org.javarosa.core.model.instance;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
+import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
+import static org.javarosa.core.util.XFormsElement.body;
+import static org.javarosa.core.util.XFormsElement.head;
+import static org.javarosa.core.util.XFormsElement.html;
+import static org.javarosa.core.util.XFormsElement.input;
+import static org.javarosa.core.util.XFormsElement.mainInstance;
+import static org.javarosa.core.util.XFormsElement.model;
+import static org.javarosa.core.util.XFormsElement.t;
+import static org.javarosa.core.util.XFormsElement.title;
+
+import java.io.IOException;
+import kotlin.Pair;
+import org.javarosa.core.test.Scenario;
+import org.javarosa.xform.parse.XFormParser;
+import org.junit.Test;
+
+public class TreeElementNamespacedTest {
+
+    @Test
+    public void namespacedElement_canBeQueried() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Entity creation", html(
+            asList(new Pair<>("example", "http://example.fake")),
+            head(
+                title("Entity creation"),
+                model(
+                    mainInstance(t("data id=\"entity-creation\"",
+                        t("question"),
+                        t("example:calculate")
+                    )),
+                    bind("/data/example:calculate").calculate("/data/question")
+                )
+            ),
+            body(
+                input("/data/question")
+            )));
+
+        scenario.answer("/data/question", "foo");
+        assertThat(scenario.answerOf("/data/example:calculate"), is(stringAnswer("foo")));
+    }
+}

--- a/src/test/java/org/javarosa/core/model/instance/TreeElementNamespacedTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeElementNamespacedTest.java
@@ -117,4 +117,46 @@ public class TreeElementNamespacedTest {
 
         assertThat(result, is(e2));
     }
+
+    @Test
+    public void pathExpressionWithNamespacedAttribute_selectsCorrectAttribute() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Attr", html(
+            asList(new Pair<>("example", "http://example.fake")),
+            head(
+                title("Attr"),
+                model(
+                    mainInstance(t("data id=\"attr\"",
+                        t("question example:a=\"b\" a=\"c\"")
+                    ))
+                )
+            ),
+            body(
+                input("/data/question")
+            )));
+
+        assertThat(scenario.answerOf("/data/question/@a").getDisplayText(), is("c"));
+        assertThat(scenario.answerOf("/data/question/@example:a").getDisplayText(), is("b"));
+    }
+
+    @Test
+    public void pathExpressionWithNamespacedAttribute_selectsCorrectAttribute_afterSerializationDeserialization() throws IOException, XFormParser.ParseException, DeserializationException {
+        Scenario scenario = Scenario.init("Attr", html(
+            asList(new Pair<>("example", "http://example.fake")),
+            head(
+                title("Attr"),
+                model(
+                    mainInstance(t("data id=\"attr\"",
+                        t("question example:a=\"b\" a=\"c\"")
+                    ))
+                )
+            ),
+            body(
+                input("/data/question")
+            )));
+
+        scenario.serializeAndDeserializeForm();
+
+        assertThat(scenario.answerOf("/data/question/@a").getDisplayText(), is("c"));
+        assertThat(scenario.answerOf("/data/question/@example:a").getDisplayText(), is("b"));
+    }
 }

--- a/src/test/java/org/javarosa/core/model/instance/test/TreeElementTests.java
+++ b/src/test/java/org/javarosa/core/model/instance/test/TreeElementTests.java
@@ -50,7 +50,7 @@ public class TreeElementTests {
 
         assertEquals("regular_group", regularGroup.getName());
         assertEquals(1, regularGroup.getAttributeCount());
-        customAttr1 = regularGroup.getAttribute(null, "custom_attr_1");
+        customAttr1 = regularGroup.getAttribute("custom_name_space", "custom_attr_1");
         assertNotNull(customAttr1);
         assertEquals("custom_attr_1", customAttr1.getName());
         assertEquals("custom_name_space", customAttr1.getNamespace());


### PR DESCRIPTION
Closes #695 and fixes some additional issues I discovered around path expressions with namespaced nodes. I considered breaking these up into multiple PRs but they feel easier to understand together. If any single commit feels riskier or harder to understand, I can separate it out.

#### What has been done to verify that this works as intended?

Added a test for each of the fixes, ran the whole test suite. Have NOT tried in Collect yet.

#### Why is this the best possible solution? Were any other approaches considered?

The first commit fixes an issue with XPath path expressions that have namespace prefixes in them. In some case, the namespace prefix was not being considered correctly. The history there is that https://github.com/getodk/javarosa/pull/153/files added support for namespaced instance elements. Either that was incomplete or later performance-related changes broke this (related to https://github.com/getodk/javarosa/pull/192). I didn't see any alternatives here and it feels safe to me.

The second commit fixes the original issue. After deserialization, there was no record of the namespace prefix. I was initially confused because #155 added testing related to serialization as discussed at https://github.com/getodk/javarosa/pull/153#issuecomment-316678155 but after closer inspection I realized we had a misunderstanding about which serialization. The test verifies serializing the instance to XML, not caching the form definition. I saw two options to fix this: serialize the namespace prefix or serialize a map from prefix to namespace. I went with serializing the namespace prefix for each node. There's potential for redundancy but I don't expect namespaced instance nodes to be very common and we can revisit if we think it's worth taking on extra complexity. This also feels safe to me.

After fixing the first issue, I went looking for other comparisons against `TreeElement` names that might cause issues. I noticed that there were problems around attributes.

In the third commit, I added testing for `getAttribute`. I also discovered an existing test with a bad assertion that would have caught the issue I was noticing. Things got a little awkward here. `getAttribute` gets called by parsing code which wants to get attributes according to well-known node names and namespaces. But it also gets called when evaluating XPath path expressions. In that case, the namespace prefix and the node name are passed in and the namespace is always null. I considered breaking up those two cases but I wasn't confident enough that I could identify exactly when each case would be needed. Even though it's not very pretty, it feels safer to me to keep the existing single method with two cases. As it is now, this feels low risk but maybe a bit higher risk than the others. Another thing I found out doing this work is that when attributes on instance elements are in the default namespace, they're set to an empty string rather than `null`. I couldn't find where that happened so I added an explicit `|| (Objects.equals(attribute.namespace, "") && namespace == null)` case for that. Again, not the prettiest but it has the advantage of being explicit and relatively easy to verify.

Finally, it occurred to me to write a test to get the value of a namespaced attribute on an instance element. That was not working either. That's because the namespace prefix was not being saved on attribute `TreeElement`s. I was tempted to get into some deeper refactoring here but didn't. I kept the existing method signatures and made my changes additive except for `setBindAttribute` which really feels like an internal implementation detail. I think there's some risk here that the fix is incomplete.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

All intentional changes are bug fixes as described above and by the tests. I overall feel like this is additive and pretty low risk. That said, if people are using custom namespaces and attributes in their forms, I could imagine some changes in behavior or regressions. This also does touch some broadly-used things like bind attributes. There's also always a bit of risk when touching serialization.

#### Do we need any specific form for testing your changes? If so, please attach one.

See tests.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No.
