### PR TITLE
Add caching for and/or and bring ItemsetBinding caching back

### DIFF
--- a/src/main/java/org/javarosa/core/model/ComparisonExpressionCacheFilterStrategy.java
+++ b/src/main/java/org/javarosa/core/model/ComparisonExpressionCacheFilterStrategy.java
@@ -4,6 +4,7 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.FilterStrategy;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.xpath.expr.XPathBoolExpr;
 import org.javarosa.xpath.expr.XPathCmpExpr;
 import org.javarosa.xpath.expr.XPathEqExpr;
 import org.javarosa.xpath.expr.XPathExpression;
@@ -31,8 +32,7 @@ public class ComparisonExpressionCacheFilterStrategy implements FilterStrategy {
 
         CompareToNodeExpression candidate = CompareToNodeExpression.parse(predicate);
         if (candidate != null) {
-            Object absoluteValue = candidate.evalContextSide(sourceInstance, evaluationContext);
-            String key = nodeSet.toString() + predicate + candidate.getNodeSide() + absoluteValue.toString();
+            String key = getKey(sourceInstance, nodeSet, predicate, evaluationContext, candidate);
 
             if (cachedEvaluations.containsKey(key)) {
                 return cachedEvaluations.get(key);
@@ -41,9 +41,37 @@ public class ComparisonExpressionCacheFilterStrategy implements FilterStrategy {
                 cachedEvaluations.put(key, filtered);
                 return filtered;
             }
+        } else if (predicate instanceof XPathBoolExpr) {
+            XPathExpression a = ((XPathBoolExpr) predicate).a;
+            XPathExpression b = ((XPathBoolExpr) predicate).b;
+
+            CompareToNodeExpression candidateA = CompareToNodeExpression.parse(a);
+            CompareToNodeExpression candidateB = CompareToNodeExpression.parse(b);
+
+            if (candidateA != null && candidateB != null) {
+                String keyA = getKey(sourceInstance, nodeSet, a, evaluationContext, candidateA);
+                String keyB = getKey(sourceInstance, nodeSet, b, evaluationContext, candidateB);
+                String key = keyA + keyB + predicate;
+
+                if (cachedEvaluations.containsKey(key)) {
+                    return cachedEvaluations.get(key);
+                } else {
+                    List<TreeReference> filtered = next.get();
+                    cachedEvaluations.put(key, filtered);
+                    return filtered;
+                }
+            } else {
+                return next.get();
+            }
         } else {
             return next.get();
         }
+    }
+
+    @NotNull
+    private static String getKey(@NotNull DataInstance sourceInstance, @NotNull TreeReference nodeSet, @NotNull XPathExpression predicate, @NotNull EvaluationContext evaluationContext, CompareToNodeExpression candidate) {
+        Object absoluteValue = candidate.evalContextSide(sourceInstance, evaluationContext);
+        return nodeSet.toString() + predicate + candidate.getNodeSide() + absoluteValue.toString();
     }
 
 }

--- a/src/test/java/org/javarosa/core/model/SelectCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectCachingTest.java
@@ -2,7 +2,6 @@ package org.javarosa.core.model;
 
 import org.javarosa.core.test.Scenario;
 import org.javarosa.measure.Measure;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;

--- a/src/test/java/org/javarosa/core/model/SelectCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectCachingTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.equalTo;
 import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
 import static org.javarosa.core.util.XFormsElement.body;
 import static org.javarosa.core.util.XFormsElement.head;
@@ -54,8 +54,8 @@ public class SelectCachingTest {
             scenario.choicesOf("/data/select");
         });
 
-        // Check that we do less than (size of secondary instance) * (number of choice lookups)
-        assertThat(evaluations, lessThan(4));
+        // Check that we do just (size of secondary instance)
+        assertThat(evaluations, equalTo(2));
     }
 
     @Test
@@ -92,8 +92,8 @@ public class SelectCachingTest {
             scenario.choicesOf("/data/select2");
         });
 
-        // Check that we do less than (size of secondary instance) * (number of choice lookups)
-        assertThat(evaluations, lessThan(4));
+        // Check that we do just (size of secondary instance)
+        assertThat(evaluations, equalTo(2));
     }
 
     @Test
@@ -130,8 +130,8 @@ public class SelectCachingTest {
             scenario.choicesOf("/data/select2");
         });
 
-        // Check that we do less than (size of secondary instance) * (number of choice lookups)
-        assertThat(evaluations, lessThan(4));
+        // Check that we do just (size of secondary instance)
+        assertThat(evaluations, equalTo(2));
     }
 
     @Test
@@ -169,8 +169,8 @@ public class SelectCachingTest {
             scenario.choicesOf("/data/select2");
         });
 
