### PR TITLE
Return false instead of crashing when asking if a repeat can be added at a deleted position

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -585,8 +585,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 TreeElement countNode = this.getMainInstance().resolveReference(
                     countRef.contextualize(repeatRef));
                 if (countNode == null) {
-                    throw new RuntimeException("Could not locate the repeat count value expected at "
-                        + repeat.getCountReference().getReference().toString());
+                    return false;
                 }
                 // get the total multiplicity possible
                 long fullcount = AnswerDataUtil.answerDataToInt(countNode.getValue());

--- a/src/main/java/org/javarosa/form/api/FormEntryCaption.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryCaption.java
@@ -320,35 +320,6 @@ public class FormEntryCaption implements FormElementStateListener {
         return reps;
     }
 
-    public class RepeatOptions {
-        public String header;
-        public String add;
-        public String delete;
-        public String done;
-        public String delete_header;
-    }
-
-    public RepeatOptions getRepeatOptions () {
-        RepeatOptions ro = new RepeatOptions();
-        boolean has_repetitions = (getNumRepetitions() > 0);
-
-        ro.header = getRepeatText("mainheader");
-
-        ro.add = null;
-        if (form.canCreateRepeat(form.getChildInstanceRef(index), index)) {
-            ro.add = getRepeatText(has_repetitions ? "add" : "add-empty");
-        }
-        ro.delete = null;
-        ro.delete_header = null;
-        if (has_repetitions) {
-            ro.delete = getRepeatText("del");
-            ro.delete_header = getRepeatText("delheader");
-        }
-        ro.done = getRepeatText(has_repetitions ? "done" : "done-empty");
-
-        return ro;
-    }
-
     public String getAppearanceHint ()  {
         return element.getAppearanceAttr();
     }


### PR DESCRIPTION
Closes #https://github.com/getodk/collect/issues/5539

#### What has been done to verify that this works as intended?
I've added tests and also tested the fix with ODK Collect.

#### Why is this the best possible solution? Were any other approaches considered?
In ODK Collect when we remove a repeat we need to find the last relevant index. In this case we navigate back and check every possible index. If something does not exist we don't want any exceptions but just simple false value.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix so testing the described scenario should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
any form with nested repeats and `repeat_count` like the one attached in https://github.com/getodk/collect/issues/5539

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.