### PR TITLE
Fix custom function handler support

### DIFF
--- a/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -38,9 +38,14 @@ import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.condition.IFunctionHandler;
 import org.javarosa.core.test.Scenario;
 import org.javarosa.core.util.XFormsElement;
 import org.javarosa.form.api.FormEntryCaption;
@@ -370,5 +375,55 @@ public class FormDefTest {
 
         caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
         MatcherAssert.assertThat(caption.getQuestionText(), is("Position: 2"));
+    }
+
+    @Test
+    public void canAddFunctionHandlersBeforeInitialize() throws Exception {
+        FormDef formDef = Scenario.createFormDef("custom-func-form", html(
+            head(
+                title("custom-func-form"),
+                model(
+                    mainInstance(t("data",
+                        t("calculate"),
+                        t("input")
+                    )),
+                    bind("/data/calculate").type("string").calculate("custom-func()")
+                )
+            ),
+            body(
+                input("/data/input",
+                    label("/data/calculate")
+                )
+            )
+        ));
+
+        formDef.getEvaluationContext().addFunctionHandler(new IFunctionHandler() {
+            @Override
+            public String getName() {
+                return "custom-func";
+            }
+
+            @Override
+            public List<Class[]> getPrototypes() {
+                return new ArrayList<Class[]>();
+            }
+
+            @Override
+            public boolean rawArgs() {
+                return true;
+            }
+
+            @Override
+            public boolean realTime() {
+                return false;
+            }
+
+            @Override
+            public Object eval(Object[] args, EvaluationContext ec) {
+                return "blah";
+            }
+        });
+
+        Scenario.init(formDef);
     }
 }

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -57,6 +57,7 @@ import org.javarosa.xpath.expr.XPathNumNegExpr;
 import org.javarosa.xpath.expr.XPathNumericLiteral;
 import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -438,6 +439,14 @@ public class Scenario {
         return Scenario.init(formFile);
     }
 
+    public static FormDef createFormDef(String formName, XFormsElement form) throws IOException, XFormParser.ParseException {
+        Path formFile = createTempDirectory("javarosa").resolve(formName + ".xml");
+        String xml = form.asXml();
+        System.out.println(xml);
+        write(formFile, xml.getBytes(UTF_8), CREATE);
+        return Scenario.createFormDef(formFile);
+    }
+
     /**
      * Initializes the Scenario with provided form filename.
      * <p>
@@ -451,13 +460,24 @@ public class Scenario {
      * Initializes the Scenario with the form at the provided path
      */
     public static Scenario init(Path formFile) throws XFormParser.ParseException {
+        FormDef formDef = createFormDef(formFile);
+        formDef.initialize(true, new InstanceInitializationFactory());
+        return Scenario.from(formDef);
+    }
+
+    public static Scenario init(FormDef formDef) throws XFormParser.ParseException {
+        formDef.initialize(true, new InstanceInitializationFactory());
+        return Scenario.from(formDef);
+    }
+
+    @NotNull
+    public static FormDef createFormDef(Path formFile) throws XFormParser.ParseException {
         // TODO explain why this sequence of calls
         StorageManager.setStorageFactory((name, type) -> new DummyIndexedStorageUtility<>());
         new XFormsModule().registerModule();
         FormParseInit fpi = new FormParseInit(formFile);
         FormDef formDef = fpi.getFormDef();
-        formDef.initialize(true, new InstanceInitializationFactory());
-        return Scenario.from(formDef);
+        return formDef;
     }
 
     // endregion


### PR DESCRIPTION
This had been broken by #722.

#### What has been done to verify that this works as intended?

New and existing tests.

#### Why is this the best possible solution? Were any other approaches considered?

I'd really like to deprecate `FormDef#getEvaluationContext` as it really doesn't feel like it belongs there. I might do an afternoon spike on that and see how far I can get, but it's definitely too much work to hold up a fix for.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This basically reverts the behavior to how it was pre #722 so this is hopefully fairly low risk. That said, changes to this are are pretty scary and can have subtle side effects.
