### PR TITLE
Protect caches from being modified concurrently

### DIFF
--- a/src/main/java/org/javarosa/core/model/ComparisonExpressionCacheFilterStrategy.java
+++ b/src/main/java/org/javarosa/core/model/ComparisonExpressionCacheFilterStrategy.java
@@ -56,7 +56,10 @@ public class ComparisonExpressionCacheFilterStrategy implements FilterStrategy {
         }
     }
 
-    private List<TreeReference> getCachedEvaluations(@NotNull Supplier<List<TreeReference>> next, String key) {
+    /**
+     * Synchronized to prevent two or more threads from modifying {@link #cachedEvaluations} at once
+     */
+    private synchronized List<TreeReference> getCachedEvaluations(@NotNull Supplier<List<TreeReference>> next, String key) {
         if (cachedEvaluations.containsKey(key)) {
             return cachedEvaluations.get(key);
         } else {

--- a/src/main/java/org/javarosa/core/model/EqualityExpressionIndexFilterStrategy.java
+++ b/src/main/java/org/javarosa/core/model/EqualityExpressionIndexFilterStrategy.java
@@ -62,6 +62,9 @@ public class EqualityExpressionIndexFilterStrategy implements FilterStrategy {
         }
     }
 
+    /**
+     * Non thread safe index for tree references based on nested string keys (a "section" and an "item").
+     */
     private static class InMemTreeReferenceIndex {
 
         private final Map<String, Map<String, List<TreeReference>>> map = new HashMap<>();
@@ -70,22 +73,22 @@ public class EqualityExpressionIndexFilterStrategy implements FilterStrategy {
             return map.containsKey(section);
         }
 
-        public void add(String section, String key, TreeReference reference) {
+        public void add(String section, String item, TreeReference reference) {
             if (!map.containsKey(section)) {
                 map.put(section, new HashMap<>());
             }
 
             Map<String, List<TreeReference>> sectionMap = map.get(section);
-            if (!sectionMap.containsKey(key)) {
-                sectionMap.put(key, new ArrayList<>());
+            if (!sectionMap.containsKey(item)) {
+                sectionMap.put(item, new ArrayList<>());
             }
 
-            sectionMap.get(key).add(reference);
+            sectionMap.get(item).add(reference);
         }
 
-        public List<TreeReference> lookup(String section, String key) {
-            if (map.containsKey(section) && map.get(section).containsKey(key)) {
-                return map.get(section).get(key);
+        public List<TreeReference> lookup(String section, String item) {
+            if (map.containsKey(section) && map.get(section).containsKey(item)) {
+                return map.get(section).get(item);
             } else {
                 return emptyList();
             }


### PR DESCRIPTION
Fixes [this crash](https://console.firebase.google.com/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/2d661ab07c0f27e0cd0fa062e93b1353?time=last-seven-days&types=crash&versions=v2024.1.0%20(4789)&sessionEventKey=65CE05EA02D0000122615F3FEFEAAB1C_1914254909992117432).

The only way I can see the crash occurring is if two evaluations for the same thing happen at once. In that case, we could end up modifying the index for the same key concurrently, creating the scenario which could cause a crash (an `null` returned for a key we just checked).

My solution here is to `synchronize` accesses to the index (and doing the same thing for our comparison cache for good measure) to prevent them happening concurrently. 

#### What has been done to verify that this works as intended?

It's really hard to test this stuff without injecting some kind of executor into the objects and this can often result in pretty contrived examples. The best I can do here is to reason about the possible concurrent accesses.

#### Why is this the best possible solution? Were any other approaches considered?

An alternative to using `synchronized` here would be to use a lock in the `FilterStrategy` that can be conditionally acquired. If the lock can't be acquired, we could actually just fall through to the next strategy hoping that that is thread safe (or not currently locked by another thread at least). We'd probably want both `EqualityExpressionIndexFilterStrategy` and `ComparisonExpressionCacheFilterStrategy` to behave like this. I'm assuming that `RawFilterStrategy` is thread safe. I think I like that more than the PR solution (and it's also far easier to test), but the PR solution is far simpler and swifter fix for the crash as far as I can tell.

Falling through on a failed lock attempt would be a good follow up.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The risk here is a performance drop if a thread ends up waiting for a lock. This is especially bad news in Collect if the thread waiting for the lock is the UI/main one. It's hard to say whether that scenario is better or worse than the thread actually taking the time to evaluate the filter however.