### PR TITLE
Add ability to process xpath expressions during parse

### DIFF
--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -59,6 +59,7 @@ import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.javarosa.xpath.XPathConditional;
 import org.javarosa.xpath.XPathParseTool;
+import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.javarosa.xpath.expr.XPathNumericLiteral;
 import org.javarosa.xpath.expr.XPathPathExpr;
@@ -182,6 +183,9 @@ public class XFormParser implements IXFormParserFunctions {
     private final List<FormDefProcessor> formDefProcessors = new ArrayList<>();
     private final List<ModelAttributeProcessor> modelAttributeProcessors = new ArrayList<>();
     private final List<QuestionProcessor> questionProcessors = new ArrayList<>();
+    private final List<XPathProcessor> xpathProcessors = new ArrayList<>();
+
+    public static final List<XPathProcessor> tempXPathProcessors = new ArrayList<>();
 
     /**
      * The string IDs of all instances that are referenced in a instance() function call in the primary instance
@@ -396,6 +400,7 @@ public class XFormParser implements IXFormParserFunctions {
                 throw new IllegalStateException("Another XForm is being parsed!");
             }
 
+            tempXPathProcessors.addAll(xpathProcessors);
 
             if (_f == null) {
                 logger.info("Parsing form...");
@@ -428,6 +433,7 @@ public class XFormParser implements IXFormParserFunctions {
 
             return _f;
         } finally {
+            tempXPathProcessors.clear();
             parseLock.unlock();
         }
     }
@@ -447,6 +453,10 @@ public class XFormParser implements IXFormParserFunctions {
 
         if (processor instanceof QuestionProcessor) {
             questionProcessors.add((QuestionProcessor) processor);
+        }
+
+        if (processor instanceof XPathProcessor) {
+            xpathProcessors.add((XPathProcessor) processor);
         }
     }
 
@@ -2449,6 +2459,10 @@ public class XFormParser implements IXFormParserFunctions {
 
     public interface Processor {
 
+    }
+
+    public interface XPathProcessor extends Processor {
+        void processXPath(@NotNull XPathExpression xPathExpression);
     }
 
     public interface FormDefProcessor extends Processor {

--- a/src/main/java/org/javarosa/xpath/XPathParseTool.java
+++ b/src/main/java/org/javarosa/xpath/XPathParseTool.java
@@ -16,6 +16,7 @@
 
 package org.javarosa.xpath;
 
+import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.parser.Lexer;
 import org.javarosa.xpath.parser.Parser;
@@ -38,6 +39,11 @@ public class XPathParseTool {
     };
 
     public static XPathExpression parseXPath (String xpath) throws XPathSyntaxException {
-        return Parser.parse(Lexer.lex(xpath));
+        XPathExpression expression = Parser.parse(Lexer.lex(xpath));
+        for (XFormParser.XPathProcessor processor : XFormParser.tempXPathProcessors) {
+            processor.processXPath(expression);
+        }
+
+        return expression;
     }
 }

--- a/src/test/java/org/javarosa/xform/parse/XPathProcessorTest.java
+++ b/src/test/java/org/javarosa/xform/parse/XPathProcessorTest.java
@@ -1,0 +1,102 @@
+package org.javarosa.xform.parse;
+
+import org.javarosa.core.util.XFormsElement;
+import org.javarosa.xpath.expr.XPathExpression;
+import org.javarosa.xpath.expr.XPathPathExpr;
+import org.javarosa.xpath.expr.XPathQName;
+import org.javarosa.xpath.expr.XPathStep;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
+import static org.javarosa.core.util.XFormsElement.body;
+import static org.javarosa.core.util.XFormsElement.head;
+import static org.javarosa.core.util.XFormsElement.input;
+import static org.javarosa.core.util.XFormsElement.mainInstance;
+import static org.javarosa.core.util.XFormsElement.model;
+import static org.javarosa.core.util.XFormsElement.t;
+
+public class XPathProcessorTest {
+
+    @Test
+    public void processesXPathExpressions() throws Exception {
+        XFormsElement form = XFormsElement.html(
+            head(
+                model(
+                    mainInstance(
+                        t("data id=\"form\"",
+                            t("question")
+                        )
+                    ),
+                    bind("/data/question").type("string")
+                )
+            ),
+            body(
+                input("/data/question")
+            )
+        );
+
+        XFormParser parser = new XFormParser(new InputStreamReader(new ByteArrayInputStream(form.asXml().getBytes())));
+        RecordingXPathProcessor processor = new RecordingXPathProcessor();
+        parser.addProcessor(processor);
+        parser.parse(null);
+
+        assertThat(processor.processedExpressions, contains(
+            new XPathPathExpr(XPathPathExpr.INIT_CONTEXT_ROOT, new XPathStep[]{
+                new XPathStep(XPathStep.AXIS_CHILD, new XPathQName("data")),
+                new XPathStep(XPathStep.AXIS_CHILD, new XPathQName("question"))
+            }),
+            new XPathPathExpr(XPathPathExpr.INIT_CONTEXT_ROOT, new XPathStep[]{
+                new XPathStep(XPathStep.AXIS_CHILD, new XPathQName("data")),
+                new XPathStep(XPathStep.AXIS_CHILD, new XPathQName("question"))
+            })
+        ));
+    }
+
+    @Test
+    public void processorsAreNotRetainedBetweenParses() throws Exception {
+        XFormsElement form = XFormsElement.html(
+            head(
+                model(
+                    mainInstance(
+                        t("data id=\"form\"",
+                            t("question")
+                        )
+                    ),
+                    bind("/data/question").type("string")
+                )
+            ),
+            body(
+                input("/data/question")
+            )
+        );
+
+        XFormParser parser = new XFormParser(new InputStreamReader(new ByteArrayInputStream(form.asXml().getBytes())));
+        RecordingXPathProcessor processor = new RecordingXPathProcessor();
+        parser.addProcessor(processor);
+        parser.parse(null);
+        assertThat(processor.processedExpressions.size(), equalTo(2));
+
+        XFormParser secondParser = new XFormParser(new InputStreamReader(new ByteArrayInputStream(form.asXml().getBytes())));
+        secondParser.parse(null);
+        assertThat(processor.processedExpressions.size(), equalTo(2));
+    }
+
+    private static class RecordingXPathProcessor implements XFormParser.XPathProcessor {
+
+        public final List<XPathExpression> processedExpressions = new ArrayList<>();
+
+        @Override
+        public void processXPath(@NotNull XPathExpression xPathExpression) {
+            processedExpressions.add(xPathExpression);
+        }
+    }
+}


### PR DESCRIPTION
Work toward getodk/collect#5620

This adds a new `XPathProcessor` for `XFormProcessor` that allows a client to inspect every XPath expression in an XForm during parse:

```java
parser.addProcessor(new XFormParser.XPathProcessor() {
    @Override
    public void processXPath(@NotNull XPathExpression xPathExpression) {
        // Do something
    }
});
```

I've also added a lock to `XFormParser#parse` that will prevent two forms being parsed at the same time (even using two different `XFormParser` instances) as `XPathProcessor` (and existing parse code) manipulates static state that could cause problems if that were to happen.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?


We had initially considered just using our existing bind processing with `XPathExpression#containsFunc` to find `pulldata`, but we realised that we needed a more general solution to be able to detect a custom function anywhere in the form (as it could appear in any xpath expression). I'm not a fan of the static state I've added here, but it felt like a losing battle to avoid it given `XFormParser` was already not thread safe in any way. Down the line, we should look at improving that so clients like Collect can parse multiple forms in parallel.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Stopping two forms from being parsed simultaneously is probably the riskiest change here. As far as I know, Collect doesn't do this on purpose, but it might be that it's a possibility with things like auto update or match exactly. That said, if that was happening, I'd potentially rather we crash the app than end up with whatever could happen mixing state from two form parses.