### PR TITLE
Change absolute refs in repeats to relative

### DIFF
--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.AnswerDataMatchers.booleanAnswer;
@@ -32,7 +33,6 @@ import static org.javarosa.core.util.XFormsElement.t;
 import static org.javarosa.core.util.XFormsElement.title;
 import static org.javarosa.form.api.FormEntryController.ANSWER_CONSTRAINT_VIOLATED;
 import static org.javarosa.form.api.FormEntryController.ANSWER_REQUIRED_BUT_EMPTY;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -834,7 +834,7 @@ public class TriggerableDagTest {
                         ))),
                     // position(..) means the full cascade is evaulated as part of triggerTriggerables
                     bind("/data/repeat/position").calculate("position(..)"),
-                    bind("/data/repeat/position_2").calculate("/data/repeat/position * 2"),
+                    bind("/data/repeat/position_2").calculate("../position * 2"),
                     bind("/data/repeat/other").calculate("2 * 2"),
                     // concat needs to be evaluated after /data/repeat/other has a value
                     bind("/data/repeat/concatenated").calculate("concat(../position_2, '-', ../other)"))),
@@ -1017,7 +1017,7 @@ public class TriggerableDagTest {
                     )),
                     bind("/data/sum").type("int").calculate("sum(/data/repeat/position1)"),
                     bind("/data/repeat/position1").type("int").calculate("position(..)"),
-                    bind("/data/repeat/position2").type("int").calculate("/data/repeat/position1"))),
+                    bind("/data/repeat/position2").type("int").calculate("../position1"))),
 
             body(
                 repeat("/data/repeat",
@@ -1194,7 +1194,7 @@ public class TriggerableDagTest {
                     )),
                     bind("/data/house/number").type("int").calculate("position(..)"),
                     bind("/data/house/name").type("string").required(),
-                    bind("/data/house/name_and_number").type("string").calculate("concat(/data/house/name, /data/house/number)")
+                    bind("/data/house/name_and_number").type("string").calculate("concat(../name, ../number)")
                 )
             ),
             body(group("/data/house", repeat("/data/house", input("/data/house/name"))))
@@ -1245,7 +1245,7 @@ public class TriggerableDagTest {
                     )),
                     bind("/data/house/number").type("int").calculate("position(..)"),
                     bind("/data/house/name").type("string").required(),
-                    bind("/data/house/name_and_number").type("string").calculate("concat(/data/house/name, 'X')")
+                    bind("/data/house/name_and_number").type("string").calculate("concat(../name, 'X')")
                 )
             ),
             body(group("/data/house", repeat("/data/house", input("/data/house/name"))))
@@ -1729,7 +1729,7 @@ public class TriggerableDagTest {
                     bind("/data/inner_trigger").type("int"),
                     bind("/data/outer").relevant("/data/outer_trigger = 'D'"),
                     bind("/data/outer/inner_condition").type("boolean").calculate("/data/inner_trigger > 10"),
-                    bind("/data/outer/inner").relevant("/data/outer/inner_condition"),
+                    bind("/data/outer/inner").relevant("../inner_condition"),
                     bind("/data/outer/inner/target_question").type("string")
                 )
             ),

--- a/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
@@ -374,7 +374,7 @@ public class SetValueActionTest {
             body(
                 repeat("/data/repeat1",
                     input("/data/repeat1/source",
-                        setvalue("xforms-value-changed", "/data/repeat1/repeat2/destination", "/data/repeat1/source")),
+                        setvalue("xforms-value-changed", "/data/repeat1/repeat2/destination", "../../source")),
                     repeat("/data/repeat1/repeat2",
                         input("/data/repeat1/repeat2/destination")
             )))));


### PR DESCRIPTION
Prior to https://github.com/XLSForm/pyxform/pull/187 and https://github.com/getodk/xforms-spec/pull/252/, absolute paths representing single nodes inside repeats were always evaluated as if they were relative to the current nodeset. That is, any repeat paths in the expression were qualified according to the current repeat index. In true XPath, absolute paths representing single nodes inside repeats are intended to represent the first node in any repeat path segment.

`pyxform` no longer generates absolute paths representing single nodes inside repeats and we should test forms that are likely to actually be produced by users.

#### What has been done to verify that this works as intended?
I ran each test, made the change, ran the test again.

#### Why is this the best possible solution? Were any other approaches considered?
I thought about automating the detection of these kinds of tests but quickly decided it would be faster for me to just open all 136 test files (`find . -name "*.java" -print | wc -l`) and manually inspect them. This situation only occurs with forms with repeats in them so already that cuts down the number of relevant test files dramatically. It also only applies if there's some kind of calculation in the repeat using a reference to a value also in that repeat.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Test-only change, no possible user-facing effect. There could be a risk of a regression on the legacy behavior which we do want to maintain for now so I added a test specifically for that.

#### Do we need any specific form for testing your changes? If so, please attach one.
See tests.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.