### PR TITLE
Accept forms with entities version 2023.1

### DIFF
--- a/src/main/java/org/javarosa/entities/internal/EntityFormParseProcessor.java
+++ b/src/main/java/org/javarosa/entities/internal/EntityFormParseProcessor.java
@@ -11,11 +11,12 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 public class EntityFormParseProcessor implements XFormParser.BindAttributeProcessor, XFormParser.FormDefProcessor, XFormParser.ModelAttributeProcessor {
 
     private static final String ENTITIES_NAMESPACE = "http://www.opendatakit.org/xforms/entities";
-    public static final String SUPPORTED_VERSION = "2022.1";
+    private static final String[] SUPPORTED_VERSIONS = {"2022.1", "2023.1"};
 
     private final List<Pair<XPathReference, String>> saveTos = new ArrayList<>();
     private boolean versionPresent;
@@ -32,12 +33,7 @@ public class EntityFormParseProcessor implements XFormParser.BindAttributeProces
     public void processModelAttribute(String name, String value) throws XFormParser.ParseException {
         versionPresent = true;
 
-        try {
-            String[] versionParts = value.split("\\.");
-            if (!SUPPORTED_VERSION.equals(versionParts[0] + "." + versionParts[1])) {
-                throw new UnrecognizedEntityVersionException();
-            }
-        } catch (ArrayIndexOutOfBoundsException e) {
+        if (Stream.of(SUPPORTED_VERSIONS).noneMatch(value::startsWith)) {
             throw new UnrecognizedEntityVersionException();
         }
     }

--- a/src/test/java/org/javarosa/entities/EntitiesTest.java
+++ b/src/test/java/org/javarosa/entities/EntitiesTest.java
@@ -6,7 +6,6 @@ import org.javarosa.core.test.Scenario;
 import org.javarosa.core.util.XFormsElement;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.entities.internal.Entities;
-import org.javarosa.entities.internal.EntityFormParseProcessor;
 import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xform.parse.XFormParserFactory;
 import org.javarosa.xform.util.XFormUtils;
@@ -54,7 +53,7 @@ public class EntitiesTest {
             ),
             head(
                 title("Entity form"),
-                model(asList(new Pair<>("entities:entities-version", EntityFormParseProcessor.SUPPORTED_VERSION + ".1")),
+                model(asList(new Pair<>("entities:entities-version", "2022.1.1")),
                     mainInstance(
                         t("data id=\"entity-form\"",
                             t("name"),
@@ -89,7 +88,7 @@ public class EntitiesTest {
             ),
             head(
                 title("Create entity form"),
-                model(asList(new Pair<>("entities:entities-version", EntityFormParseProcessor.SUPPORTED_VERSION + ".1")),
+                model(asList(new Pair<>("entities:entities-version", "2022.1.1")),
                     mainInstance(
                         t("data id=\"create-entity-form\"",
                             t("name"),
@@ -126,7 +125,7 @@ public class EntitiesTest {
             ),
             head(
                 title("Create entity form"),
-                model(asList(new Pair<>("entities:entities-version", EntityFormParseProcessor.SUPPORTED_VERSION + ".1")),
+                model(asList(new Pair<>("entities:entities-version", "2022.1.1")),
                     mainInstance(
                         t("data id=\"create-entity-form\"",
                             t("name"),
@@ -177,7 +176,7 @@ public class EntitiesTest {
             ),
             head(
                 title("Create entity form"),
-                model(asList(new Pair<>("entities:entities-version", EntityFormParseProcessor.SUPPORTED_VERSION + ".1")),
+                model(asList(new Pair<>("entities:entities-version", "2022.1.1")),
                     mainInstance(
                         t("data id=\"create-entity-form\"",
                             t("name"),
@@ -217,7 +216,7 @@ public class EntitiesTest {
             ),
             head(
                 title("Create entity form"),
-                model(asList(new Pair<>("blah:entities-version", EntityFormParseProcessor.SUPPORTED_VERSION + ".1")),
+                model(asList(new Pair<>("blah:entities-version", "2022.1.1")),
                     mainInstance(
                         t("data id=\"create-entity-form\"",
                             t("name"),
@@ -253,7 +252,7 @@ public class EntitiesTest {
             ),
             head(
                 title("Create entity form"),
-                model(asList(new Pair<>("entities:entities-version", EntityFormParseProcessor.SUPPORTED_VERSION + ".1")),
+                model(asList(new Pair<>("entities:entities-version", "2022.1.1")),
                     mainInstance(
                         t("data id=\"create-entity-form\"",
                             t("team"),
@@ -289,7 +288,7 @@ public class EntitiesTest {
             ),
             head(
                 title("Create entity form"),
-                model(asList(new Pair<>("entities:entities-version", EntityFormParseProcessor.SUPPORTED_VERSION + ".1")),
+                model(asList(new Pair<>("entities:entities-version", "2022.1.1")),
                     mainInstance(
                         t("data id=\"create-entity-form\"",
                             t("name"),
@@ -322,7 +321,7 @@ public class EntitiesTest {
             ),
             head(
                 title("Create entity form"),
-                model(asList(new Pair<>("entities:entities-version", EntityFormParseProcessor.SUPPORTED_VERSION + ".1")),
+                model(asList(new Pair<>("entities:entities-version", "2022.1.1")),
                     mainInstance(
                         t("data id=\"create-entity-form\"",
                             t("name"),

--- a/src/test/java/org/javarosa/entities/internal/EntityFormParseProcessorTest.java
+++ b/src/test/java/org/javarosa/entities/internal/EntityFormParseProcessorTest.java
@@ -130,7 +130,7 @@ public class EntityFormParseProcessorTest {
 
     @Test
     public void whenVersionIsNewPatch_parsesCorrectly() throws XFormParser.ParseException {
-        String newPatchVersion = EntityFormParseProcessor.SUPPORTED_VERSION + ".12";
+        String newPatchVersion = "2022.1.12";
 
         XFormsElement form = XFormsElement.html(
             asList(
@@ -164,6 +164,41 @@ public class EntityFormParseProcessorTest {
     }
 
     @Test
+    public void whenVersionIsNewVersionWithUpdates_parsesCorrectly() throws XFormParser.ParseException {
+        String updateVersion = "2023.1.0";
+
+        XFormsElement form = XFormsElement.html(
+            asList(
+                new Pair<>("entities", "http://www.opendatakit.org/xforms/entities")
+            ),
+            head(
+                title("Create entity form"),
+                model(asList(new Pair<>("entities:entities-version", updateVersion)),
+                    mainInstance(
+                        t("data id=\"update-entity-form\"",
+                            t("name"),
+                            t("meta",
+                                t("entity dataset=\"people\" update=\"1\" id=\"17\"")
+                            )
+                        )
+                    ),
+                    bind("/data/name").type("string").withAttribute("entities", "saveto", "name")
+                )
+            ),
+            body(
+                input("/data/name")
+            )
+        );
+
+        EntityFormParseProcessor processor = new EntityFormParseProcessor();
+        XFormParser parser = new XFormParser(new InputStreamReader(new ByteArrayInputStream(form.asXml().getBytes())));
+        parser.addProcessor(processor);
+
+        FormDef formDef = parser.parse(null);
+        assertThat(formDef.getExtras().get(EntityFormExtra.class), notNullValue());
+    }
+
+    @Test
     public void saveTosWithIncorrectNamespaceAreIgnored() throws XFormParser.ParseException {
         XFormsElement form = XFormsElement.html(
             asList(
@@ -172,7 +207,7 @@ public class EntityFormParseProcessorTest {
             ),
             head(
                 title("Create entity form"),
-                model(asList(new Pair<>("correct:entities-version", EntityFormParseProcessor.SUPPORTED_VERSION + ".1")),
+                model(asList(new Pair<>("correct:entities-version", "2022.1.1")),
                     mainInstance(
                         t("data id=\"create-entity-form\"",
                             t("name"),


### PR DESCRIPTION
Related to https://github.com/XLSForm/pyxform/pull/664#discussion_r1386031722

This accepts forms that specify entity updates but doesn't actually do anything with the update directive. This is ok because for now there's no local concept of permanent entity storage and updates will always be processed server-side.

#### What has been done to verify that this works as intended?
Added tests

#### Why is this the best possible solution? Were any other approaches considered?
Previously there was a single supported version stored in a public constant. I changed that to a list of supported versions in a private constant. I think the constant was previously public only for use in tests and it's unlikely it was accessed by any other code so it feels ok to make it private without considering this a breaking change.

I think explicitly enumerating supported versions is the least error-prone way to go.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This one feels very low risk. There's testing to ensure the previous version is still supported.

#### Do we need any specific form for testing your changes? If so, please attach one.
See tests.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No