### PR TITLE
Use placeholder root for empty external secondary instance

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -1,9 +1,5 @@
 package org.javarosa.core.model.instance;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import org.javarosa.core.model.instance.geojson.GeoJsonExternalInstance;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
@@ -17,6 +13,11 @@ import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
 // This is still a work in progress.
 
@@ -62,6 +63,11 @@ public class ExternalDataInstance extends DataInstance {
         TreeElement root;
         try {
             root = parseExternalInstance(instanceSrc, instanceId);
+
+            // Avoid parse error for missing name and label refs if a select is built on an empty placeholder file
+            if (!root.hasChildren()) {
+                root = PLACEHOLDER_ROOT;
+            }
         } catch (FileNotFoundException | InvalidReferenceException e) {
             logger.info("External instance not found, falling back to placeholder");
             root = PLACEHOLDER_ROOT;

--- a/src/test/java/org/javarosa/xform/parse/ExternalSecondaryInstanceParseTest.java
+++ b/src/test/java/org/javarosa/xform/parse/ExternalSecondaryInstanceParseTest.java
@@ -1,5 +1,23 @@
 package org.javarosa.xform.parse;
 
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.data.helper.Selection;
+import org.javarosa.core.model.instance.AbstractTreeElement;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.core.test.Scenario;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.xpath.expr.XPathPathExpr;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,23 +39,6 @@ import static org.javarosa.xpath.XPathParseTool.parseXPath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.List;
-import org.javarosa.core.model.FormDef;
-import org.javarosa.core.model.SelectChoice;
-import org.javarosa.core.model.condition.EvaluationContext;
-import org.javarosa.core.model.data.helper.Selection;
-import org.javarosa.core.model.instance.AbstractTreeElement;
-import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.core.test.FormParseInit;
-import org.javarosa.core.test.Scenario;
-import org.javarosa.core.util.externalizable.DeserializationException;
-import org.javarosa.xpath.expr.XPathPathExpr;
-import org.javarosa.xpath.parser.XPathSyntaxException;
-import org.junit.Test;
 
 public class ExternalSecondaryInstanceParseTest {
 
@@ -130,6 +131,30 @@ public class ExternalSecondaryInstanceParseTest {
         } catch (XFormParser.ParseException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    public void csvSecondaryInstanceWithHeaderOnly_parsesWithoutError() throws IOException, XFormParser.ParseException {
+        configureReferenceManagerCorrectly();
+
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("first")
+                    )),
+
+                    t("instance id=\"external-csv\" src=\"jr://file-csv/header_only.csv\""),
+
+                    bind("/data/first").type("string")
+                )
+            ),
+            body(
+                select1Dynamic("/data/first", "instance('external-csv')/root/item")
+            )));
+
+        assertThat(scenario.choicesOf("/data/first").size(), is(0));
     }
 
     @Test

--- a/src/test/resources/org/javarosa/xform/parse/header_only.csv
+++ b/src/test/resources/org/javarosa/xform/parse/header_only.csv
@@ -1,0 +1,1 @@
+name,label,first_name,last_name


### PR DESCRIPTION
Closes #743

This comes up for users who build forms that both create and use an Entity List. The first time the form is used, the Entity List is empty and this crash occurs.

#### What has been done to verify that this works as intended?
Added a test

#### Why is this the best possible solution? Were any other approaches considered?
I considered specifically targeting CSVs since there's concept of header-only XML and geojson files but I decided that the case is generic -- a form designer may want to start by attaching an empty file and then later add to that file (programmatically, with Entities, etc).

I think treating this the same way as an empty file makes the most sense because they are so similar.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I can't think of any risk to existing functionality. Maybe someone could argue it would make it harder to notice an unintentionally empty file but I don't think that's a big problem.

#### Do we need any specific form for testing your changes? If so, please attach one.
See test.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.