-        // Check that we do less than (size of secondary instance) * (number of choice lookups)
-        assertThat(evaluations, lessThan(4));
+        // Check that we do just (size of secondary instance)
+        assertThat(evaluations, equalTo(2));
     }
 
     //region repeats
@@ -206,8 +206,8 @@ public class SelectCachingTest {
             scenario.choicesOf("/data/repeat[1]/select");
         });
 
-        // Check that we do less than (size of secondary instance) * (number of choice lookups)
-        assertThat(evaluations, lessThan(8));
+        // Check that we do just (size of secondary instance)
+        assertThat(evaluations, equalTo(4));
     }
 
     @Test
@@ -244,8 +244,8 @@ public class SelectCachingTest {
             scenario.choicesOf("/data/outer[0]/inner[1]/select");
         });
 
-        // Check that we do less than (size of secondary instance) * (number of choice lookups)
-        assertThat(evaluations, lessThan(4));
+        // Check that we do just (size of secondary instance)
+        assertThat(evaluations, equalTo(2));
     }
     //endregion
 }

--- a/src/test/java/org/javarosa/core/util/XFormsElement.java
+++ b/src/test/java/org/javarosa/core/util/XFormsElement.java
@@ -18,12 +18,12 @@ package org.javarosa.core.util;
 
 import kotlin.Pair;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 
 public interface XFormsElement {
@@ -43,7 +43,7 @@ public interface XFormsElement {
             return emptyMap();
         Map<String, String> attributes = new HashMap<>();
         String[] words = name.split(" ");
-        for (String word : Arrays.asList(words).subList(1, words.length)) {
+        for (String word : asList(words).subList(1, words.length)) {
             String[] parts = word.split("(?<!\\))=(\"|')");
             attributes.put(parts[0], parts[1].substring(0, parts[1].length() - 1));
         }
@@ -59,7 +59,7 @@ public interface XFormsElement {
     static XFormsElement t(String name, XFormsElement... children) {
         if (children.length == 0)
             return new EmptyXFormsElement(parseName(name), parseAttributes(name));
-        return new TagXFormsElement(parseName(name), parseAttributes(name), Arrays.asList(children));
+        return new TagXFormsElement(parseName(name), parseAttributes(name), asList(children));
     }
 
     static XFormsElement t(String name, String innerHtml) {
@@ -135,7 +135,16 @@ public interface XFormsElement {
     }
 
     static XFormsElement select1Dynamic(String ref, String nodesetRef) {
-        return select1Dynamic(ref, nodesetRef, "value", "label");
+        XFormsElement value = t("value ref=\"value\"");
+        XFormsElement label = t("label ref=\"label\"");
+
+        HashMap<String, String> itemsetAttributes = new HashMap<>();
+        itemsetAttributes.put("nodeset", nodesetRef);
+        TagXFormsElement itemset = new TagXFormsElement("itemset", itemsetAttributes, asList(value, label));
+
+        HashMap<String, String> select1Attributes = new HashMap<>();
+        select1Attributes.put("ref", ref);
+        return new TagXFormsElement("select1", select1Attributes, asList(itemset));
     }
 
     static XFormsElement select1Dynamic(String ref, String nodesetRef, String valueRef, String labelRef) {
@@ -186,13 +195,13 @@ public interface XFormsElement {
 
     class HeadXFormsElement extends TagXFormsElement {
         public HeadXFormsElement(XFormsElement[] children) {
-            super("h:head", emptyMap(), Arrays.asList(children));
+            super("h:head", emptyMap(), asList(children));
         }
     }
 
     class BodyXFormsElement extends TagXFormsElement {
         public BodyXFormsElement(XFormsElement[] children) {
-            super("h:body", emptyMap(), Arrays.asList(children));
+            super("h:body", emptyMap(), asList(children));
         }
     }
 }


### PR DESCRIPTION
This also adds the old caching for `ItemsetBinding` back in. This will mean that the last choice calculation for a question will always be cached for an O(1) lookup. This cache is evaluated when the non static parts of the nodes expression change.

#### What has been done to verify that this works as intended?

New tests and verified performance improvement for forms with `and` in Collect (with `./gradlew installLocal`.

#### Why is this the best possible solution? Were any other approaches considered?

As discussed with @lognaturel, long term we'd like to reduce how often Collect calls `getSelectChoices()` to reduce the need for the caching code in `ItemsetBinding`. That aside, this level of caching will probably always be advantageous for cases where a data collector is navigating back and forwards to a question that other caching isn't covering.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The main risk here is that the caching breaks some select choice calculations. It'd be good to try and think of ways this could happen.
