### PR TITLE
Add `extract-signed`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,7 @@ dependencies {
     implementation 'commons-io:commons-io:2.5'
 
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.10'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
 
     compileOnly 'net.sf.kxml:kxml2:2.3.0'
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
       <version>1.7.33</version>
     </dependency>
     <dependency>
+       <groupId>org.bouncycastle</groupId>
+       <artifactId>bcprov-jdk18on</artifactId>
+       <version>1.77</version>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.2.10</version>

--- a/src/main/java/org/javarosa/core/util/Base64.java
+++ b/src/main/java/org/javarosa/core/util/Base64.java
@@ -1,0 +1,88 @@
+package org.javarosa.core.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+// Copied from: https://github.com/brsanthu/migbase64/blob/master/src/main/java/com/migcomponents/migbase64/Base64.java
+// Irrelevant after Java8
+public class Base64 {
+
+    private static final char[] BASE_64_TBL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
+    private static final int[] IA = new int[256];
+    static {
+        Arrays.fill(IA, -1);
+        for (int i = 0, iS = BASE_64_TBL.length; i < iS; i++)
+            IA[BASE_64_TBL[i]] = i;
+        IA['='] = 0;
+    }
+
+    public static String encode(byte[] sArr) {
+        int sLen = sArr.length;
+        int sOff = 0;
+
+        if (sLen == 0)
+            return "";
+
+        int eLen = (sLen / 3) * 3;
+        int dLen = ((sLen - 1) / 3 + 1) << 2;
+        byte[] dArr = new byte[dLen];
+
+        for (int s = sOff, d = 0; s < sOff + eLen; ) {
+            int i = (sArr[s++] & 0xff) << 16 | (sArr[s++] & 0xff) << 8 | (sArr[s++] & 0xff);
+            dArr[d++] = (byte) BASE_64_TBL[(i >>> 18) & 0x3f];
+            dArr[d++] = (byte) BASE_64_TBL[(i >>> 12) & 0x3f];
+            dArr[d++] = (byte) BASE_64_TBL[(i >>> 6) & 0x3f];
+            dArr[d++] = (byte) BASE_64_TBL[i & 0x3f];
+        }
+
+        int left = sLen - eLen;
+        if (left > 0) {
+            int i = ((sArr[sOff + eLen] & 0xff) << 10) | (left == 2 ? ((sArr[sOff + sLen - 1] & 0xff) << 2) : 0);
+            dArr[dLen - 4] = (byte) BASE_64_TBL[i >> 12];
+            dArr[dLen - 3] = (byte) BASE_64_TBL[(i >>> 6) & 0x3f];
+            dArr[dLen - 2] = left == 2 ? (byte) BASE_64_TBL[i & 0x3f] : (byte) '=';
+            dArr[dLen - 1] = '=';
+        }
+
+        return new String(dArr, StandardCharsets.UTF_8);
+    }
+
+    public static byte[] decode(byte[] sArr) {
+        int sepCnt = 0;
+        for (byte b : sArr)
+            if (IA[b & 0xff] < 0)
+                sepCnt++;
+
+        if ((sArr.length - sepCnt) % 4 != 0)
+            return new byte[0];
+
+        int pad = 0;
+        for (int i = sArr.length; i > 1 && IA[sArr[--i] & 0xff] <= 0; )
+            if (sArr[i] == '=')
+                pad++;
+
+        int len = ((sArr.length - sepCnt) * 6 >> 3) - pad;
+
+        byte[] dArr = new byte[len];
+
+        for (int s = 0, d = 0; d < len; ) {
+            int i = 0;
+            for (int j = 0; j < 4; j++) {
+                int c = IA[sArr[s++] & 0xff];
+                if (c >= 0)
+                    i |= c << (18 - j * 6);
+                else
+                    j--;
+            }
+
+            dArr[d++] = (byte) (i >> 16);
+            if (d < len) {
+                dArr[d++] = (byte) (i >> 8);
+                if (d < len)
+                    dArr[d++] = (byte) i;
+            }
+        }
+
+        return dArr;
+    }
+}

--- a/src/main/java/org/javarosa/core/util/Ed25519.java
+++ b/src/main/java/org/javarosa/core/util/Ed25519.java
@@ -5,6 +5,8 @@ import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 import org.bouncycastle.crypto.signers.Ed25519Signer;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.charset.StandardCharsets;
+
 public class Ed25519 {
 
     private static final int SIGNATURE_LENGTH = 64;
@@ -23,7 +25,7 @@ public class Ed25519 {
         System.arraycopy(contents, SIGNATURE_LENGTH, message, 0, messageLength);
 
         if (verify(publicKey, signature, message)) {
-            return new String(message);
+            return new String(message, StandardCharsets.UTF_8);
         } else {
             return null;
         }

--- a/src/main/java/org/javarosa/core/util/Ed25519.java
+++ b/src/main/java/org/javarosa/core/util/Ed25519.java
@@ -1,0 +1,36 @@
+package org.javarosa.core.util;
+
+import org.bouncycastle.crypto.Signer;
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
+import org.bouncycastle.crypto.signers.Ed25519Signer;
+import org.jetbrains.annotations.Nullable;
+
+public class Ed25519 {
+
+    private static final int SIGNATURE_LENGTH = 64;
+
+    @Nullable
+    public static String extractSigned(byte[] contents, byte[] publicKey) {
+        byte[] signature = new byte[SIGNATURE_LENGTH];
+        System.arraycopy(contents, 0, signature, 0, SIGNATURE_LENGTH);
+
+        int messageLength = contents.length - SIGNATURE_LENGTH;
+        byte[] message = new byte[messageLength];
+        System.arraycopy(contents, SIGNATURE_LENGTH, message, 0, messageLength);
+
+        if (verify(publicKey, signature, message)) {
+            return new String(message);
+        } else {
+            return null;
+        }
+    }
+
+    private static boolean verify(byte[] publicKey, byte[] signature, byte[] message) {
+        Ed25519PublicKeyParameters publicKeyParameters = new Ed25519PublicKeyParameters(publicKey, 0);
+        Signer signer = new Ed25519Signer();
+        signer.init(false, publicKeyParameters);
+        signer.update(message, 0, message.length);
+
+        return signer.verifySignature(signature);
+    }
+}

--- a/src/main/java/org/javarosa/core/util/Ed25519.java
+++ b/src/main/java/org/javarosa/core/util/Ed25519.java
@@ -11,6 +11,10 @@ public class Ed25519 {
 
     @Nullable
     public static String extractSigned(byte[] contents, byte[] publicKey) {
+        if (contents.length < 64) {
+            return null;
+        }
+
         byte[] signature = new byte[SIGNATURE_LENGTH];
         System.arraycopy(contents, 0, signature, 0, SIGNATURE_LENGTH);
 
@@ -26,11 +30,19 @@ public class Ed25519 {
     }
 
     private static boolean verify(byte[] publicKey, byte[] signature, byte[] message) {
-        Ed25519PublicKeyParameters publicKeyParameters = new Ed25519PublicKeyParameters(publicKey, 0);
-        Signer signer = new Ed25519Signer();
-        signer.init(false, publicKeyParameters);
-        signer.update(message, 0, message.length);
+        try {
+            Ed25519PublicKeyParameters publicKeyParameters = new Ed25519PublicKeyParameters(publicKey, 0);
+            Signer signer = new Ed25519Signer();
+            signer.init(false, publicKeyParameters);
+            signer.update(message, 0, message.length);
 
-        return signer.verifySignature(signature);
+            return signer.verifySignature(signature);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            // The key was too small
+            return false;
+        } catch (IllegalArgumentException e) {
+            // The key was invalid
+            return false;
+        }
     }
 }

--- a/src/main/java/org/javarosa/xpath/expr/Encoding.java
+++ b/src/main/java/org/javarosa/xpath/expr/Encoding.java
@@ -15,8 +15,7 @@
  */
 package org.javarosa.xpath.expr;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import org.javarosa.core.util.Base64;
 import org.javarosa.xpath.XPathUnsupportedException;
 
 /**
@@ -46,78 +45,14 @@ enum Encoding {
         }
     },
     BASE64("base64") {
-        // Copied from: https://github.com/brsanthu/migbase64/blob/master/src/main/java/com/migcomponents/migbase64/Base64.java
-        // Irrelevant after Java8
         @Override
         String encode(byte[] sArr) {
-            int sLen = sArr.length;
-            int sOff = 0;
-
-            if (sLen == 0)
-                return "";
-
-            int eLen = (sLen / 3) * 3;
-            int dLen = ((sLen - 1) / 3 + 1) << 2;
-            byte[] dArr = new byte[dLen];
-
-            for (int s = sOff, d = 0; s < sOff + eLen; ) {
-                int i = (sArr[s++] & 0xff) << 16 | (sArr[s++] & 0xff) << 8 | (sArr[s++] & 0xff);
-                dArr[d++] = (byte) BASE_64_TBL[(i >>> 18) & 0x3f];
-                dArr[d++] = (byte) BASE_64_TBL[(i >>> 12) & 0x3f];
-                dArr[d++] = (byte) BASE_64_TBL[(i >>> 6) & 0x3f];
-                dArr[d++] = (byte) BASE_64_TBL[i & 0x3f];
-            }
-
-            int left = sLen - eLen;
-            if (left > 0) {
-                int i = ((sArr[sOff + eLen] & 0xff) << 10) | (left == 2 ? ((sArr[sOff + sLen - 1] & 0xff) << 2) : 0);
-                dArr[dLen - 4] = (byte) BASE_64_TBL[i >> 12];
-                dArr[dLen - 3] = (byte) BASE_64_TBL[(i >>> 6) & 0x3f];
-                dArr[dLen - 2] = left == 2 ? (byte) BASE_64_TBL[i & 0x3f] : (byte) '=';
-                dArr[dLen - 1] = '=';
-            }
-
-            return new String(dArr, StandardCharsets.UTF_8);
+            return Base64.encode(sArr);
         }
 
         @Override
-        public byte[] decode(byte[] sArr) {
-            int sepCnt = 0;
-            for (byte b : sArr)
-                if (IA[b & 0xff] < 0)
-                    sepCnt++;
-
-            if ((sArr.length - sepCnt) % 4 != 0)
-                return new byte[0];
-
-            int pad = 0;
-            for (int i = sArr.length; i > 1 && IA[sArr[--i] & 0xff] <= 0; )
-                if (sArr[i] == '=')
-                    pad++;
-
-            int len = ((sArr.length - sepCnt) * 6 >> 3) - pad;
-
-            byte[] dArr = new byte[len];
-
-            for (int s = 0, d = 0; d < len; ) {
-                int i = 0;
-                for (int j = 0; j < 4; j++) {
-                    int c = IA[sArr[s++] & 0xff];
-                    if (c >= 0)
-                        i |= c << (18 - j * 6);
-                    else
-                        j--;
-                }
-
-                dArr[d++] = (byte) (i >> 16);
-                if (d < len) {
-                    dArr[d++] = (byte) (i >> 8);
-                    if (d < len)
-                        dArr[d++] = (byte) i;
-                }
-            }
-
-            return dArr;
+        byte[] decode(byte[] sArr) {
+            return Base64.decode(sArr);
         }
     };
 
@@ -136,16 +71,6 @@ enum Encoding {
     }
 
     private static final char[] HEX_TBL = "0123456789abcdef".toCharArray();
-
-    private static final char[] BASE_64_TBL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
-
-    private static final int[] IA = new int[256];
-    static {
-        Arrays.fill(IA, -1);
-        for (int i = 0, iS = BASE_64_TBL.length; i < iS; i++)
-            IA[BASE_64_TBL[i]] = i;
-        IA['='] = 0;
-    }
 
     abstract String encode(byte[] bytes);
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -501,6 +501,8 @@ public class XPathFuncExpr extends XPathExpression {
             assertArgsCount(name, args, 1);
             return base64Decode(argVals[0]);
         } else if (name.equals("extract-signed")) {
+            assertArgsCount(name, args, 2);
+
             byte[] decodedContents = Base64.decode(toString(argVals[0]).getBytes());
 
             byte[] signature = new byte[64];

--- a/src/test/java/org/javarosa/xpath/expr/ExtractSignedTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/ExtractSignedTest.java
@@ -9,11 +9,15 @@ import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters;
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 import org.bouncycastle.crypto.signers.Ed25519Signer;
 import org.javarosa.core.test.Scenario;
+import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xpath.XPathUnhandledException;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -39,27 +43,10 @@ public class ExtractSignedTest {
         AsymmetricCipherKeyPair keyPair = createKeyPair();
 
         byte[] signedMessage = signMessage(message, keyPair.getPrivate());
-
         String encodedPublicKey = Encoding.BASE64.encode(((Ed25519PublicKeyParameters) keyPair.getPublic()).getEncoded());
         String encodedContents = Encoding.BASE64.encode(signedMessage);
 
-        Scenario scenario = Scenario.init("extract signed form", html(
-            head(
-                title("extract signed form"),
-                model(
-                    mainInstance(t("data id=\"extract-signed\"",
-                        t("contents", encodedContents),
-                        t("extracted")
-                    )),
-                    bind("/data/contents").type("string"),
-                    bind("/data/extracted").type("string").calculate("extract-signed(/data/contents,'" + encodedPublicKey + "')")
-                )
-            ),
-            body(
-                input("/data/contents")
-            ))
-        );
-
+        Scenario scenario = createScenario(encodedContents, encodedPublicKey);
         assertThat(scenario.answerOf("/data/extracted"), is(stringAnswer(message)));
     }
 
@@ -70,27 +57,10 @@ public class ExtractSignedTest {
         AsymmetricCipherKeyPair keyPair2 = createKeyPair();
 
         byte[] signedMessage = signMessage(message, keyPair1.getPrivate());
-
         String encodedPublicKey = Encoding.BASE64.encode(((Ed25519PublicKeyParameters) keyPair2.getPublic()).getEncoded());
         String encodedContents = Encoding.BASE64.encode(signedMessage);
 
-        Scenario scenario = Scenario.init("extract signed form", html(
-            head(
-                title("extract signed form"),
-                model(
-                    mainInstance(t("data id=\"extract-signed\"",
-                        t("contents", encodedContents),
-                        t("extracted")
-                    )),
-                    bind("/data/contents").type("string"),
-                    bind("/data/extracted").type("string").calculate("extract-signed(/data/contents,'" + encodedPublicKey + "')")
-                )
-            ),
-            body(
-                input("/data/contents")
-            ))
-        );
-
+        Scenario scenario = createScenario(encodedContents, encodedPublicKey);
         assertThat(scenario.answerOf("/data/extracted"), is(nullValue()));
     }
 
@@ -119,6 +89,54 @@ public class ExtractSignedTest {
         }
     }
 
+    @Test
+    public void whenContentIsTooShort_returnsEmptyString() throws Exception {
+        AsymmetricCipherKeyPair keyPair = createKeyPair();
+        String encodedPublicKey = Encoding.BASE64.encode(((Ed25519PublicKeyParameters) keyPair.getPublic()).getEncoded());
+
+        Scenario scenario = createScenario("blah", encodedPublicKey);
+        assertThat(scenario.answerOf("/data/extracted"), is(nullValue()));
+    }
+
+    @Test
+    public void whenNonSignatureDataIsEmpty_andSignatureIsValid_returnsEmptyString() throws Exception {
+        String message = "";
+        AsymmetricCipherKeyPair keyPair = createKeyPair();
+
+        byte[] signedMessage = signMessage(message, keyPair.getPrivate());
+        String encodedPublicKey = Encoding.BASE64.encode(((Ed25519PublicKeyParameters) keyPair.getPublic()).getEncoded());
+        String encodedContents = Encoding.BASE64.encode(signedMessage);
+
+        Scenario scenario = createScenario(encodedContents, encodedPublicKey);
+        assertThat(scenario.answerOf("/data/extracted"), is(nullValue()));
+    }
+
+    @Test
+    public void whenPublicKeyIsTooShort_returnsEmptyString() throws Exception {
+        String message = "";
+        AsymmetricCipherKeyPair keyPair = createKeyPair();
+
+        byte[] signedMessage = signMessage(message, keyPair.getPrivate());
+        String encodedPublicKey = Encoding.BASE64.encode("blah".getBytes());
+        String encodedContents = Encoding.BASE64.encode(signedMessage);
+
+        Scenario scenario = createScenario(encodedContents, encodedPublicKey);
+        assertThat(scenario.answerOf("/data/extracted"), is(nullValue()));
+    }
+
+    @Test
+    public void whenPublicKeyIsInvalid_returnsEmptyString() throws Exception {
+        String message = "";
+        AsymmetricCipherKeyPair keyPair = createKeyPair();
+
+        byte[] signedMessage = signMessage(message, keyPair.getPrivate());
+        String encodedPublicKey = Encoding.BASE64.encode(UUID.randomUUID().toString().getBytes());
+        String encodedContents = Encoding.BASE64.encode(signedMessage);
+
+        Scenario scenario = createScenario(encodedContents, encodedPublicKey);
+        assertThat(scenario.answerOf("/data/extracted"), is(nullValue()));
+    }
+
     private static AsymmetricCipherKeyPair createKeyPair() {
         Ed25519KeyPairGenerator ed25519KeyPairGenerator = new Ed25519KeyPairGenerator();
         ed25519KeyPairGenerator.init(new Ed25519KeyGenerationParameters(new SecureRandom()));
@@ -136,5 +154,25 @@ public class ExtractSignedTest {
         System.arraycopy(signature, 0, signedMessage, 0, signature.length);
         System.arraycopy(messageBytes, 0, signedMessage, signature.length, messageBytes.length);
         return signedMessage;
+    }
+
+    @NotNull
+    private static Scenario createScenario(String encodedContents, String encodedPublicKey) throws IOException, XFormParser.ParseException {
+        return Scenario.init("extract signed form", html(
+            head(
+                title("extract signed form"),
+                model(
+                    mainInstance(t("data id=\"extract-signed\"",
+                        t("contents", encodedContents),
+                        t("extracted")
+                    )),
+                    bind("/data/contents").type("string"),
+                    bind("/data/extracted").type("string").calculate("extract-signed(/data/contents,'" + encodedPublicKey + "')")
+                )
+            ),
+            body(
+                input("/data/contents")
+            ))
+        );
     }
 }

--- a/src/test/java/org/javarosa/xpath/expr/ExtractSignedTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/ExtractSignedTest.java
@@ -137,6 +137,19 @@ public class ExtractSignedTest {
         assertThat(scenario.answerOf("/data/extracted"), is(nullValue()));
     }
 
+    @Test
+    public void whenNonSignaturePartIncludesUnicode_successfullyDecodes() throws Exception{
+        String message = "🎃";
+        AsymmetricCipherKeyPair keyPair = createKeyPair();
+
+        byte[] signedMessage = signMessage(message, keyPair.getPrivate());
+        String encodedPublicKey = Encoding.BASE64.encode(((Ed25519PublicKeyParameters) keyPair.getPublic()).getEncoded());
+        String encodedContents = Encoding.BASE64.encode(signedMessage);
+
+        Scenario scenario = createScenario(encodedContents, encodedPublicKey);
+        assertThat(scenario.answerOf("/data/extracted"), is(stringAnswer(message)));
+    }
+
     private static AsymmetricCipherKeyPair createKeyPair() {
         Ed25519KeyPairGenerator ed25519KeyPairGenerator = new Ed25519KeyPairGenerator();
         ed25519KeyPairGenerator.init(new Ed25519KeyGenerationParameters(new SecureRandom()));

--- a/src/test/java/org/javarosa/xpath/expr/ExtractSignedTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/ExtractSignedTest.java
@@ -1,0 +1,112 @@
+package org.javarosa.xpath.expr;
+
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.crypto.CryptoException;
+import org.bouncycastle.crypto.Signer;
+import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator;
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters;
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
+import org.bouncycastle.crypto.signers.Ed25519Signer;
+import org.javarosa.core.test.Scenario;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
+import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
+import static org.javarosa.core.util.XFormsElement.body;
+import static org.javarosa.core.util.XFormsElement.head;
+import static org.javarosa.core.util.XFormsElement.html;
+import static org.javarosa.core.util.XFormsElement.input;
+import static org.javarosa.core.util.XFormsElement.mainInstance;
+import static org.javarosa.core.util.XFormsElement.model;
+import static org.javarosa.core.util.XFormsElement.t;
+import static org.javarosa.core.util.XFormsElement.title;
+
+public class ExtractSignedTest {
+
+    @Test
+    public void whenSignatureIsValid_returnsNonSignatureContents() throws Exception {
+        String message = "real genuine data";
+        AsymmetricCipherKeyPair keyPair = createKeyPair();
+
+        byte[] signedMessage = signMessage(message, keyPair.getPrivate());
+
+        String encodedPublicKey = Encoding.BASE64.encode(((Ed25519PublicKeyParameters) keyPair.getPublic()).getEncoded());
+        String encodedContents = Encoding.BASE64.encode(signedMessage);
+
+        Scenario scenario = Scenario.init("extract sign form", html(
+            head(
+                title("extract sign form"),
+                model(
+                    mainInstance(t("data id=\"extract-signed\"",
+                        t("contents", encodedContents),
+                        t("extracted")
+                    )),
+                    bind("/data/contents").type("string"),
+                    bind("/data/extracted").type("string").calculate("extract-signed(/data/contents,'" + encodedPublicKey + "')")
+                )
+            ),
+            body(
+                input("/data/contents")
+            ))
+        );
+
+        assertThat(scenario.answerOf("/data/extracted"), is(stringAnswer(message)));
+    }
+
+    @Test
+    public void whenSignatureIsNotValid_returnsEmptyString() throws Exception {
+        String message = "real genuine data";
+        AsymmetricCipherKeyPair keyPair1 = createKeyPair();
+        AsymmetricCipherKeyPair keyPair2 = createKeyPair();
+
+        byte[] signedMessage = signMessage(message, keyPair1.getPrivate());
+
+        String encodedPublicKey = Encoding.BASE64.encode(((Ed25519PublicKeyParameters) keyPair2.getPublic()).getEncoded());
+        String encodedContents = Encoding.BASE64.encode(signedMessage);
+
+        Scenario scenario = Scenario.init("extract sign form", html(
+            head(
+                title("extract sign form"),
+                model(
+                    mainInstance(t("data id=\"extract-signed\"",
+                        t("contents", encodedContents),
+                        t("extracted")
+                    )),
+                    bind("/data/contents").type("string"),
+                    bind("/data/extracted").type("string").calculate("extract-signed(/data/contents,'" + encodedPublicKey + "')")
+                )
+            ),
+            body(
+                input("/data/contents")
+            ))
+        );
+
+        assertThat(scenario.answerOf("/data/extracted"), is(nullValue()));
+    }
+
+    private static AsymmetricCipherKeyPair createKeyPair() {
+        Ed25519KeyPairGenerator ed25519KeyPairGenerator = new Ed25519KeyPairGenerator();
+        ed25519KeyPairGenerator.init(new Ed25519KeyGenerationParameters(new SecureRandom()));
+        return ed25519KeyPairGenerator.generateKeyPair();
+    }
+
+    private static byte[] signMessage(String message, AsymmetricKeyParameter privateKey) throws CryptoException {
+        Signer signer = new Ed25519Signer();
+        signer.init(true, privateKey);
+        byte[] messageBytes = message.getBytes(StandardCharsets.UTF_8);
+        signer.update(messageBytes, 0, messageBytes.length);
+        byte[] signature = signer.generateSignature();
+
+        byte[] signedMessage = new byte[signature.length + messageBytes.length];
+        System.arraycopy(signature, 0, signedMessage, 0, signature.length);
+        System.arraycopy(messageBytes, 0, signedMessage, signature.length, messageBytes.length);
+        return signedMessage;
+    }
+}


### PR DESCRIPTION
As proposed at https://forum.getodk.org/t/form-spec-proposal-allow-signed-content-to-verified-using-form-logic/44228.

#### What has been done to verify that this works as intended?

New tests and verified manually using [this form](https://github.com/getodk/javarosa/files/13651756/Extract.signed.form.xlsx) (which includes a randomly generated public key) and the following QR code (which contains the message "real genuine data"):

<img width="190" alt="Screenshot 2023-12-12 at 18 04 08" src="https://github.com/getodk/javarosa/assets/556280/45114894-61d6-4b26-b19d-d7ed2ce24876">

#### Why is this the best possible solution? Were any other approaches considered?

The function signature is discussed at https://forum.getodk.org/t/form-spec-proposal-allow-signed-content-to-verified-using-form-logic/44228.

In terms of implementation, I did briefly look into using Java's build it crypto utilities, but it seemed like we'd need Java 15 for Ed25519 support and JavaRosa is still Java 8 compatible as far as I know. Using Bouncy Castle keeps that support in place. One ramification could be that it increases the size of binaries built suing JavaRosa (like Collect's APK).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just add the new function! Nothing else has really been touched (other than moving Base64 to a new helper).

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

https://github.com/getodk/docs/issues/1723
