### PR TITLE
Checking relevance of an inner repeat group should be possible even if its parent group does not exist yet

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -552,7 +552,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             TreeReference parentPath = templNode.getParent().getRef().genericize();
             TreeElement parentNode = mainInstance
                 .resolveReference(parentPath.contextualize(repeatRef));
-            relev = parentNode.isRelevant() && templNode.isRelevant();
+            relev = parentNode != null && parentNode.isRelevant() && templNode.isRelevant();
         }
 
         return relev;

--- a/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -266,6 +266,34 @@ public class FormDefTest {
         scenario.next();
         assertThat(scenario.refAtIndex(), is(getRef("/data/outer[0]/inner[0]")));
     }
+
+    @Test
+    public void innerRepeatGroupIsIrrelevant_whenItsParentRepeatGroupDoesNotExist() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Nested repeat relevance", html(
+            head(
+                title("Nested repeat relevance"),
+                model(
+                    mainInstance(t("data id=\"nested-repeat-relevance\"",
+                        t("outer",
+                            t("inner",
+                                t("q1")
+                            )
+                        )
+                    ))
+                )),
+            body(
+                repeat("/data/outer",
+                    repeat("/data/outer/inner",
+                        input("/data/outer/inner/q1")
+                    )
+                )
+            )));
+
+
+        FormDef formDef = scenario.getFormDef();
+        // outer[1] does not exist at this moment, we only have outer[0]. Checking if its inner repeat group is relevant should be possible and return false.
+        assertThat(formDef.isRepeatRelevant(getRef("/data/outer[1]/inner[0]")), is(false));
+    }
     //endregion
 
     @Test


### PR DESCRIPTION
Closes [#5469 ](https://github.com/getodk/collect/issues/5264)

#### What has been done to verify that this works as intended?
I've tested the fix manually with ODK Collect and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that in nested repeats we weren't able to check the relevance of an inner group if its parent group didn't exist yet. It caused an NPE. This is a small fix and probably there is nothing to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue and have no side effects. It's a small fix so it's rather safe but it would be good to play with nested repeats more in the future. I will add that to the todo list that we use with the QA team.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form from: https://github.com/getodk/collect/issues/5264 for example

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.
