### PR TITLE
Add base64-decode

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/Encoding.java
+++ b/src/main/java/org/javarosa/xpath/expr/Encoding.java
@@ -22,75 +22,75 @@ import org.javarosa.xpath.XPathUnsupportedException;
  * Implements the hash encoding methods for XPathFuncExpr digest() function
  */
 enum Encoding {
-  HEX("hex") {
-    @Override
-    String encode(byte[] bytes) {
-      StringBuilder sb = new StringBuilder(bytes.length * 2);
-      for (byte b : bytes) {
-        sb.append(HEX_TBL[(b >> 4) & 0xF]);
-        sb.append(HEX_TBL[(b & 0xF)]);
-      }
-      return sb.toString();
+    HEX("hex") {
+        @Override
+        String encode(byte[] bytes) {
+            StringBuilder sb = new StringBuilder(bytes.length * 2);
+            for (byte b : bytes) {
+                sb.append(HEX_TBL[(b >> 4) & 0xF]);
+                sb.append(HEX_TBL[(b & 0xF)]);
+            }
+            return sb.toString();
+        }
+    },
+    BASE64("base64") {
+        @Override
+        String encode(byte[] sArr) {
+            // Copied from: https://github.com/brsanthu/migbase64/blob/master/src/main/java/com/migcomponents/migbase64/Base64.java
+            // Irrelevant after Java8
+            int sLen = sArr.length;
+            int sOff = 0;
+
+            if (sLen == 0)
+                return "";
+
+            int eLen = (sLen / 3) * 3;
+            int dLen = ((sLen - 1) / 3 + 1) << 2;
+            byte[] dArr = new byte[dLen];
+
+            for (int s = sOff, d = 0; s < sOff + eLen; ) {
+                int i = (sArr[s++] & 0xff) << 16 | (sArr[s++] & 0xff) << 8 | (sArr[s++] & 0xff);
+                dArr[d++] = (byte) BASE_64_TBL[(i >>> 18) & 0x3f];
+                dArr[d++] = (byte) BASE_64_TBL[(i >>> 12) & 0x3f];
+                dArr[d++] = (byte) BASE_64_TBL[(i >>> 6) & 0x3f];
+                dArr[d++] = (byte) BASE_64_TBL[i & 0x3f];
+            }
+
+            int left = sLen - eLen;
+            if (left > 0) {
+                int i = ((sArr[sOff + eLen] & 0xff) << 10) | (left == 2 ? ((sArr[sOff + sLen - 1] & 0xff) << 2) : 0);
+                dArr[dLen - 4] = (byte) BASE_64_TBL[i >> 12];
+                dArr[dLen - 3] = (byte) BASE_64_TBL[(i >>> 6) & 0x3f];
+                dArr[dLen - 2] = left == 2 ? (byte) BASE_64_TBL[i & 0x3f] : (byte) '=';
+                dArr[dLen - 1] = '=';
+            }
+
+            try {
+                return new String(dArr, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                // It’s unlikely that UTF-8 would not be supported
+                throw new RuntimeException("Encoding to base64 failed to use UTF-8");
+            }
+        }
+    };
+
+    private final String name;
+
+    Encoding(String name) {
+        this.name = name;
     }
-  },
-  BASE64("base64") {
-    @Override
-    String encode(byte[] sArr) {
-      // Copied from: https://github.com/brsanthu/migbase64/blob/master/src/main/java/com/migcomponents/migbase64/Base64.java
-      // Irrelevant after Java8
-      int sLen = sArr.length;
-      int sOff = 0;
 
-      if (sLen == 0)
-        return "";
-
-      int eLen = (sLen / 3) * 3;
-      int dLen = ((sLen - 1) / 3 + 1) << 2;
-      byte[] dArr = new byte[dLen];
-
-      for (int s = sOff, d = 0; s < sOff + eLen; ) {
-        int i = (sArr[s++] & 0xff) << 16 | (sArr[s++] & 0xff) << 8 | (sArr[s++] & 0xff);
-        dArr[d++] = (byte) BASE_64_TBL[(i >>> 18) & 0x3f];
-        dArr[d++] = (byte) BASE_64_TBL[(i >>> 12) & 0x3f];
-        dArr[d++] = (byte) BASE_64_TBL[(i >>> 6) & 0x3f];
-        dArr[d++] = (byte) BASE_64_TBL[i & 0x3f];
-      }
-
-      int left = sLen - eLen;
-      if (left > 0) {
-        int i = ((sArr[sOff + eLen] & 0xff) << 10) | (left == 2 ? ((sArr[sOff + sLen - 1] & 0xff) << 2) : 0);
-        dArr[dLen - 4] = (byte) BASE_64_TBL[i >> 12];
-        dArr[dLen - 3] = (byte) BASE_64_TBL[(i >>> 6) & 0x3f];
-        dArr[dLen - 2] = left == 2 ? (byte) BASE_64_TBL[i & 0x3f] : (byte) '=';
-        dArr[dLen - 1] = '=';
-      }
-
-      try {
-        return new String(dArr, "UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        // It’s unlikely that UTF-8 would not be supported
-        throw new RuntimeException("Encoding to base64 failed to use UTF-8");
-      }
+    static Encoding from(String name) {
+        try {
+            return valueOf(name.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new XPathUnsupportedException("digest(..., ..., '" + name + "')");
+        }
     }
-  };
 
-  private final String name;
+    private static final char[] HEX_TBL = "0123456789abcdef".toCharArray();
 
-  Encoding(String name) {
-    this.name = name;
-  }
+    private static final char[] BASE_64_TBL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
 
-  static Encoding from(String name) {
-    try {
-      return valueOf(name.toUpperCase());
-    } catch (IllegalArgumentException ex) {
-      throw new XPathUnsupportedException("digest(..., ..., '" + name + "')");
-    }
-  }
-
-  private static final char[] HEX_TBL = "0123456789abcdef".toCharArray();
-
-  private static final char[] BASE_64_TBL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
-
-  abstract String encode(byte[] bytes);
+    abstract String encode(byte[] bytes);
 }

--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -507,8 +507,8 @@ public class XPathFuncExpr extends XPathExpression {
 
     private static void assertArgsCount(String name, Object[] args, int count) {
         if (args.length != count) {
-            throw new XPathUnhandledException("function \'" + name + "\' requires " +
-                count + " arguments. Only " + args.length + " provided.");
+            throw new XPathUnhandledException("function '" + name + "'. Requires " +
+                count + " arguments but " + args.length + " provided.");
         }
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -22,7 +22,9 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -486,6 +488,9 @@ public class XPathFuncExpr extends XPathExpression {
                 return XPathNodeset.shuffle((XPathNodeset) argVals[0], toNumeric(argVals[1]).longValue());
 
             throw new XPathUnhandledException("function \'randomize\' requires 1 or 2 arguments. " + args.length + " provided.");
+        } else if (name.equals("base64-decode")) {
+            assertArgsCount(name, args, 1);
+            return base64Decode(argVals[0]);
         } else {
             //check for custom handler
             IFunctionHandler handler = funcHandlers.get(name);
@@ -1245,6 +1250,13 @@ public class XPathFuncExpr extends XPathExpression {
         String re = toString(o2);
 
         return Pattern.matches(re, str);
+    }
+
+    private static String base64Decode(Object o1) {
+        String base64String = toString(o1);
+
+        byte[] decoded = Base64.getDecoder().decode(base64String.getBytes(StandardCharsets.UTF_8));
+        return new String(decoded);
     }
 
     private static Object[] subsetArgList(Object[] args, int start) {

--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -1255,8 +1254,8 @@ public class XPathFuncExpr extends XPathExpression {
     private static String base64Decode(Object o1) {
         String base64String = toString(o1);
 
-        byte[] decoded = Base64.getDecoder().decode(base64String.getBytes(StandardCharsets.UTF_8));
-        return new String(decoded);
+        byte[] decoded = Encoding.BASE64.decode(base64String.getBytes(StandardCharsets.UTF_8));
+        return new String(decoded, StandardCharsets.UTF_8);
     }
 
     private static Object[] subsetArgList(Object[] args, int start) {

--- a/src/test/java/org/javarosa/xpath/expr/Base64DecodeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/Base64DecodeTest.java
@@ -1,6 +1,7 @@
 package org.javarosa.xpath.expr;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
@@ -13,11 +14,13 @@ import static org.javarosa.core.util.XFormsElement.mainInstance;
 import static org.javarosa.core.util.XFormsElement.model;
 import static org.javarosa.core.util.XFormsElement.t;
 import static org.javarosa.core.util.XFormsElement.title;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Arrays;
 import org.javarosa.core.test.Scenario;
 import org.javarosa.xform.parse.XFormParser;
+import org.javarosa.xpath.XPathUnhandledException;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -72,6 +75,32 @@ public class Base64DecodeTest {
     }
 
     public static class InvalidValuesTest {
+        @Test
+        public void base64DecodeFunction_throwsWhenNotExactlyOneArg() throws IOException, XFormParser.ParseException {
+            try {
+                Scenario scenario = Scenario.init("Invalid base64 string", html(
+                    head(
+                        title("Invalid base64 string"),
+                        model(
+                            mainInstance(t("data id=\"base64\"",
+                                t("text", "a"),
+                                t("decoded")
+                            )),
+                            bind("/data/text").type("string"),
+                            bind("/data/decoded").type("string").calculate("base64-decode()")
+                        )
+                    ),
+                    body(
+                        input("/data/text")
+                    ))
+                );
+
+                fail("RuntimeException caused by XPathUnhandledException expected");
+            } catch (RuntimeException e) {
+                assertThat(e.getCause(), instanceOf(XPathUnhandledException.class));
+            }
+        }
+
         @Test
         public void base64DecodeFunction_returnsEmptyStringWhenInputInvalid() throws IOException, XFormParser.ParseException {
             Scenario scenario = Scenario.init("Invalid base64 string", html(

--- a/src/test/java/org/javarosa/xpath/expr/Base64DecodeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/Base64DecodeTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Enclosed.class)
-public class XPathFuncExprBase64DecodeTest {
+public class Base64DecodeTest {
 
     @RunWith(Parameterized.class)
     public static class ValidValuesTest {

--- a/src/test/java/org/javarosa/xpath/expr/CurrentFieldRefTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/CurrentFieldRefTest.java
@@ -24,7 +24,7 @@ import org.javarosa.xform.parse.XFormParser;
 import org.junit.Before;
 import org.junit.Test;
 
-public class XPathPathExprCurrentFieldRefTest {
+public class CurrentFieldRefTest {
     private Scenario scenario;
 
     @Before

--- a/src/test/java/org/javarosa/xpath/expr/CurrentGroupCountRefTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/CurrentGroupCountRefTest.java
@@ -24,7 +24,7 @@ import org.javarosa.xform.parse.XFormParser;
 import org.junit.Before;
 import org.junit.Test;
 
-public class XPathPathExprCurrentGroupCountRefTest {
+public class CurrentGroupCountRefTest {
     private Scenario scenario;
 
     @Before

--- a/src/test/java/org/javarosa/xpath/expr/CurrentTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/CurrentTest.java
@@ -28,7 +28,7 @@ import org.javarosa.xform.parse.XFormParser;
 import org.junit.Before;
 import org.junit.Test;
 
-public class XPathPathExprCurrentTest {
+public class CurrentTest {
     private Scenario scenario;
 
     @Before

--- a/src/test/java/org/javarosa/xpath/expr/EncodingDecodeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/EncodingDecodeTest.java
@@ -1,0 +1,41 @@
+package org.javarosa.xpath.expr;
+
+import static org.javarosa.xpath.expr.Encoding.BASE64;
+import static org.javarosa.xpath.expr.Encoding.HEX;
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class EncodingDecodeTest {
+    @Parameterized.Parameter(value = 0)
+    public String testName;
+
+    @Parameterized.Parameter(value = 1)
+    public Encoding encodingMethod;
+
+    @Parameterized.Parameter(value = 2)
+    public String input;
+
+    @Parameterized.Parameter(value = 3)
+    public String expectedOutput;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"Hexadecimal", HEX, "736f6d652074657874", "some text"},
+            {"Hexadecimal (empty string)", HEX, "", ""},
+            {"Base64", BASE64, "c29tZSB0ZXh0", "some text"},
+            {"Base64 (empty string)", BASE64, "", ""},
+        });
+    }
+
+    @Test
+    public void decodes_byte_arrays() {
+        assertEquals(expectedOutput, encodingMethod.decode(input.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/src/test/java/org/javarosa/xpath/expr/EncodingDecodeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/EncodingDecodeTest.java
@@ -36,6 +36,6 @@ public class EncodingDecodeTest {
 
     @Test
     public void decodes_byte_arrays() {
-        assertEquals(expectedOutput, encodingMethod.decode(input.getBytes(StandardCharsets.UTF_8)));
+        assertEquals(expectedOutput, new String(encodingMethod.decode(input.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8));
     }
 }

--- a/src/test/java/org/javarosa/xpath/expr/EncodingEncodeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/EncodingEncodeTest.java
@@ -20,14 +20,14 @@ import static org.javarosa.xpath.expr.Encoding.BASE64;
 import static org.javarosa.xpath.expr.Encoding.HEX;
 import static org.junit.Assert.assertEquals;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class EncodingTest {
+public class EncodingEncodeTest {
   @Parameterized.Parameter(value = 0)
   public String testName;
 
@@ -51,7 +51,7 @@ public class EncodingTest {
   }
 
   @Test
-  public void encodes_byte_arrays() throws UnsupportedEncodingException {
-    assertEquals(expectedOutput, encodingMethod.encode(input.getBytes("UTF-8")));
+  public void encodes_byte_arrays()  {
+    assertEquals(expectedOutput, encodingMethod.encode(input.getBytes(StandardCharsets.UTF_8)));
   }
 }

--- a/src/test/java/org/javarosa/xpath/expr/RandomizeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/RandomizeTest.java
@@ -49,7 +49,7 @@ import org.javarosa.xform.parse.XFormParser;
 import org.junit.Before;
 import org.junit.Test;
 
-public class XPathFuncExprRandomizeTest {
+public class RandomizeTest {
 
     private FormDef formDef;
 

--- a/src/test/java/org/javarosa/xpath/expr/RelativeRefTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/RelativeRefTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
-public class XPathPathExprRelativeRefTest {
+public class RelativeRefTest {
     @Test
     public void predicateInRelativeRef_isAppliedToCorrectLevel() throws XPathSyntaxException {
         XPathExpression predicate = XPathParseTool.parseXPath("position() = ../count");

--- a/src/test/java/org/javarosa/xpath/expr/XPathFuncExprBase64DecodeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathFuncExprBase64DecodeTest.java
@@ -1,0 +1,67 @@
+package org.javarosa.xpath.expr;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
+import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
+import static org.javarosa.core.util.XFormsElement.body;
+import static org.javarosa.core.util.XFormsElement.head;
+import static org.javarosa.core.util.XFormsElement.html;
+import static org.javarosa.core.util.XFormsElement.input;
+import static org.javarosa.core.util.XFormsElement.mainInstance;
+import static org.javarosa.core.util.XFormsElement.model;
+import static org.javarosa.core.util.XFormsElement.t;
+import static org.javarosa.core.util.XFormsElement.title;
+
+import java.io.IOException;
+import java.util.Arrays;
+import org.javarosa.core.test.Scenario;
+import org.javarosa.xform.parse.XFormParser;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class XPathFuncExprBase64DecodeTest {
+    @Parameterized.Parameter(value = 0)
+    public String testName;
+
+    @Parameterized.Parameter(value = 1)
+    public String source;
+
+    @Parameterized.Parameter(value = 2)
+    public String expectedOutput;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"ASCII string", "SGVsbG8=", "Hello"},
+            {"Example from Saxonica", "RGFzc2Vs", "Dassel"},
+            {"String with accented characters", "w6nDqMOx", "éèñ"},
+            {"String with emoji", "8J+lsA==", "🥰"},
+            {"UTF-16 encoded string", "AGEAYgBj", "\u0000a\u0000b\u0000c"} // source string: "abc" in UTF-16
+        });
+    }
+
+    @Test
+    public void base64DecodeFunction_acceptsDynamicParameters() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init(testName, html(
+            head(
+                title(testName),
+                model(
+                    mainInstance(t("data id=\"base64\"",
+                        t("text", source),
+                        t("decoded")
+                    )),
+                    bind("/data/text").type("string"),
+                    bind("/data/decoded").type("string").calculate("base64-decode(/data/text)")
+                )
+            ),
+            body(
+                input("/data/text")
+            ))
+        );
+
+        assertThat(scenario.answerOf("/data/decoded"), is(stringAnswer(expectedOutput)));
+    }
+}

--- a/src/test/java/org/javarosa/xpath/expr/XPathFuncExprBase64DecodeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathFuncExprBase64DecodeTest.java
@@ -2,6 +2,7 @@ package org.javarosa.xpath.expr;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
 import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
 import static org.javarosa.core.util.XFormsElement.body;
@@ -18,50 +19,79 @@ import java.util.Arrays;
 import org.javarosa.core.test.Scenario;
 import org.javarosa.xform.parse.XFormParser;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
+@RunWith(Enclosed.class)
 public class XPathFuncExprBase64DecodeTest {
-    @Parameterized.Parameter(value = 0)
-    public String testName;
 
-    @Parameterized.Parameter(value = 1)
-    public String source;
+    @RunWith(Parameterized.class)
+    public static class ValidValuesTest {
+        @Parameterized.Parameter(value = 0)
+        public String testName;
 
-    @Parameterized.Parameter(value = 2)
-    public String expectedOutput;
+        @Parameterized.Parameter(value = 1)
+        public String source;
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Iterable<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-            {"ASCII string", "SGVsbG8=", "Hello"},
-            {"Example from Saxonica", "RGFzc2Vs", "Dassel"},
-            {"String with accented characters", "w6nDqMOx", "éèñ"},
-            {"String with emoji", "8J+lsA==", "🥰"},
-            {"UTF-16 encoded string", "AGEAYgBj", "\u0000a\u0000b\u0000c"} // source string: "abc" in UTF-16
-        });
+        @Parameterized.Parameter(value = 2)
+        public String expectedOutput;
+
+        @Parameterized.Parameters(name = "{0}")
+        public static Iterable<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                {"ASCII string", "SGVsbG8=", "Hello"},
+                {"Example from Saxonica", "RGFzc2Vs", "Dassel"},
+                {"String with accented characters", "w6nDqMOx", "éèñ"},
+                {"String with emoji", "8J+lsA==", "🥰"},
+                {"UTF-16 encoded string", "AGEAYgBj", "\u0000a\u0000b\u0000c"}, // source string: "abc" in UTF-16
+            });
+        }
+
+        @Test
+        public void base64DecodeFunction_acceptsDynamicParameters() throws IOException, XFormParser.ParseException {
+            Scenario scenario = Scenario.init(testName, html(
+                head(
+                    title(testName),
+                    model(
+                        mainInstance(t("data id=\"base64\"",
+                            t("text", source),
+                            t("decoded")
+                        )),
+                        bind("/data/text").type("string"),
+                        bind("/data/decoded").type("string").calculate("base64-decode(/data/text)")
+                    )
+                ),
+                body(
+                    input("/data/text")
+                ))
+            );
+
+            assertThat(scenario.answerOf("/data/decoded"), is(stringAnswer(expectedOutput)));
+        }
     }
 
-    @Test
-    public void base64DecodeFunction_acceptsDynamicParameters() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init(testName, html(
-            head(
-                title(testName),
-                model(
-                    mainInstance(t("data id=\"base64\"",
-                        t("text", source),
-                        t("decoded")
-                    )),
-                    bind("/data/text").type("string"),
-                    bind("/data/decoded").type("string").calculate("base64-decode(/data/text)")
-                )
-            ),
-            body(
-                input("/data/text")
-            ))
-        );
+    public static class InvalidValuesTest {
+        @Test
+        public void base64DecodeFunction_returnsEmptyStringWhenInputInvalid() throws IOException, XFormParser.ParseException {
+            Scenario scenario = Scenario.init("Invalid base64 string", html(
+                head(
+                    title("Invalid base64 string"),
+                    model(
+                        mainInstance(t("data id=\"base64\"",
+                            t("text", "a"),
+                            t("decoded")
+                        )),
+                        bind("/data/text").type("string"),
+                        bind("/data/decoded").type("string").calculate("base64-decode(/data/text)")
+                    )
+                ),
+                body(
+                    input("/data/text")
+                ))
+            );
 
-        assertThat(scenario.answerOf("/data/decoded"), is(stringAnswer(expectedOutput)));
+            assertThat(scenario.answerOf("/data/decoded"), is(nullValue()));
+        }
     }
 }


### PR DESCRIPTION
Discussion at https://forum.getodk.org/t/proposal-add-centroid-and-base64binary-to-string-functions/40289/5

#### What has been done to verify that this works as intended?
Added tests.

#### Why is this the best possible solution? Were any other approaches considered?
Name was selected with community input. Since we're not following an existing spec, I decided not to add an encoding parameter. In practice, most things are UTF-8 these days. We can add an encoding parameter later if needed.

We had talked about throwing an exception in case of invalid input but I decided to use a blank/null value instead. The problem with throwing an exception is that the exception can manifest as a Validate error and/or be thrown at undesirable moment if the input is not complete yet. With a blank value, it may be harder to track down unexpected values but I think it's an overall better experience.

I wanted to use standard Java `Base64` but that's not in Android until API 26. We already have a precedent for pulling code in from https://github.com/brsanthu/migbase64/blob/master/src/main/java/com/migcomponents/migbase64/Base64.java so I continued that.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Isolated addition so all risk is to the new code which could be wrong.

#### Do we need any specific form for testing your changes? If so, please attach one.

See test.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
https://github.com/getodk/xforms-spec/pull/301