### PR TITLE
Use `FilterStrategy` optimizations for select choice filters

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -163,6 +163,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     private boolean predicateCaching = true;
     private final FilterStrategy comparisonExpressionCacheFilterStrategy = new ComparisonExpressionCacheFilterStrategy();
+    private final FilterStrategy equalityExpressionIndexFilterStrategy = new EqualityExpressionIndexFilterStrategy();
     private final Queue<FilterStrategy> customFilterStrategies = new LinkedList<>();
 
     private EvaluationContext exprEvalContext;
@@ -762,7 +763,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         if (predicateCaching) {
             List<FilterStrategy> filters = Stream.concat(
                 customFilterStrategies.stream(),
-                Stream.of(comparisonExpressionCacheFilterStrategy)
+                Stream.of(equalityExpressionIndexFilterStrategy, comparisonExpressionCacheFilterStrategy)
             ).collect(Collectors.toList());
 
             context = new EvaluationContext(this.exprEvalContext, filters);

--- a/src/main/java/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/main/java/org/javarosa/core/model/ItemsetBinding.java
@@ -1,6 +1,7 @@
 package org.javarosa.core.model;
 
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.condition.FilterStrategy;
 import org.javarosa.core.model.condition.IConditionExpr;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.MultipleItemsData;
@@ -30,6 +31,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +67,8 @@ public class ItemsetBinding implements Externalizable, Localizable {
     public boolean randomize = false;
     public XPathNumericLiteral randomSeedNumericExpr = null;
     public XPathPathExpr randomSeedPathExpr = null;
+
+    private final FilterStrategy comparisonExpressionCacheFilterStrategy = new ComparisonExpressionCacheFilterStrategy();
 
     /**
      * @deprecated No tests and no evidence it's used.
@@ -108,8 +112,9 @@ public class ItemsetBinding implements Externalizable, Localizable {
             formInstance = formDef.getMainInstance();
         }
 
-        List<TreeReference> filteredItemReferences = nodesetExpr.evalNodeset(formDef.getMainInstance(),
-            new EvaluationContext(formDef.getEvaluationContext(), contextRef.contextualize(curQRef)));
+        EvaluationContext evalContext = new EvaluationContext(formDef.getEvaluationContext(), contextRef.contextualize(curQRef));
+        EvaluationContext cachingContext = new EvaluationContext(evalContext, Arrays.asList(comparisonExpressionCacheFilterStrategy));
+        List<TreeReference> filteredItemReferences = nodesetExpr.evalNodeset(formDef.getMainInstance(), cachingContext);
 
         if (filteredItemReferences == null) {
             throw new XPathException("Could not find references depended on by" + nodesetRef.getInstanceName());

--- a/src/main/java/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/main/java/org/javarosa/core/model/ItemsetBinding.java
@@ -1,18 +1,5 @@
 package org.javarosa.core.model;
 
-import static org.javarosa.core.model.FormDef.getAbsRef;
-import static org.javarosa.xform.parse.RandomizeHelper.shuffle;
-import static org.javarosa.xpath.expr.XPathFuncExpr.toNumeric;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IConditionExpr;
 import org.javarosa.core.model.data.IAnswerData;
@@ -38,6 +25,19 @@ import org.javarosa.xpath.XPathConditional;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.expr.XPathNumericLiteral;
 import org.javarosa.xpath.expr.XPathPathExpr;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.javarosa.core.model.FormDef.getAbsRef;
+import static org.javarosa.xform.parse.RandomizeHelper.shuffle;
+import static org.javarosa.xpath.expr.XPathFuncExpr.toNumeric;
 
 public class ItemsetBinding implements Externalizable, Localizable {
     // Temporarily cached filtered list (not serialized)
@@ -101,14 +101,6 @@ public class ItemsetBinding implements Externalizable, Localizable {
         boolean allTriggerRefsBound = currentTriggerValues != null;
 
         Long currentRandomizeSeed = resolveRandomSeed(formDef.getMainInstance(), formDef.getEvaluationContext());
-
-        // Return cached list if possible
-        if (cachedFilteredChoiceList != null && allTriggerRefsBound && Objects.equals(currentTriggerValues, cachedTriggerValues)
-            && Objects.equals(currentRandomizeSeed, cachedRandomizeSeed)) {
-            updateQuestionAnswerInModel(formDef, curQRef);
-
-            return randomize && cachedRandomizeSeed == null ? shuffle(cachedFilteredChoiceList) : cachedFilteredChoiceList;
-        }
 
         formDef.getEventNotifier().publishEvent(new Event("Dynamic choices", new EvaluationResult(curQRef, null)));
 

--- a/src/main/java/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/main/java/org/javarosa/core/model/ItemsetBinding.java
@@ -1,7 +1,6 @@
 package org.javarosa.core.model;
 
 import org.javarosa.core.model.condition.EvaluationContext;
-import org.javarosa.core.model.condition.FilterStrategy;
 import org.javarosa.core.model.condition.IConditionExpr;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.MultipleItemsData;
@@ -31,7 +30,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,8 +65,6 @@ public class ItemsetBinding implements Externalizable, Localizable {
     public boolean randomize = false;
     public XPathNumericLiteral randomSeedNumericExpr = null;
     public XPathPathExpr randomSeedPathExpr = null;
-
-    private final FilterStrategy comparisonExpressionCacheFilterStrategy = new ComparisonExpressionCacheFilterStrategy();
 
     /**
      * @deprecated No tests and no evidence it's used.
@@ -113,8 +109,7 @@ public class ItemsetBinding implements Externalizable, Localizable {
         }
 
         EvaluationContext evalContext = new EvaluationContext(formDef.getEvaluationContext(), contextRef.contextualize(curQRef));
-        EvaluationContext cachingContext = new EvaluationContext(evalContext, Arrays.asList(comparisonExpressionCacheFilterStrategy));
-        List<TreeReference> filteredItemReferences = nodesetExpr.evalNodeset(formDef.getMainInstance(), cachingContext);
+        List<TreeReference> filteredItemReferences = nodesetExpr.evalNodeset(formDef.getMainInstance(), evalContext);
 
         if (filteredItemReferences == null) {
             throw new XPathException("Could not find references depended on by" + nodesetRef.getInstanceName());

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -18,7 +18,6 @@ package org.javarosa.core.model;
 
 import org.javarosa.core.model.condition.Condition;
 import org.javarosa.core.model.condition.EvaluationContext;
-import org.javarosa.core.model.condition.FilterStrategy;
 import org.javarosa.core.model.condition.Recalculate;
 import org.javarosa.core.model.condition.Triggerable;
 import org.javarosa.core.model.instance.AbstractTreeElement;
@@ -41,6 +40,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 
 public class TriggerableDag {
@@ -99,7 +98,6 @@ public class TriggerableDag {
     private Map<TreeReference, QuickTriggerable> relevancePerRepeat = new HashMap<>();
 
     private boolean predicateCaching = true;
-    private final FilterStrategy equalityExpressionIndexFilterStrategy = new EqualityExpressionIndexFilterStrategy();
 
     TriggerableDag(EventNotifierAccessor accessor) {
         this.accessor = accessor;
@@ -522,9 +520,8 @@ public class TriggerableDag {
 
         EvaluationContext context;
         if (predicateCaching) {
-            context = new EvaluationContext(evalContext, asList(
-                new IdempotentExpressionCacheFilterStrategy(),
-                equalityExpressionIndexFilterStrategy
+            context = new EvaluationContext(evalContext, Collections.singletonList(
+                new IdempotentExpressionCacheFilterStrategy()
             ));
         } else {
             context = evalContext;

--- a/src/main/java/org/javarosa/core/model/TriggerableDag.java
+++ b/src/main/java/org/javarosa/core/model/TriggerableDag.java
@@ -47,11 +47,9 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 
 public class TriggerableDag {
@@ -101,9 +99,7 @@ public class TriggerableDag {
     private Map<TreeReference, QuickTriggerable> relevancePerRepeat = new HashMap<>();
 
     private boolean predicateCaching = true;
-    private final FilterStrategy comparisonExpressionCacheFilterStrategy = new ComparisonExpressionCacheFilterStrategy();
     private final FilterStrategy equalityExpressionIndexFilterStrategy = new EqualityExpressionIndexFilterStrategy();
-    private final Queue<FilterStrategy> customFilterStrategies = new LinkedList<>();
 
     TriggerableDag(EventNotifierAccessor accessor) {
         this.accessor = accessor;
@@ -526,12 +522,10 @@ public class TriggerableDag {
 
         EvaluationContext context;
         if (predicateCaching) {
-            List<FilterStrategy> filters = Stream.concat(
-                customFilterStrategies.stream(),
-                Stream.of(equalityExpressionIndexFilterStrategy, comparisonExpressionCacheFilterStrategy, new IdempotentExpressionCacheFilterStrategy())
-            ).collect(Collectors.toList());
-
-            context = new EvaluationContext(evalContext, filters);
+            context = new EvaluationContext(evalContext, asList(
+                new IdempotentExpressionCacheFilterStrategy(),
+                equalityExpressionIndexFilterStrategy
+            ));
         } else {
             context = evalContext;
         }
@@ -748,10 +742,6 @@ public class TriggerableDag {
     // endregion
 
     public void disablePredicateCaching() {
-        this.predicateCaching = false;
-    }
-
-    public void addFilterStrategy(FilterStrategy filterStrategy) {
-        customFilterStrategies.add(filterStrategy);
+        predicateCaching = false;
     }
 }

--- a/src/test/java/org/javarosa/core/model/DynamicSelectUpdateTest.java
+++ b/src/test/java/org/javarosa/core/model/DynamicSelectUpdateTest.java
@@ -184,33 +184,6 @@ public class DynamicSelectUpdateTest {
     }
     //endregion
 
-    //region Caching
-    @Test
-    public void selectWithUnchangedTriggers_providesCachedChoiceList() throws Exception {
-        Scenario scenario = Scenario.init("Select", html(
-            head(
-                title("Select"),
-                model(
-                    mainInstance(
-                        t("data id='select'",
-                            t("filter"),
-                            t("select"))),
-
-                    instance("choices",
-                        item("aa", "A"),
-                        item("aaa", "AA"),
-                        item("bb", "B"),
-                        item("bbb", "BB")))),
-            body(
-                input("/data/filter"),
-                select1Dynamic("/data/select", "instance('choices')/root/item[starts-with(value,/data/filter)]")
-            )));
-
-        scenario.answer("/data/filter", "a");
-        List<SelectChoice> choices = scenario.choicesOf("/data/select");
-        assertThat(scenario.choicesOf("/data/select"), sameInstance(choices));
-    }
-
     @Test
     public void selectWithChangedTriggers_recomputesChoiceList() throws Exception {
         Scenario scenario = Scenario.init("Select", html(
@@ -316,81 +289,6 @@ public class DynamicSelectUpdateTest {
         scenario.answer("/data/repeat[1]/filter", "bb");
         assertThat(scenario.choicesOf("/data/repeat[0]/select").size(), is(2));
         assertThat(scenario.choicesOf("/data/repeat[1]/select").size(), is(1));
-    }
-
-    @Test
-    public void selectInRepeat_withRootRefInPredicate_returnsCachedChoiceListUnlessRootValueChanges() throws Exception {
-        Scenario scenario = Scenario.init("Select in repeat", html(
-            head(
-                title("Select in repeat"),
-                model(
-                    mainInstance(
-                        t("data id='repeat-select'",
-                            t("filter"),
-                            t("repeat",
-                                t("select")))),
-
-                    instance("choices",
-                        item("a", "A"),
-                        item("aa", "AA"),
-                        item("b", "B"),
-                        item("bb", "BB")))),
-            body(
-                input("filter"),
-                repeat("/data/repeat",
-                    select1Dynamic("/data/repeat/select", "instance('choices')/root/item[starts-with(value,/data/filter)]"))
-            )));
-
-        scenario.answer("/data/filter", "a");
-        scenario.createNewRepeat("/data/repeat");
-
-        List<SelectChoice> repeat0Choices = scenario.choicesOf("/data/repeat[0]/select");
-        List<SelectChoice> repeat1Choices = scenario.choicesOf("/data/repeat[1]/select");
-        assertThat(repeat0Choices, sameInstance(repeat1Choices));
-
-        scenario.answer("/data/filter", "bb");
-        assertThat(scenario.choicesOf("/data/repeat[0]/select").size(), is(1));
-    }
-
-    @Test
-    public void selectInNestedRepeat_withPredicateWithOuterRef_returnsCachedChoiceListForSameOuterRepeatInstance() throws Exception {
-        Scenario scenario = Scenario.init("Select in repeat", html(
-            head(
-                title("Select in repeat"),
-                model(
-                    mainInstance(
-                        t("data id='repeat-select'",
-                            t("outer",
-                                t("filter"),
-                                t("inner",
-                                    t("select"))))),
-
-                    instance("choices",
-                        item("a", "A"),
-                        item("aa", "AA"),
-                        item("b", "B"),
-                        item("bb", "BB")))),
-            body(
-                repeat("/data/outer",
-                    input("filter"),
-                    repeat("/data/outer/inner",
-                        select1Dynamic("/data/outer/inner/select", "instance('choices')/root/item[starts-with(value,current()/../../filter)]"))
-            ))));
-
-        scenario.answer("/data/outer[0]/filter", "a");
-        scenario.createNewRepeat("/data/outer[0]/inner");
-        scenario.answer("/data/outer[1]/filter", "a");
-        scenario.createNewRepeat("/data/outer[1]/inner");
-        scenario.createNewRepeat("/data/outer[1]/inner");
-
-        List<SelectChoice> outer0Inner0Choices = scenario.choicesOf("/data/outer[0]/inner[0]/select");
-        List<SelectChoice> outer0Inner1Choices = scenario.choicesOf("/data/outer[0]/inner[1]/select");
-        assertThat(outer0Inner0Choices, sameInstance(outer0Inner1Choices));
-
-        List<SelectChoice> outer1Inner0Choices = scenario.choicesOf("/data/outer[1]/inner[0]/select");
-        List<SelectChoice> outer1Inner1Choices = scenario.choicesOf("/data/outer[1]/inner[1]/select");
-        assertThat(outer1Inner0Choices, sameInstance(outer1Inner1Choices));
-        assertThat(outer1Inner0Choices, not(sameInstance(outer0Inner0Choices)));
     }
     //endregion
     //endregion

--- a/src/test/java/org/javarosa/core/model/PredicateCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/PredicateCachingTest.java
@@ -1,4 +1,4 @@
-package org.javarosa.core.model.test;
+package org.javarosa.core.model;
 
 import org.javarosa.core.test.Scenario;
 import org.javarosa.measure.Measure;

--- a/src/test/java/org/javarosa/core/model/SelectCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectCachingTest.java
@@ -58,7 +58,7 @@ public class SelectCachingTest {
     }
 
     @Test
-    public void repeatedEqChoiceFiltersAreOnlyEvaluatedOnce() throws Exception {
+    public void repeatedEqChoiceFiltersAreOnlyEvaluatedOnce_whileLiteralExpressionIsTheSame() throws Exception {
         Scenario scenario = Scenario.init("Some form", html(
             head(
                 title("Some form"),
@@ -88,6 +88,45 @@ public class SelectCachingTest {
             scenario.answer("/data/choice", "a");
 
             scenario.choicesOf("/data/select1");
+            scenario.choicesOf("/data/select2");
+        });
+
+        // Check that we do less than (size of secondary instance) * (number of choice lookups)
+        assertThat(evaluations, lessThan(4));
+    }
+
+    @Test
+    public void repeatedEqChoiceFiltersAreOnlyEvaluatedOnce() throws Exception {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("choice"),
+                        t("select1"),
+                        t("select2")
+                    )),
+                    instance("instance",
+                        item("a", "A"),
+                        item("b", "B")
+                    ),
+                    bind("/data/choice").type("string"),
+                    bind("/data/select1").type("string"),
+                    bind("/data/select2").type("string")
+                )
+            ),
+            body(
+                input("/data/choice"),
+                select1Dynamic("/data/select1", "instance('instance')/root/item[value=/data/choice]"),
+                select1Dynamic("/data/select2", "instance('instance')/root/item[value=/data/choice]")
+            )
+        ));
+
+        int evaluations = Measure.withMeasure(asList("PredicateEvaluation", "IndexEvaluation"), () -> {
+            scenario.answer("/data/choice", "a");
+            scenario.choicesOf("/data/select1");
+
+            scenario.answer("/data/choice", "b");
             scenario.choicesOf("/data/select2");
         });
 

--- a/src/test/java/org/javarosa/core/model/SelectCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectCachingTest.java
@@ -1,0 +1,59 @@
+package org.javarosa.core.model;
+
+import org.javarosa.core.test.Scenario;
+import org.javarosa.measure.Measure;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
+import static org.javarosa.core.util.XFormsElement.body;
+import static org.javarosa.core.util.XFormsElement.head;
+import static org.javarosa.core.util.XFormsElement.html;
+import static org.javarosa.core.util.XFormsElement.input;
+import static org.javarosa.core.util.XFormsElement.instance;
+import static org.javarosa.core.util.XFormsElement.item;
+import static org.javarosa.core.util.XFormsElement.mainInstance;
+import static org.javarosa.core.util.XFormsElement.model;
+import static org.javarosa.core.util.XFormsElement.select1Dynamic;
+import static org.javarosa.core.util.XFormsElement.t;
+import static org.javarosa.core.util.XFormsElement.title;
+
+public class SelectCachingTest {
+
+    @Test
+    public void EqChoiceFiltersAreOnlyEvaluatedOnceForRepeatedChoiceListEvaluations() throws Exception {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("choice"),
+                        t("select")
+                    )),
+                    instance("instance",
+                        item("a", "A"),
+                        item("b", "B")
+                    ),
+                    bind("/data/choice").type("string"),
+                    bind("/data/select").type("string")
+                )
+            ),
+            body(
+                input("/data/choice"),
+                select1Dynamic("/data/select", "instance('instance')/root/item[value=/data/choice]")
+            )
+        ));
+
+        int evaluations = Measure.withMeasure(asList("PredicateEvaluation", "IndexEvaluation"), () -> {
+            scenario.answer("/data/choice", "a");
+
+            scenario.choicesOf("/data/select");
+            scenario.choicesOf("/data/select");
+        });
+
+        // Check that we do less than (size of secondary instance) * (number of choice lookups)
+        assertThat(evaluations, lessThan(4));
+    }
+}

--- a/src/test/java/org/javarosa/core/model/SelectCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectCachingTest.java
@@ -23,7 +23,7 @@ import static org.javarosa.core.util.XFormsElement.title;
 public class SelectCachingTest {
 
     @Test
-    public void EqChoiceFiltersAreOnlyEvaluatedOnceForRepeatedChoiceListEvaluations() throws Exception {
+    public void eqChoiceFiltersAreOnlyEvaluatedOnceForRepeatedChoiceListEvaluations() throws Exception {
         Scenario scenario = Scenario.init("Some form", html(
             head(
                 title("Some form"),

--- a/src/test/java/org/javarosa/core/model/SelectCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectCachingTest.java
@@ -56,4 +56,42 @@ public class SelectCachingTest {
         // Check that we do less than (size of secondary instance) * (number of choice lookups)
         assertThat(evaluations, lessThan(4));
     }
+
+    @Test
+    public void repeatedEqChoiceFiltersAreOnlyEvaluatedOnce() throws Exception {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("choice"),
+                        t("select1"),
+                        t("select2")
+                    )),
+                    instance("instance",
+                        item("a", "A"),
+                        item("b", "B")
+                    ),
+                    bind("/data/choice").type("string"),
+                    bind("/data/select1").type("string"),
+                    bind("/data/select2").type("string")
+                )
+            ),
+            body(
+                input("/data/choice"),
+                select1Dynamic("/data/select1", "instance('instance')/root/item[value=/data/choice]"),
+                select1Dynamic("/data/select2", "instance('instance')/root/item[value=/data/choice]")
+            )
+        ));
+
+        int evaluations = Measure.withMeasure(asList("PredicateEvaluation", "IndexEvaluation"), () -> {
+            scenario.answer("/data/choice", "a");
+
+            scenario.choicesOf("/data/select1");
+            scenario.choicesOf("/data/select2");
+        });
+
+        // Check that we do less than (size of secondary instance) * (number of choice lookups)
+        assertThat(evaluations, lessThan(4));
+    }
 }

--- a/src/test/java/org/javarosa/core/util/XFormsElement.java
+++ b/src/test/java/org/javarosa/core/util/XFormsElement.java
@@ -44,8 +44,8 @@ public interface XFormsElement {
         Map<String, String> attributes = new HashMap<>();
         String[] words = name.split(" ");
         for (String word : Arrays.asList(words).subList(1, words.length)) {
-            String[] parts = word.split("(?<!\\))=");
-            attributes.put(parts[0], parts[1].substring(1, parts[1].length() - 1));
+            String[] parts = word.split("(?<!\\))=(\"|')");
+            attributes.put(parts[0], parts[1].substring(0, parts[1].length() - 1));
         }
         return attributes;
     }


### PR DESCRIPTION
Closes getodk/collect#5694

The core change here is to move the state around building the base `FilterStrategy` chain to `FormDef` up from `TriggerableDag` to allow it to be shared by `ItemsetBinding` (where choice filters are evaluated).

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

It does feel to me like `FormDef` is the wrong place to own both the base `EvaluationContext` and the `TriggerableDag` instances. In my mind, `FormDef` should really be a "data" object that's output by the "parsing" part of JavaRosa and that `EvaluationContext` and `TriggerableDag` should probably be owned by something in the "runtime" world (`FormEntryController` for instance). I had a quick think through detaching these, but it would be massive and not something I feel like should distract from the user facing improvements here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just speed things up! Obvious things to think about are how the `FilterStrategy` instances that are now used during choice filter evaluations could cause problems.