### PR TITLE
Additions needed for offline entity updates

### DIFF
--- a/src/main/java/org/javarosa/entities/Entity.java
+++ b/src/main/java/org/javarosa/entities/Entity.java
@@ -1,6 +1,7 @@
 package org.javarosa.entities;
 
 import kotlin.Pair;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -9,10 +10,12 @@ public class Entity {
     public final String dataset;
     public final List<Pair<String, String>> properties;
     public final String id;
+
+    @Nullable
     public final String label;
     public Integer version;
 
-    public Entity(String dataset, String id, String label, Integer version, List<Pair<String, String>> properties) {
+    public Entity(String dataset, String id, @Nullable String label, Integer version, List<Pair<String, String>> properties) {
         this.dataset = dataset;
         this.id = id;
         this.label = label;

--- a/src/main/java/org/javarosa/entities/Entity.java
+++ b/src/main/java/org/javarosa/entities/Entity.java
@@ -10,11 +10,13 @@ public class Entity {
     public final List<Pair<String, String>> properties;
     public final String id;
     public final String label;
+    public Integer version;
 
-    public Entity(String dataset, String id, String label, List<Pair<String, String>> properties) {
+    public Entity(String dataset, String id, String label, Integer version, List<Pair<String, String>> properties) {
         this.dataset = dataset;
         this.id = id;
         this.label = label;
+        this.version = version;
         this.properties = properties;
     }
 }

--- a/src/main/java/org/javarosa/entities/EntityFormFinalizationProcessor.java
+++ b/src/main/java/org/javarosa/entities/EntityFormFinalizationProcessor.java
@@ -30,19 +30,21 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
         List<Pair<XPathReference, String>> saveTos = entityFormExtra.getSaveTos();
 
         TreeElement entityElement = EntityFormParser.getEntityElement(mainInstance);
-        String createDataset = EntityFormParser.parseFirstDatasetToCreate(entityElement);
-        String updateDataset = EntityFormParser.parseFirstDatasetToUpdate(entityElement);
+        if (entityElement != null) {
+            EntityFormParser.EntityAction action = EntityFormParser.parseAction(entityElement);
+            String dataset = EntityFormParser.parseDataset(entityElement);
 
-        if (createDataset != null) {
-            Entity entity = createEntity(entityElement, 1, createDataset, saveTos, mainInstance);
-            formEntryModel.getExtras().put(new Entities(asList(entity)));
-        } else if (updateDataset != null ){
-            int baseVersion = EntityFormParser.parseBaseVersion(entityElement);
-            int newVersion = baseVersion + 1;
-            Entity entity = createEntity(entityElement, newVersion, updateDataset, saveTos, mainInstance);
-            formEntryModel.getExtras().put(new Entities(asList(entity)));
-        } else {
-            formEntryModel.getExtras().put(new Entities(emptyList()));
+            if (action == EntityFormParser.EntityAction.CREATE) {
+                Entity entity = createEntity(entityElement, 1, dataset, saveTos, mainInstance);
+                formEntryModel.getExtras().put(new Entities(asList(entity)));
+            } else if (action == EntityFormParser.EntityAction.UPDATE){
+                int baseVersion = EntityFormParser.parseBaseVersion(entityElement);
+                int newVersion = baseVersion + 1;
+                Entity entity = createEntity(entityElement, newVersion, dataset, saveTos, mainInstance);
+                formEntryModel.getExtras().put(new Entities(asList(entity)));
+            } else {
+                formEntryModel.getExtras().put(new Entities(emptyList()));
+            }
         }
     }
 

--- a/src/main/java/org/javarosa/entities/EntityFormFinalizationProcessor.java
+++ b/src/main/java/org/javarosa/entities/EntityFormFinalizationProcessor.java
@@ -34,7 +34,7 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
         String updateDataset = EntityFormParser.parseFirstDatasetToUpdate(entityElement);
 
         if (createDataset != null) {
-            Entity entity = createEntity(entityElement, -1, createDataset, saveTos, mainInstance);
+            Entity entity = createEntity(entityElement, 1, createDataset, saveTos, mainInstance);
             formEntryModel.getExtras().put(new Entities(asList(entity)));
         } else if (updateDataset != null ){
             int baseVersion = EntityFormParser.parseBaseVersion(entityElement);

--- a/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
+++ b/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
@@ -7,8 +7,6 @@ import org.jetbrains.annotations.Nullable;
 
 public class EntityFormParser {
 
-    private static final String ENTITIES_NAMESPACE = "http://www.opendatakit.org/xforms/entities";
-
     private EntityFormParser() {
 
     }

--- a/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
+++ b/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
@@ -3,6 +3,7 @@ package org.javarosa.entities.internal;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.xpath.expr.XPathFuncExpr;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class EntityFormParser {
@@ -11,34 +12,8 @@ public class EntityFormParser {
 
     }
 
-    @Nullable
-    public static String parseFirstDatasetToCreate(TreeElement entity) {
-        if (entity != null) {
-            String create = entity.getAttributeValue(null, "create");
-
-            if (create != null) {
-                if (XPathFuncExpr.boolStr(create)) {
-                    return entity.getAttributeValue(null, "dataset");
-                }
-            }
-        }
-
-        return null;
-    }
-
-    @Nullable
-    public static String parseFirstDatasetToUpdate(TreeElement entity) {
-        if (entity != null) {
-            String create = entity.getAttributeValue(null, "update");
-
-            if (create != null) {
-                if (XPathFuncExpr.boolStr(create)) {
-                    return entity.getAttributeValue(null, "dataset");
-                }
-            }
-        }
-
-        return null;
+    public static String parseDataset(TreeElement entity) {
+        return entity.getAttributeValue(null, "dataset");
     }
 
     public static String parseLabel(TreeElement entity) {
@@ -69,5 +44,30 @@ public class EntityFormParser {
         } else {
             return null;
         }
+    }
+
+    @Nullable
+    public static EntityAction parseAction(@NotNull TreeElement entity) {
+        String create = entity.getAttributeValue(null, "create");
+        String update = entity.getAttributeValue(null, "update");
+
+        if (create != null) {
+            if (XPathFuncExpr.boolStr(create)) {
+                return EntityAction.CREATE;
+            }
+        }
+
+        if (update != null) {
+            if (XPathFuncExpr.boolStr(update)) {
+                return EntityAction.UPDATE;
+            }
+        }
+
+        return null;
+    }
+
+    public enum EntityAction {
+        CREATE,
+        UPDATE
     }
 }

--- a/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
+++ b/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
@@ -16,13 +16,14 @@ public class EntityFormParser {
         return entity.getAttributeValue(null, "dataset");
     }
 
+    @Nullable
     public static String parseLabel(TreeElement entity) {
         TreeElement labelElement = entity.getFirstChild("label");
 
         if (labelElement != null) {
             return (String) labelElement.getValue().getValue();
         } else {
-            return "";
+            return null;
         }
     }
 

--- a/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
+++ b/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
@@ -28,6 +28,21 @@ public class EntityFormParser {
         return null;
     }
 
+    @Nullable
+    public static String parseFirstDatasetToUpdate(TreeElement entity) {
+        if (entity != null) {
+            String create = entity.getAttributeValue(null, "update");
+
+            if (create != null) {
+                if (XPathFuncExpr.boolStr(create)) {
+                    return entity.getAttributeValue(null, "dataset");
+                }
+            }
+        }
+
+        return null;
+    }
+
     public static String parseLabel(TreeElement entity) {
         TreeElement labelElement = entity.getFirstChild("label");
 
@@ -40,6 +55,10 @@ public class EntityFormParser {
 
     public static String parseId(TreeElement entity) {
         return entity.getAttributeValue("", "id");
+    }
+
+    public static Integer parseBaseVersion(TreeElement entity) {
+        return Integer.valueOf(entity.getAttributeValue("", "baseVersion"));
     }
 
     @Nullable

--- a/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
+++ b/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
@@ -51,15 +51,15 @@ public class EntityFormParser {
         String create = entity.getAttributeValue(null, "create");
         String update = entity.getAttributeValue(null, "update");
 
-        if (create != null) {
-            if (XPathFuncExpr.boolStr(create)) {
-                return EntityAction.CREATE;
-            }
-        }
-
         if (update != null) {
             if (XPathFuncExpr.boolStr(update)) {
                 return EntityAction.UPDATE;
+            }
+        }
+
+        if (create != null) {
+            if (XPathFuncExpr.boolStr(create)) {
+                return EntityAction.CREATE;
             }
         }
 

--- a/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
+++ b/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
@@ -31,7 +31,11 @@ public class EntityFormParser {
     }
 
     public static Integer parseBaseVersion(TreeElement entity) {
-        return Integer.valueOf(entity.getAttributeValue("", "baseVersion"));
+        try {
+            return Integer.valueOf(entity.getAttributeValue("", "baseVersion"));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     @Nullable

--- a/src/test/java/org/javarosa/entities/EntitiesTest.java
+++ b/src/test/java/org/javarosa/entities/EntitiesTest.java
@@ -122,6 +122,7 @@ public class EntitiesTest {
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo(scenario.answerOf("/data/meta/entity/@id").getValue()));
         assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
+        assertThat(entities.get(0).version, equalTo(1));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
     }
 

--- a/src/test/java/org/javarosa/entities/EntitiesTest.java
+++ b/src/test/java/org/javarosa/entities/EntitiesTest.java
@@ -171,6 +171,50 @@ public class EntitiesTest {
     }
 
     @Test
+    public void fillingFormWithCreateAndUpdate_makesEntityAvailableAsUpdate() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Create entity form", XFormsElement.html(
+            asList(
+                new Pair<>("entities", "http://www.opendatakit.org/xforms/entities")
+            ),
+            head(
+                title("Upsert entity form"),
+                model(asList(new Pair<>("entities:entities-version", "2023.1.0")),
+                    mainInstance(
+                        t("data id=\"upsert-entity-form\"",
+                            t("name"),
+                            t("meta",
+                                t("entity dataset=\"people\" create=\"1\" update=\"1\" id=\"123\" baseVersion=\"1\"",
+                                    t("label")
+                                )
+                            )
+                        )
+                    ),
+                    bind("/data/name").type("string").withAttribute("entities", "saveto", "name"),
+                    bind("/data/meta/entity/@id").type("string"),
+                    bind("/data/meta/entity/label").type("string").calculate("/data/name")
+                )
+            ),
+            body(
+                input("/data/name")
+            )
+        ));
+
+        scenario.getFormEntryController().addPostProcessor(new EntityFormFinalizationProcessor());
+
+        scenario.next();
+        scenario.answer("Tom Wambsgans");
+
+        scenario.finalizeInstance();
+        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(Entities.class).getEntities();
+        assertThat(entities.size(), equalTo(1));
+        assertThat(entities.get(0).dataset, equalTo("people"));
+        assertThat(entities.get(0).id, equalTo("123"));
+        assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
+        assertThat(entities.get(0).version, equalTo(2));
+        assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
+    }
+
+    @Test
     public void fillingFormWithDynamicCreateExpression_conditionallyCreatesEntities() throws IOException, XFormParser.ParseException {
         Scenario scenario = Scenario.init("Create entity form", XFormsElement.html(
             asList(

--- a/src/test/java/org/javarosa/entities/EntitiesTest.java
+++ b/src/test/java/org/javarosa/entities/EntitiesTest.java
@@ -126,6 +126,50 @@ public class EntitiesTest {
     }
 
     @Test
+    public void fillingFormWithUpdate_makesEntityAvailable() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Create entity form", XFormsElement.html(
+            asList(
+                new Pair<>("entities", "http://www.opendatakit.org/xforms/entities")
+            ),
+            head(
+                title("Uodate entity form"),
+                model(asList(new Pair<>("entities:entities-version", "2023.1.0")),
+                    mainInstance(
+                        t("data id=\"update-entity-form\"",
+                            t("name"),
+                            t("meta",
+                                t("entity dataset=\"people\" update=\"1\" id=\"123\" baseVersion=\"1\"",
+                                    t("label")
+                                )
+                            )
+                        )
+                    ),
+                    bind("/data/name").type("string").withAttribute("entities", "saveto", "name"),
+                    bind("/data/meta/entity/@id").type("string"),
+                    bind("/data/meta/entity/label").type("string").calculate("/data/name")
+                )
+            ),
+            body(
+                input("/data/name")
+            )
+        ));
+
+        scenario.getFormEntryController().addPostProcessor(new EntityFormFinalizationProcessor());
+
+        scenario.next();
+        scenario.answer("Tom Wambsgans");
+
+        scenario.finalizeInstance();
+        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(Entities.class).getEntities();
+        assertThat(entities.size(), equalTo(1));
+        assertThat(entities.get(0).dataset, equalTo("people"));
+        assertThat(entities.get(0).id, equalTo("123"));
+        assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
+        assertThat(entities.get(0).version, equalTo(2));
+        assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
+    }
+
+    @Test
     public void fillingFormWithDynamicCreateExpression_conditionallyCreatesEntities() throws IOException, XFormParser.ParseException {
         Scenario scenario = Scenario.init("Create entity form", XFormsElement.html(
             asList(

--- a/src/test/java/org/javarosa/entities/EntityFormFinalizationProcessorTest.java
+++ b/src/test/java/org/javarosa/entities/EntityFormFinalizationProcessorTest.java
@@ -1,0 +1,62 @@
+package org.javarosa.entities;
+
+import org.javarosa.core.test.Scenario;
+import org.javarosa.core.util.XFormsElement;
+import org.javarosa.entities.internal.Entities;
+import org.javarosa.form.api.FormEntryModel;
+import org.javarosa.xform.parse.XFormParserFactory;
+import org.javarosa.xform.util.XFormUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
+import static org.javarosa.core.util.XFormsElement.body;
+import static org.javarosa.core.util.XFormsElement.head;
+import static org.javarosa.core.util.XFormsElement.input;
+import static org.javarosa.core.util.XFormsElement.mainInstance;
+import static org.javarosa.core.util.XFormsElement.model;
+import static org.javarosa.core.util.XFormsElement.t;
+import static org.javarosa.core.util.XFormsElement.title;
+
+public class EntityFormFinalizationProcessorTest {
+
+    private final EntityXFormParserFactory entityXFormParserFactory = new EntityXFormParserFactory(new XFormParserFactory());
+
+    @Before
+    public void setup() {
+        XFormUtils.setXFormParserFactory(entityXFormParserFactory);
+    }
+
+    @After
+    public void teardown() {
+        XFormUtils.setXFormParserFactory(new XFormParserFactory());
+    }
+
+    @Test
+    public void whenFormDoesNotHaveEntityElement_addsNoEntitiesToExtras() throws Exception {
+        Scenario scenario = Scenario.init("Normal form", XFormsElement.html(
+            head(
+                title("Normal form"),
+                model(
+                    mainInstance(
+                        t("data id=\"normal\"",
+                            t("name")
+                        )
+                    ),
+                    bind("/data/name").type("string")
+                )
+            ),
+            body(
+                input("/data/name")
+            )
+        ));
+
+        EntityFormFinalizationProcessor processor = new EntityFormFinalizationProcessor();
+        FormEntryModel model = scenario.getFormEntryController().getModel();
+        processor.processForm(model);
+        assertThat(model.getExtras().get(Entities.class), equalTo(null));
+    }
+}

--- a/src/test/java/org/javarosa/entities/EntityFormParserTest.java
+++ b/src/test/java/org/javarosa/entities/EntityFormParserTest.java
@@ -25,7 +25,7 @@ import static org.javarosa.core.util.XFormsElement.title;
 public class EntityFormParserTest {
 
     @Test
-    public void parseFirstDatasetToCreate_findsCreateWithTrueString() throws XFormParser.ParseException {
+    public void parseAction_findsCreateWithTrueString() throws XFormParser.ParseException {
         XFormsElement form = XFormsElement.html(
             asList(
                 new Pair<>("entities", "http://www.opendatakit.org/xforms/entities")
@@ -52,7 +52,39 @@ public class EntityFormParserTest {
         XFormParser parser = new XFormParser(new InputStreamReader(new ByteArrayInputStream(form.asXml().getBytes())));
         FormDef formDef = parser.parse(null);
 
-        String dataset = EntityFormParser.parseFirstDatasetToCreate(EntityFormParser.getEntityElement(formDef.getMainInstance()));
-        assertThat(dataset, equalTo("people"));
+        EntityFormParser.EntityAction dataset = EntityFormParser.parseAction(EntityFormParser.getEntityElement(formDef.getMainInstance()));
+        assertThat(dataset, equalTo(EntityFormParser.EntityAction.CREATE));
+    }
+
+    @Test
+    public void parseAction_findsUpdateWithTrueString() throws XFormParser.ParseException {
+        XFormsElement form = XFormsElement.html(
+            asList(
+                new Pair<>("entities", "http://www.opendatakit.org/xforms/entities")
+            ),
+            head(
+                title("Create entity form"),
+                model(
+                    mainInstance(
+                        t("data id=\"create-entity-form\"",
+                            t("name"),
+                            t("meta",
+                                t("entity dataset=\"people\" update=\"true\"")
+                            )
+                        )
+                    ),
+                    bind("/data/name").type("string").withAttribute("entities", "saveto", "name")
+                )
+            ),
+            body(
+                input("/data/name")
+            )
+        );
+
+        XFormParser parser = new XFormParser(new InputStreamReader(new ByteArrayInputStream(form.asXml().getBytes())));
+        FormDef formDef = parser.parse(null);
+
+        EntityFormParser.EntityAction dataset = EntityFormParser.parseAction(EntityFormParser.getEntityElement(formDef.getMainInstance()));
+        assertThat(dataset, equalTo(EntityFormParser.EntityAction.UPDATE));
     }
 }


### PR DESCRIPTION
~~Blocked by #748~~

This adds new features to JavaRosa to allow clients to handle offline updates to Entities:

- Entities updated using an `update` action are now exposed from the `Entities` extra on `FormEntryModel`
- `Entity` now has a `version` field that is set to 1 for created Entities
- Updated Entities have their version set to the `entity` element's `baseVersion` attribute incremented by 1
- Forms that do an "upsert" (contain both a truthy `create` and `update`) expose an `Entity` as an update (version is `baseVersion` + 1)
- Forms that do an "upsert", but do not define a `baseVersion` expose an `Entity` as a create (version is set to 1)
- Forms that do an update, but do not contain a `label` node for the Entity, expose an `Entity` with a `null` label so clients know not to override an existing label if they have it

#### What has been done to verify that this works as intended?

New tests and verified with new Collect features at https://github.com/getodk/collect/pull/5982.

#### Why is this the best possible solution? Were any other approaches considered?

I did consider leaving the version incrementing to clients, but that would mean them making a decision about how to deal with the "upsert" cases. It felt more natural to me for JavaRosa to be the one making decisions about how to interpret the spec.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We now care a lot more about the `entity` element at finalization as we parse more out of it. I think this probably means that there is more scope for crashes during form finalization due to incorrect forms. I think we should collect those cases and handle in a follow up rather than holding this up however as we're mostly concerned right now with getting an experimental version of offline entities together (and the feature will still be opt in). It also feels easier to me to play with bad forms once we're able to do it Collect.
