### PR TITLE
Values referenced from jr:repeat-count should be coerced to int 

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -28,6 +28,7 @@ import org.javarosa.core.model.condition.Triggerable;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.MultipleItemsData;
 import org.javarosa.core.model.data.SelectOneData;
+import org.javarosa.core.model.data.helper.AnswerDataUtil;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstance;
@@ -579,9 +580,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                         + repeat.getCountReference().getReference().toString());
                 }
                 // get the total multiplicity possible
-                IAnswerData count = countNode.getValue();
-                long fullcount = count == null ? 0 : (Integer) count.getValue();
-
+                long fullcount = AnswerDataUtil.answerDataToInt(countNode.getValue());
                 if (fullcount <= currentMultiplicity) {
                     return false;
                 }

--- a/src/main/java/org/javarosa/core/model/data/helper/AnswerDataUtil.java
+++ b/src/main/java/org/javarosa/core/model/data/helper/AnswerDataUtil.java
@@ -1,0 +1,22 @@
+package org.javarosa.core.model.data.helper;
+
+import org.javarosa.core.model.data.IAnswerData;
+
+public class AnswerDataUtil {
+    public static int answerDataToInt(IAnswerData countData) {
+        if (countData == null) {
+            return 0;
+        }
+
+        Object count = countData.getValue();
+        if (count instanceof Integer) {
+            return (int) count;
+        } else if (count instanceof Double) {
+            return (int) Math.floor((Double) count);
+        } else if (count instanceof Long) {
+            return (int) ((Long) count).longValue();
+        } else {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/org/javarosa/form/api/FormEntryModel.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryModel.java
@@ -22,6 +22,7 @@ import org.javarosa.core.model.GroupDef;
 import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.helper.AnswerDataUtil;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.InvalidReferenceException;
 import org.javarosa.core.model.instance.TreeElement;
@@ -433,7 +434,7 @@ public class FormEntryModel {
                     TreeReference contextualized = countRef.contextualize(index.getReference());
                     IAnswerData count = getForm().getMainInstance().resolveReference(contextualized).getValue();
                     if (count != null) {
-                        long fullcount = ((Integer) count.getValue()).intValue();
+                        long fullcount = AnswerDataUtil.answerDataToInt(count);
                         TreeReference ref = getForm().getChildInstanceRef(index);
                         TreeElement element = getForm().getMainInstance().resolveReference(ref);
                         if (element == null) {

--- a/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
@@ -90,6 +90,34 @@ public class OdkNewRepeatEventTest {
     }
 
     @Test
+    public void setOtherThanIntegerValueOnRepeatWithCount_convertsValueToInteger() throws XFormParser.ParseException {
+        Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
+
+        // String
+        scenario.answer("/data/repeat-count", "1");
+        while (!scenario.atTheEndOfForm()) {
+            scenario.next();
+        }
+        assertThat(scenario.countRepeatInstancesOf("/data/my-jr-count-repeat"), is(0));
+
+        // Decimal
+        scenario.jumpToBeginningOfForm();
+        scenario.answer("/data/repeat-count", 2.5);
+        while (!scenario.atTheEndOfForm()) {
+            scenario.next();
+        }
+        assertThat(scenario.countRepeatInstancesOf("/data/my-jr-count-repeat"), is(2));
+
+        // Long
+        scenario.jumpToBeginningOfForm();
+        scenario.answer("/data/repeat-count", 3L);
+        while (!scenario.atTheEndOfForm()) {
+            scenario.next();
+        }
+        assertThat(scenario.countRepeatInstancesOf("/data/my-jr-count-repeat"), is(3));
+    }
+
+    @Test
     public void repeatInFormDefInstance_neverFiresNewRepeatEvent() throws XFormParser.ParseException {
         Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
 

--- a/src/test/java/org/javarosa/core/model/data/helper/AnswerDataUtilTest.java
+++ b/src/test/java/org/javarosa/core/model/data/helper/AnswerDataUtilTest.java
@@ -1,0 +1,42 @@
+package org.javarosa.core.model.data.helper;
+
+import org.javarosa.core.model.data.BooleanData;
+import org.javarosa.core.model.data.DateData;
+import org.javarosa.core.model.data.DecimalData;
+import org.javarosa.core.model.data.IntegerData;
+import org.javarosa.core.model.data.LongData;
+import org.javarosa.core.model.data.SelectOneData;
+import org.javarosa.core.model.data.StringData;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+public class AnswerDataUtilTest {
+
+    @Test
+    public void NumericalDataReturnsProperValueWhenConvertedToInt() {
+        assertEquals(5, AnswerDataUtil.answerDataToInt(new IntegerData(5)));
+
+        assertEquals(7, AnswerDataUtil.answerDataToInt(new DecimalData(7.35)));
+
+        assertEquals(3, AnswerDataUtil.answerDataToInt(new LongData(3L)));
+    }
+
+    @Test
+    public void NonNumericalDataReturnsZeroWhenConvertedToInt() {
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new BooleanData(true)));
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new SelectOneData(new Selection("Selection1"))));
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new DateData(new Date())));
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new StringData("blah")));
+    }
+
+    @Test
+    public void IfDataTypeHasNoAnswerReturnsZeroWhenConvertedToInt() {
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new IntegerData()));
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new DecimalData()));
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new LongData()));
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new BooleanData()));
+    }
+}

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -26,6 +26,7 @@ import org.javarosa.core.model.ValidateOutcome;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.data.BooleanData;
 import org.javarosa.core.model.data.DateData;
+import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.model.data.MultipleItemsData;
@@ -510,6 +511,21 @@ public class Scenario {
     }
 
     /**
+     * Answers with an double value the question at the form index
+     * corresponding to the provided reference.
+     * <p>
+     * This method has side effects:
+     * - It will create all the required middle and end repeat group instances
+     * - It changes the current form index
+     */
+    public AnswerResult answer(String xPath, double value) {
+        createMissingRepeats(xPath);
+        TreeReference ref = getRef(xPath);
+        silentJump(getIndexOf(ref));
+        return answer(value);
+    }
+
+    /**
      * Answers with a boolean value the question at the form index
      * corresponding to the provided reference.
      * <p>
@@ -552,6 +568,13 @@ public class Scenario {
      */
     public AnswerResult answer(int value) {
         return answer(new IntegerData(value));
+    }
+
+    /**
+     * Answers the question at the form index
+     */
+    public AnswerResult answer(double value) {
+        return answer(new DecimalData(value));
     }
 
     /**


### PR DESCRIPTION
Closes #686

#### What has been done to verify that this works as intended?
I've tested the fix with ODK Collect and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
There is not much to discuss here. As mentioned in the issue the value that represents the number of repeats should be coerced to int.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's rather a safe change that might affect only how we determine the number of repeats so testing this functionality should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form that allows specifying [the number of repeats](https://xlsform.org/en/#dynamic-repeat-counts). I used this one: 
[RepeatCountTest.xlsx](https://github.com/getodk/javarosa/files/10970936/RepeatCountTest.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.