### PR TITLE
Add tests for automatically giving values to attributes

### DIFF
--- a/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
@@ -497,4 +497,47 @@ public class SetValueActionTest {
         scenario.answer("/data/source", 12);
         assertThat(scenario.answerOf("/data/destination"), is(intAnswer(24)));
     }
+
+    @Test
+    public void setvalue_setsValueOfAttribute() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Setvalue attribute", html(
+            head(
+                title("Setvalue attribute"),
+                model(
+                    mainInstance(t("data id=\"setvalue-attribute\"",
+                        t("element attr=\"\"")
+                    )),
+                    setvalue("odk-instance-first-load", "/data/element/@attr", "7")
+                )
+            ),
+            body(
+                input("/data/element")
+            )));
+
+        assertThat(scenario.answerOf("/data/element/@attr").getDisplayText(), is("7"));
+    }
+
+    @Test
+    public void setvalue_setsValueOfAttribute_afterDeserialization() throws IOException, XFormParser.ParseException, DeserializationException {
+        Scenario scenario = Scenario.init("Setvalue attribute", html(
+            head(
+                title("Setvalue attribute"),
+                model(
+                    mainInstance(t("data id=\"setvalue-attribute\"",
+                        t("element attr=\"\"")
+                    )),
+                    setvalue("odk-instance-first-load", "/data/element/@attr", "7")
+                )
+            ),
+            body(
+                input("/data/element")
+            )));
+
+        assertThat(scenario.answerOf("/data/element/@attr").getDisplayText(), is("7"));
+
+        Scenario cached = scenario.serializeAndDeserializeForm();
+
+        cached.newInstance();
+        assertThat(cached.answerOf("/data/element/@attr").getDisplayText(), is("7"));
+    }
 }

--- a/src/test/java/org/javarosa/core/model/utils/test/QuestionPreloaderTest.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/QuestionPreloaderTest.java
@@ -1,0 +1,41 @@
+package org.javarosa.core.model.utils.test;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
+import static org.javarosa.core.util.XFormsElement.body;
+import static org.javarosa.core.util.XFormsElement.head;
+import static org.javarosa.core.util.XFormsElement.html;
+import static org.javarosa.core.util.XFormsElement.input;
+import static org.javarosa.core.util.XFormsElement.mainInstance;
+import static org.javarosa.core.util.XFormsElement.model;
+import static org.javarosa.core.util.XFormsElement.t;
+import static org.javarosa.core.util.XFormsElement.title;
+
+import java.io.IOException;
+import org.javarosa.core.test.Scenario;
+import org.javarosa.xform.parse.XFormParser;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class QuestionPreloaderTest {
+    @Ignore("Not supported")
+    @Test
+    public void preloader_preloadsAttributes() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Preload attribute", html(
+            head(
+                title("Preload attribute"),
+                model(
+                    mainInstance(t("data id=\"preload-attribute\"",
+                        t("element attr=\"\"")
+                    )),
+                    bind("/data/element/@attr").preload("uid")
+                )
+            ),
+            body(
+                input("/data/element")
+            )));
+
+        assertThat(scenario.answerOf("/data/element/@attr").getDisplayText(), startsWith("uuid"));
+    }
+}

--- a/src/test/java/org/javarosa/core/model/utils/test/QuestionPreloaderTest.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/QuestionPreloaderTest.java
@@ -39,6 +39,7 @@ public class QuestionPreloaderTest {
     }
 
     @Test
+    // Unintentional limitation
     public void preloader_doesNotpreloadAttributes() throws IOException, XFormParser.ParseException {
         Scenario scenario = Scenario.init("Preload attribute", html(
             head(

--- a/src/test/java/org/javarosa/core/model/utils/test/QuestionPreloaderTest.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/QuestionPreloaderTest.java
@@ -1,5 +1,6 @@
 package org.javarosa.core.model.utils.test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
@@ -15,13 +16,30 @@ import static org.javarosa.core.util.XFormsElement.title;
 import java.io.IOException;
 import org.javarosa.core.test.Scenario;
 import org.javarosa.xform.parse.XFormParser;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class QuestionPreloaderTest {
-    @Ignore("Not supported")
     @Test
-    public void preloader_preloadsAttributes() throws IOException, XFormParser.ParseException {
+    public void preloader_preloadsElements() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Preload attribute", html(
+            head(
+                title("Preload element"),
+                model(
+                    mainInstance(t("data id=\"preload-attribute\"",
+                        t("element")
+                    )),
+                    bind("/data/element").preload("uid")
+                )
+            ),
+            body(
+                input("/data/element")
+            )));
+
+        assertThat(scenario.answerOf("/data/element").getDisplayText(), startsWith("uuid:"));
+    }
+
+    @Test
+    public void preloader_doesNotpreloadAttributes() throws IOException, XFormParser.ParseException {
         Scenario scenario = Scenario.init("Preload attribute", html(
             head(
                 title("Preload attribute"),
@@ -36,6 +54,6 @@ public class QuestionPreloaderTest {
                 input("/data/element")
             )));
 
-        assertThat(scenario.answerOf("/data/element/@attr").getDisplayText(), startsWith("uuid"));
+        assertThat(scenario.answerOf("/data/element/@attr").getDisplayText(), is(""));
     }
 }


### PR DESCRIPTION
This is a testing-only change.

We were surprised to discover that preloading attributes is not supported. I think it's helpful to have an ignored test documenting this. `setvalue` provides similar functionality that does work with attributes.