### PR TITLE
Add ability to search expressions for functions and to questions

### DIFF
--- a/src/main/java/org/javarosa/core/model/condition/IConditionExpr.java
+++ b/src/main/java/org/javarosa/core/model/condition/IConditionExpr.java
@@ -23,6 +23,7 @@ import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.xpath.expr.XPathExpression;
 
 /**
  * A condition expression is an expression which is evaluated against the current
@@ -101,4 +102,6 @@ public interface IConditionExpr extends Externalizable {
      * @throws UnpivotableExpressionException
      */
    List<Object> pivot(DataInstance model, EvaluationContext evalContext) throws UnpivotableExpressionException;
+
+   XPathExpression getExpr();
 }

--- a/src/main/java/org/javarosa/entities/EntityXFormParserFactory.java
+++ b/src/main/java/org/javarosa/entities/EntityXFormParserFactory.java
@@ -3,43 +3,19 @@ package org.javarosa.entities;
 import org.javarosa.entities.internal.EntityFormParseProcessor;
 import org.javarosa.xform.parse.IXFormParserFactory;
 import org.javarosa.xform.parse.XFormParser;
-import org.kxml2.kdom.Document;
+import org.jetbrains.annotations.NotNull;
 
-import java.io.Reader;
+public class EntityXFormParserFactory extends IXFormParserFactory.Wrapper {
 
-public class EntityXFormParserFactory implements IXFormParserFactory {
-
-    private final IXFormParserFactory wrapped;
-
-    public EntityXFormParserFactory(IXFormParserFactory wrapped) {
-        this.wrapped = wrapped;
+    public EntityXFormParserFactory(IXFormParserFactory base) {
+        super(base);
     }
 
     @Override
-    public XFormParser getXFormParser(Reader reader) {
-        return configureEntityParsing(wrapped.getXFormParser(reader));
-    }
-
-    @Override
-    public XFormParser getXFormParser(Document doc) {
-        return configureEntityParsing(wrapped.getXFormParser(doc));
-    }
-
-    @Override
-    public XFormParser getXFormParser(Reader form, Reader instance) {
-        return configureEntityParsing(wrapped.getXFormParser(form, instance));
-    }
-
-    @Override
-    public XFormParser getXFormParser(Document form, Document instance) {
-        return configureEntityParsing(wrapped.getXFormParser(form, instance));
-    }
-
-    private XFormParser configureEntityParsing(XFormParser xFormParser) {
+    public XFormParser apply(@NotNull XFormParser xFormParser) {
         EntityFormParseProcessor processor = new EntityFormParseProcessor();
         xFormParser.addProcessor(processor);
 
         return xFormParser;
     }
-
 }

--- a/src/main/java/org/javarosa/xform/parse/IXFormParserFactory.java
+++ b/src/main/java/org/javarosa/xform/parse/IXFormParserFactory.java
@@ -1,8 +1,9 @@
 package org.javarosa.xform.parse;
 
-import java.io.Reader;
-
+import org.jetbrains.annotations.NotNull;
 import org.kxml2.kdom.Document;
+
+import java.io.Reader;
 
 /**
  * Interface for class factory for creating an XFormParser.
@@ -12,12 +13,42 @@ import org.kxml2.kdom.Document;
  *
  */
 public interface IXFormParserFactory {
-    public XFormParser getXFormParser(Reader reader);
+    XFormParser getXFormParser(Reader reader);
 
-    public XFormParser getXFormParser(Document doc);
+    XFormParser getXFormParser(Document doc);
 
-    public XFormParser getXFormParser(Reader form, Reader instance);
+    XFormParser getXFormParser(Reader form, Reader instance);
 
-    public XFormParser getXFormParser(Document form, Document instance);
+    XFormParser getXFormParser(Document form, Document instance);
 
+    abstract class Wrapper implements IXFormParserFactory {
+
+        private final IXFormParserFactory base;
+
+        public Wrapper(@NotNull IXFormParserFactory base) {
+            this.base = base;
+        }
+
+        public abstract XFormParser apply(@NotNull XFormParser xFormParser);
+
+        @Override
+        public XFormParser getXFormParser(Reader reader) {
+            return apply(base.getXFormParser(reader));
+        }
+
+        @Override
+        public XFormParser getXFormParser(Document doc) {
+            return apply(base.getXFormParser(doc));
+        }
+
+        @Override
+        public XFormParser getXFormParser(Reader form, Reader instance) {
+            return apply(base.getXFormParser(form, instance));
+        }
+
+        @Override
+        public XFormParser getXFormParser(Document form, Document instance) {
+            return apply(base.getXFormParser(form, instance));
+        }
+    }
 }

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -64,6 +64,7 @@ import org.javarosa.xpath.expr.XPathNumericLiteral;
 import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.expr.XPathStringLiteral;
 import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.jetbrains.annotations.NotNull;
 import org.kxml2.io.KXmlParser;
 import org.kxml2.kdom.Document;
 import org.kxml2.kdom.Element;
@@ -178,6 +179,7 @@ public class XFormParser implements IXFormParserFunctions {
     private final List<BindAttributeProcessor> bindAttributeProcessors = new ArrayList<>();
     private final List<FormDefProcessor> formDefProcessors = new ArrayList<>();
     private final List<ModelAttributeProcessor> modelAttributeProcessors = new ArrayList<>();
+    private final List<QuestionProcessor> questionProcessors = new ArrayList<>();
 
     /**
      * The string IDs of all instances that are referenced in a instance() function call in the primary instance
@@ -428,6 +430,10 @@ public class XFormParser implements IXFormParserFunctions {
 
         if (processor instanceof ModelAttributeProcessor) {
             addModelAttributeProcessor((ModelAttributeProcessor) processor);
+        }
+
+        if (processor instanceof QuestionProcessor) {
+            questionProcessors.add((QuestionProcessor) processor);
         }
     }
 
@@ -1172,6 +1178,7 @@ public class XFormParser implements IXFormParserFunctions {
 
         processAdditionalAttributes(question, e, usedAtts, passedThroughAtts);
 
+        questionProcessors.stream().forEach(questionProcessor -> questionProcessor.processQuestion(question));
         return question;
     }
 
@@ -2447,6 +2454,10 @@ public class XFormParser implements IXFormParserFunctions {
         Set<Pair<String, String>> getModelAttributes();
 
         void processModelAttribute(String name, String value) throws ParseException;
+    }
+
+    public interface QuestionProcessor extends Processor {
+        void processQuestion(@NotNull QuestionDef question);
     }
 
     public static class ParseException extends Exception {

--- a/src/main/java/org/javarosa/xpath/XPathConditional.java
+++ b/src/main/java/org/javarosa/xpath/XPathConditional.java
@@ -62,6 +62,7 @@ public class XPathConditional implements IConditionExpr {
 
     }
 
+    @Override
     public XPathExpression getExpr () {
         return expr;
     }

--- a/src/main/java/org/javarosa/xpath/expr/XPathBinaryOpExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathBinaryOpExpr.java
@@ -28,6 +28,7 @@ import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.core.util.externalizable.DeserializationException;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class XPathBinaryOpExpr extends XPathOpExpr {
     public XPathExpression a, b;
@@ -37,6 +38,11 @@ public abstract class XPathBinaryOpExpr extends XPathOpExpr {
     public XPathBinaryOpExpr (XPathExpression a, XPathExpression b) {
         this.a = a;
         this.b = b;
+    }
+
+    @Override
+    public boolean containsFunc(@NotNull String name) {
+        return a.containsFunc(name) || b.containsFunc(name);
     }
 
     public String toString (String op) {

--- a/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
 import org.javarosa.core.model.instance.DataInstance;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger; import org.slf4j.LoggerFactory;
 import org.javarosa.core.util.externalizable.Externalizable;
 
@@ -252,4 +253,6 @@ public abstract class XPathExpression implements Externalizable, Serializable {
      * Returns true if this expression is idempotent with respect to the current state of the form.
      */
     public abstract boolean isIdempotent();
+
+    public abstract boolean containsFunc(@NotNull String name);
 }

--- a/src/main/java/org/javarosa/xpath/expr/XPathFilterExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFilterExpr.java
@@ -16,13 +16,6 @@
 
 package org.javarosa.xpath.expr;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
 import org.javarosa.core.model.instance.DataInstance;
@@ -32,6 +25,14 @@ import org.javarosa.core.util.externalizable.ExtWrapListPoly;
 import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.XPathUnsupportedException;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class XPathFilterExpr extends XPathExpression {
     public XPathExpression x;
@@ -104,5 +105,10 @@ public class XPathFilterExpr extends XPathExpression {
     @Override
     public boolean isIdempotent() {
         return x.isIdempotent() && Arrays.stream(predicates).allMatch(XPathExpression::isIdempotent);
+    }
+
+    @Override
+    public boolean containsFunc(@NotNull String name) {
+        return x.containsFunc(name) || Arrays.stream(predicates).anyMatch(expression -> expression.containsFunc(name));
     }
 }

--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -38,6 +38,7 @@ import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.XPathUnhandledException;
+import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
 
 import java.io.DataInputStream;
@@ -77,6 +78,10 @@ public class XPathFuncExpr extends XPathExpression {
         if (id.name.equals("instance") && args[0] instanceof XPathStringLiteral) {
             XFormParser.recordInstanceFunctionCall(((XPathStringLiteral) args[0]).s);
         }
+    }
+
+    public XPathFuncExpr(XPathQName id) {
+        this(id, new XPathExpression[] {});
     }
 
     public String toString() {
@@ -1363,6 +1368,11 @@ public class XPathFuncExpr extends XPathExpression {
     public boolean isIdempotent() {
         return Arrays.asList(IDEMPOTENT_FUNCTIONS).contains(id.toString()) &&
             Arrays.stream(args).allMatch(XPathExpression::isIdempotent);
+    }
+
+    @Override
+    public boolean containsFunc(@NotNull String name) {
+        return name.equals(id.name) || Arrays.stream(args).anyMatch(expression -> expression.containsFunc(name));
     }
 
     private static final String[] IDEMPOTENT_FUNCTIONS = new String[]{

--- a/src/main/java/org/javarosa/xpath/expr/XPathNumNegExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathNumNegExpr.java
@@ -16,14 +16,14 @@
 
 package org.javarosa.xpath.expr;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 
 public class XPathNumNegExpr extends XPathUnaryOpExpr {
     public XPathNumNegExpr () { } //for deserialization

--- a/src/main/java/org/javarosa/xpath/expr/XPathNumericLiteral.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathNumericLiteral.java
@@ -25,6 +25,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
 
 public class XPathNumericLiteral extends XPathExpression {
     public double d;
@@ -42,6 +43,11 @@ public class XPathNumericLiteral extends XPathExpression {
     @Override
     public boolean isIdempotent() {
         return true;
+    }
+
+    @Override
+    public boolean containsFunc(@NotNull String name) {
+        return false;
     }
 
     public String toString () {

--- a/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -16,23 +16,15 @@
 
 package org.javarosa.xpath.expr;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
 import org.javarosa.core.model.data.BooleanData;
 import org.javarosa.core.model.data.DateData;
 import org.javarosa.core.model.data.DateTimeData;
 import org.javarosa.core.model.data.DecimalData;
-import org.javarosa.core.model.data.GeoTraceData;
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.GeoShapeData;
+import org.javarosa.core.model.data.GeoTraceData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.model.data.LongData;
@@ -53,8 +45,17 @@ import org.javarosa.xform.util.XFormAnswerDataSerializer;
 import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.XPathUnsupportedException;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class XPathPathExpr extends XPathExpression {
     private static final Logger logger = LoggerFactory.getLogger(XPathPathExpr.class.getSimpleName());
@@ -422,5 +423,12 @@ public class XPathPathExpr extends XPathExpression {
         return (filtExpr == null || filtExpr.isIdempotent()) && Arrays.stream(steps).allMatch((step) -> {
             return Arrays.stream(step.predicates).allMatch(XPathExpression::isIdempotent);
         });
+    }
+
+    @Override
+    public boolean containsFunc(@NotNull String name) {
+        return (filtExpr != null && filtExpr.containsFunc(name)) || Arrays.stream(steps).anyMatch(xPathStep -> Arrays.stream(xPathStep.predicates)
+            .anyMatch(expression -> expression.containsFunc(name))
+        );
     }
 }

--- a/src/main/java/org/javarosa/xpath/expr/XPathStringLiteral.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathStringLiteral.java
@@ -25,6 +25,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
 
 public class XPathStringLiteral extends XPathExpression {
     public String s;
@@ -42,6 +43,11 @@ public class XPathStringLiteral extends XPathExpression {
     @Override
     public boolean isIdempotent() {
         return true;
+    }
+
+    @Override
+    public boolean containsFunc(@NotNull String name) {
+        return false;
     }
 
     public String toString () {

--- a/src/main/java/org/javarosa/xpath/expr/XPathUnaryOpExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathUnaryOpExpr.java
@@ -24,6 +24,7 @@ import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.core.util.externalizable.DeserializationException;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class XPathUnaryOpExpr extends XPathOpExpr {
     public XPathExpression a;
@@ -46,6 +47,11 @@ public abstract class XPathUnaryOpExpr extends XPathOpExpr {
     @Override
     public boolean isIdempotent() {
         return a.isIdempotent();
+    }
+
+    @Override
+    public boolean containsFunc(@NotNull String name) {
+        return a.containsFunc(name);
     }
 
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {

--- a/src/main/java/org/javarosa/xpath/expr/XPathVariableReference.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathVariableReference.java
@@ -25,6 +25,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.jetbrains.annotations.NotNull;
 
 public class XPathVariableReference extends XPathExpression {
     public XPathQName id;
@@ -42,6 +43,11 @@ public class XPathVariableReference extends XPathExpression {
     @Override
     public boolean isIdempotent() {
         return true;
+    }
+
+    @Override
+    public boolean containsFunc(@NotNull String name) {
+        return false;
     }
 
     public String toString () {

--- a/src/test/java/org/javarosa/xpath/expr/XPathBinaryOpExprTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathBinaryOpExprTest.java
@@ -1,0 +1,49 @@
+package org.javarosa.xpath.expr;
+
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.DataInstance;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class XPathBinaryOpExprTest {
+
+    @Test
+    public void containsFunc_whenNeitherSideContainsMatchingFunction_returnsFalse() {
+        FakeXPathBinaryOpExpr expr = new FakeXPathBinaryOpExpr(
+            new XPathFuncExpr(new XPathQName("a")),
+            new XPathFuncExpr(new XPathQName("b"))
+        );
+
+        assertThat(expr.containsFunc("c"), equalTo(false));
+    }
+
+    @Test
+    public void containsFunc_whenEitherSideContainsMatchingFunction_returnTrue() {
+        FakeXPathBinaryOpExpr expr = new FakeXPathBinaryOpExpr(
+            new XPathFuncExpr(new XPathQName("a")),
+            new XPathFuncExpr(new XPathQName("b"))
+        );
+
+        assertThat(expr.containsFunc("a"), equalTo(true));
+        assertThat(expr.containsFunc("b"), equalTo(true));
+    }
+
+    private static class FakeXPathBinaryOpExpr extends XPathBinaryOpExpr {
+
+        public FakeXPathBinaryOpExpr(XPathExpression a, XPathExpression b) {
+            super(a, b);
+        }
+
+        @Override
+        public Object eval(DataInstance model, EvaluationContext evalContext) {
+            return null;
+        }
+
+        @Override
+        public boolean isIdempotent() {
+            return false;
+        }
+    }
+}

--- a/src/test/java/org/javarosa/xpath/expr/XPathFilterExprTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathFilterExprTest.java
@@ -1,0 +1,42 @@
+package org.javarosa.xpath.expr;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class XPathFilterExprTest {
+
+    @Test
+    public void containsFunc_whenFunctionNotInExpressionOrPredicates_returnsFalse() {
+        // a()[b()]
+        XPathFilterExpr expr = new XPathFilterExpr(
+            new XPathFuncExpr(new XPathQName("a")),
+            new XPathExpression[]{new XPathFuncExpr(new XPathQName("b"))}
+        );
+
+        assertThat(expr.containsFunc("c"), equalTo(false));
+    }
+
+    @Test
+    public void containsFunc_whenFunctionInExpression_returnsTrue() {
+        // a()[b()]
+        XPathFilterExpr expr = new XPathFilterExpr(
+            new XPathFuncExpr(new XPathQName("a")),
+            new XPathExpression[]{new XPathFuncExpr(new XPathQName("b"))}
+        );
+
+        assertThat(expr.containsFunc("a"), equalTo(true));
+    }
+
+    @Test
+    public void containsFunc_whenFunctionInPredicates_returnsTrue() {
+        // a()[b()]
+        XPathFilterExpr expr = new XPathFilterExpr(
+            new XPathFuncExpr(new XPathQName("a")),
+            new XPathExpression[]{new XPathFuncExpr(new XPathQName("b"))}
+        );
+
+        assertThat(expr.containsFunc("b"), equalTo(true));
+    }
+}

--- a/src/test/java/org/javarosa/xpath/expr/XPathFuncExprTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathFuncExprTest.java
@@ -11,9 +11,33 @@ public class XPathFuncExprTest {
     public void isIdempotent_whenArgsContainsNonIdempotentFunc_returnsFalse() {
         // string(random())
         XPathFuncExpr expr = new XPathFuncExpr(new XPathQName("string"), new XPathExpression[] {
-            new XPathFuncExpr(new XPathQName("random"), new XPathExpression[] {})
+            new XPathFuncExpr(new XPathQName("random"))
         });
 
         assertThat(expr.isIdempotent(), equalTo(false));
+    }
+
+    @Test
+    public void containsFunc_whenFunctionNameMatches_returnTrue() {
+        // random()
+        XPathFuncExpr expr = new XPathFuncExpr(new XPathQName("random"));
+        assertThat(expr.containsFunc("random"), equalTo(true));
+    }
+
+    @Test
+    public void containsFunc_whenArgsIncludeFunction_returnTrue() {
+        // string(random())
+        XPathFuncExpr expr = new XPathFuncExpr(new XPathQName("string"), new XPathExpression[] {
+            new XPathFuncExpr(new XPathQName("random"))
+        });
+
+        assertThat(expr.containsFunc("random"), equalTo(true));
+    }
+
+    @Test
+    public void containFunc_whenFunctionNameDoesNotMatch_returnsFalse() {
+        // random()
+        XPathFuncExpr expr = new XPathFuncExpr(new XPathQName("random"));
+        assertThat(expr.containsFunc("other"), equalTo(false));
     }
 }

--- a/src/test/java/org/javarosa/xpath/expr/XPathPathExprTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathPathExprTest.java
@@ -1,0 +1,58 @@
+package org.javarosa.xpath.expr;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class XPathPathExprTest {
+
+    @Test
+    public void containsFunc_whenNoFilter_andNoStepPredicatesContainFunction_returnsFalse() {
+        XPathStep step = new XPathStep();
+        step.predicates = new XPathExpression[]{new XPathFuncExpr(new XPathQName("a"))};
+
+        XPathPathExpr expr = new XPathPathExpr(
+            XPathPathExpr.INIT_CONTEXT_ROOT,
+            new XPathStep[]{step}
+        );
+
+        assertThat(expr.containsFunc("b"), equalTo(false));
+    }
+
+    @Test
+    public void containsFunc_whenNeitherFilterOrStepPredicatesContainFunction_returnsFalse() {
+        XPathStep step = new XPathStep();
+        step.predicates = new XPathExpression[]{new XPathFuncExpr(new XPathQName("b"))};
+
+        XPathPathExpr expr = new XPathPathExpr(
+            new XPathFilterExpr(new XPathFuncExpr(new XPathQName("a")), new XPathExpression[]{}),
+            new XPathStep[]{step}
+        );
+
+        assertThat(expr.containsFunc("c"), equalTo(false));
+    }
+
+    @Test
+    public void containsFunc_whenFunctionInFilter_returnsTrue() {
+        XPathPathExpr expr = new XPathPathExpr(
+            new XPathFilterExpr(new XPathFuncExpr(new XPathQName("a")), new XPathExpression[]{}),
+            new XPathStep[]{}
+        );
+
+        assertThat(expr.containsFunc("a"), equalTo(true));
+    }
+
+    @Test
+    public void containsFunc_whenFunctionInStep_returnsTrue() {
+        XPathStep step = new XPathStep();
+        step.predicates = new XPathExpression[]{new XPathFuncExpr(new XPathQName("a"))};
+
+        XPathPathExpr expr = new XPathPathExpr(
+            XPathPathExpr.INIT_CONTEXT_ROOT,
+            new XPathStep[]{step}
+        );
+
+        assertThat(expr.containsFunc("a"), equalTo(true));
+    }
+}

--- a/src/test/java/org/javarosa/xpath/expr/XPathUnaryOpExprTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathUnaryOpExprTest.java
@@ -1,0 +1,36 @@
+package org.javarosa.xpath.expr;
+
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.DataInstance;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class XPathUnaryOpExprTest {
+
+    @Test
+    public void containsFunc_whenFunctionNotInExpression_returnsFalse() {
+        // -a()
+        FakeXPathUnaryOpExpr expr = new FakeXPathUnaryOpExpr(new XPathFuncExpr(new XPathQName("a")));
+        assertThat(expr.containsFunc("b"), equalTo(false));
+    }
+
+    @Test
+    public void containsFunc_whenFunctionInExpression_returnsTrue() {
+        FakeXPathUnaryOpExpr expr = new FakeXPathUnaryOpExpr(new XPathFuncExpr(new XPathQName("a")));
+        assertThat(expr.containsFunc("a"), equalTo(true));
+    }
+
+    private static class FakeXPathUnaryOpExpr extends XPathUnaryOpExpr {
+
+        public FakeXPathUnaryOpExpr(XPathExpression a) {
+            super(a);
+        }
+
+        @Override
+        public Object eval(DataInstance model, EvaluationContext evalContext) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Work towards getodk/collect#5620

This change allows a client add a processor to `XFormParser` that would allow it to detect the presence of particular functions or properties of a question:

```kotlin
xFormParser.addProcessor(object : BindAttributeProcessor, QuestionProcessor {
    override fun getBindAttributes(): Set<Pair<String, String>> {
        return setOf(Pair("", "calculate"))
    }

    override fun processBindAttribute(name: String, value: String, binding: DataBinding) {
        val calculate = binding.calculate
        val containsFunc = calculate.expr.expr.containsFunc("myFunc")
    }

    override fun processQuestion(question: Question) {
        val containsAppearance = question.appearanceAttr.contains("myCustomAppearance")
    }
})
```

This will let us detect forms that do/don't contain `pulldata` or `search`.

I've also added a convenience implementation of a wrapper `IXFormParserFactory` (which will make Collect's code cleaner).

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

We could have used the existing `BindAttributeProcessor`, but that would have meant parsing `calculate` in the processor which didn't feel ideal.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No user facing changes as this is opt in.