### PR TITLE
Use 1-based indexing in test position predicates to match XPath

### DIFF
--- a/src/test/java/org/javarosa/core/model/DynamicSelectUpdateTest.java
+++ b/src/test/java/org/javarosa/core/model/DynamicSelectUpdateTest.java
@@ -58,13 +58,13 @@ public class DynamicSelectUpdateTest {
     public void selectFromRepeat_whenRepeatAdded_updatesChoices() throws Exception {
         Scenario scenario = Scenario.init("Select from repeat", getSelectFromRepeatForm());
 
-        scenario.answer("/data/repeat[0]/value","a");
-        scenario.answer("/data/repeat[0]/label","A");
+        scenario.answer("/data/repeat[1]/value","a");
+        scenario.answer("/data/repeat[1]/label","A");
         assertThat(scenario.choicesOf("/data/select"), contains(
             choice("a", "A")));
 
-        scenario.answer("/data/repeat[1]/value","b");
-        scenario.answer("/data/repeat[1]/label","B");
+        scenario.answer("/data/repeat[2]/value","b");
+        scenario.answer("/data/repeat[2]/label","B");
         assertThat(scenario.choicesOf("/data/select"), containsInAnyOrder(
             choice("a", "A"),
             choice("b", "B")));
@@ -74,13 +74,13 @@ public class DynamicSelectUpdateTest {
     public void selectFromRepeat_whenRepeatChanged_updatesChoices() throws Exception {
         Scenario scenario = Scenario.init("Select from repeat", getSelectFromRepeatForm());
 
-        scenario.answer("/data/repeat[0]/value","a");
-        scenario.answer("/data/repeat[0]/label","A");
+        scenario.answer("/data/repeat[1]/value","a");
+        scenario.answer("/data/repeat[1]/label","A");
         assertThat(scenario.choicesOf("/data/select"), contains(
             choice("a", "A")));
 
-        scenario.answer("/data/repeat[0]/value","c");
-        scenario.answer("/data/repeat[0]/label","C");
+        scenario.answer("/data/repeat[1]/value","c");
+        scenario.answer("/data/repeat[1]/label","C");
         assertThat(scenario.choicesOf("/data/select"), contains(
             choice("c", "C")));
         assertThat(scenario.choicesOf("/data/select").size(), is(1));
@@ -90,12 +90,12 @@ public class DynamicSelectUpdateTest {
     public void selectFromRepeat_whenRepeatRemoved_updatesChoices() throws Exception {
         Scenario scenario = Scenario.init("Select from repeat", getSelectFromRepeatForm());
 
-        scenario.answer("/data/repeat[0]/value", "a");
-        scenario.answer("/data/repeat[0]/label", "A");
+        scenario.answer("/data/repeat[1]/value", "a");
+        scenario.answer("/data/repeat[1]/label", "A");
         assertThat(scenario.choicesOf("/data/select"), contains(
             choice("a", "A")));
 
-        scenario.removeRepeat("/data/repeat[0]");
+        scenario.removeRepeat("/data/repeat[1]");
         assertThat(scenario.choicesOf("/data/select").size(), is(0));
     }
 
@@ -103,8 +103,8 @@ public class DynamicSelectUpdateTest {
     public void selectFromRepeat_withPredicate_whenPredicateTriggerChanges_updatesChoices() throws Exception {
         Scenario scenario = Scenario.init("Select from repeat", getSelectFromRepeatForm("starts-with(value,current()/../filter)"));
 
-        scenario.answer("/data/repeat[0]/value", "a");
-        scenario.answer("/data/repeat[0]/label", "A");
+        scenario.answer("/data/repeat[1]/value", "a");
+        scenario.answer("/data/repeat[1]/label", "A");
         scenario.answer("/data/filter", "a");
         assertThat(scenario.choicesOf("/data/select"), contains(
             choice("a", "A")));
@@ -243,10 +243,10 @@ public class DynamicSelectUpdateTest {
                 )
             ));
 
-        scenario.answer("/data/repeat[0]/question", "a");
+        scenario.answer("/data/repeat[1]/question", "a");
         assertThat(scenario.choicesOf("/data/select").size(), is(3));
 
-        scenario.answer("/data/repeat[1]/question", "b");
+        scenario.answer("/data/repeat[2]/question", "b");
         List<SelectChoice> choices = scenario.choicesOf("/data/select");
         assertThat(choices.size(), is(2));
         // Because of the repeat trigger in the count expression, choices should be recomputed every time they're requested
@@ -278,18 +278,17 @@ public class DynamicSelectUpdateTest {
                     select1Dynamic("/data/repeat/select", "instance('choices')/root/item[starts-with(value,current()/../filter)]"))
             )));
 
-        scenario.answer("/data/repeat[0]/filter", "a");
         scenario.answer("/data/repeat[1]/filter", "a");
-        List<SelectChoice> repeat0Choices = scenario.choicesOf("/data/repeat[0]/select");
-        List<SelectChoice> repeat1Choices = scenario.choicesOf("/data/repeat[1]/select");
+        scenario.answer("/data/repeat[2]/filter", "a");
+        List<SelectChoice> repeat0Choices = scenario.choicesOf("/data/repeat[1]/select");
+        List<SelectChoice> repeat1Choices = scenario.choicesOf("/data/repeat[2]/select");
 
-        // The trigger keys are /data/repeat[0]/filter and /data/repeat[1]/filter which means no caching between them
+        // The trigger keys are /data/repeat[1]/filter and /data/repeat[2]/filter which means no caching between them
         assertThat(repeat0Choices, not(sameInstance(repeat1Choices)));
 
-        scenario.answer("/data/repeat[1]/filter", "bb");
-        assertThat(scenario.choicesOf("/data/repeat[0]/select").size(), is(2));
-        assertThat(scenario.choicesOf("/data/repeat[1]/select").size(), is(1));
+        scenario.answer("/data/repeat[2]/filter", "bb");
+        assertThat(scenario.choicesOf("/data/repeat[1]/select").size(), is(2));
+        assertThat(scenario.choicesOf("/data/repeat[2]/select").size(), is(1));
     }
-    //endregion
     //endregion
 }

--- a/src/test/java/org/javarosa/core/model/PredicateCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/PredicateCachingTest.java
@@ -1,9 +1,5 @@
 package org.javarosa.core.model;
 
-import org.javarosa.core.test.Scenario;
-import org.javarosa.measure.Measure;
-import org.junit.Test;
-
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -23,6 +19,10 @@ import static org.javarosa.core.util.XFormsElement.model;
 import static org.javarosa.core.util.XFormsElement.repeat;
 import static org.javarosa.core.util.XFormsElement.t;
 import static org.javarosa.core.util.XFormsElement.title;
+
+import org.javarosa.core.test.Scenario;
+import org.javarosa.measure.Measure;
+import org.junit.Test;
 
 public class PredicateCachingTest {
 
@@ -312,13 +312,13 @@ public class PredicateCachingTest {
         scenario.createNewRepeat("/data/repeat");
         scenario.createNewRepeat("/data/repeat");
 
-        scenario.answer("/data/repeat[0]/choice", "a");
-        assertThat(scenario.answerOf("/data/repeat[0]/calculate").getValue(), equalTo("A"));
-        assertThat(scenario.answerOf("/data/repeat[1]/calculate"), equalTo(null));
+        scenario.answer("/data/repeat[1]/choice", "a");
+        assertThat(scenario.answerOf("/data/repeat[1]/calculate").getValue(), equalTo("A"));
+        assertThat(scenario.answerOf("/data/repeat[2]/calculate"), equalTo(null));
 
-        scenario.answer("/data/repeat[1]/choice", "b");
-        assertThat(scenario.answerOf("/data/repeat[0]/calculate").getValue(), equalTo("A"));
-        assertThat(scenario.answerOf("/data/repeat[1]/calculate").getValue(), equalTo("B"));
+        scenario.answer("/data/repeat[2]/choice", "b");
+        assertThat(scenario.answerOf("/data/repeat[1]/calculate").getValue(), equalTo("A"));
+        assertThat(scenario.answerOf("/data/repeat[2]/calculate").getValue(), equalTo("B"));
     }
 
     @Test
@@ -601,8 +601,8 @@ public class PredicateCachingTest {
         assertThat(scenario.answerOf("/data/result"), equalTo(null));
 
         scenario.createNewRepeat("/data/repeat");
-        scenario.answer("/data/repeat[0]/name", "John Bell");
-        scenario.answer("/data/repeat[0]/age", "70");
+        scenario.answer("/data/repeat[1]/name", "John Bell");
+        scenario.answer("/data/repeat[1]/age", "70");
 
         assertThat(scenario.answerOf("/data/result").getValue(), equalTo("70"));
     }

--- a/src/test/java/org/javarosa/core/model/RepeatTest.java
+++ b/src/test/java/org/javarosa/core/model/RepeatTest.java
@@ -144,28 +144,28 @@ public class RepeatTest {
                 )
             )));
 
-        scenario.answer("/data/outer[0]/outerq1", "5");
-        assertThat(scenario.answerOf("/data/outer[0]/outercalcabs"), is(new IntegerData(6)));
-        assertThat(scenario.answerOf("/data/outer[0]/outercalcrel"), is(new IntegerData(6)));
+        scenario.answer("/data/outer[1]/outerq1", "5");
+        assertThat(scenario.answerOf("/data/outer[1]/outercalcabs"), is(new IntegerData(6)));
+        assertThat(scenario.answerOf("/data/outer[1]/outercalcrel"), is(new IntegerData(6)));
 
         scenario.createNewRepeat("/data/outer");
 
-        scenario.answer("/data/outer[1]/outerq1", "23");
+        scenario.answer("/data/outer[2]/outerq1", "23");
         // In a standards-compliant XPath engine, this would be 6 because /data/outer/outerq1 in the calculate expression
-        // would always be equivalent to /data/outer[0]/outerq1
-        assertThat(scenario.answerOf("/data/outer[1]/outercalcabs"), is(new IntegerData(24)));
-        assertThat(scenario.answerOf("/data/outer[1]/outercalcrel"), is(new IntegerData(24)));
+        // would always be equivalent to /data/outer[1]/outerq1
+        assertThat(scenario.answerOf("/data/outer[2]/outercalcabs"), is(new IntegerData(24)));
+        assertThat(scenario.answerOf("/data/outer[2]/outercalcrel"), is(new IntegerData(24)));
 
-        scenario.answer("/data/outer[0]/inner[0]/innerq1", 18);
-        assertThat(scenario.answerOf("/data/outer[0]/inner[0]/innercalcabs"), is(new IntegerData(20)));
-        assertThat(scenario.answerOf("/data/outer[0]/inner[0]/innercalcrel"), is(new IntegerData(20)));
+        scenario.answer("/data/outer[1]/inner[1]/innerq1", 18);
+        assertThat(scenario.answerOf("/data/outer[1]/inner[1]/innercalcabs"), is(new IntegerData(20)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[1]/innercalcrel"), is(new IntegerData(20)));
 
-        scenario.createNewRepeat("/data/outer[0]/inner");
+        scenario.createNewRepeat("/data/outer[1]/inner");
 
-        scenario.answer("/data/outer[0]/inner[1]/innerq1", 19);
+        scenario.answer("/data/outer[1]/inner[2]/innerq1", 19);
         // In a standards-compliant XPath engine, this would be 20 because /data/outer/inner/innerq1 in the calculate expression
-        // would always be equivalent to /data/outer[0]/inner[0]/innerq1
-        assertThat(scenario.answerOf("/data/outer[0]/inner[1]/innercalcabs"), is(new IntegerData(21)));
-        assertThat(scenario.answerOf("/data/outer[0]/inner[1]/innercalcrel"), is(new IntegerData(21)));
+        // would always be equivalent to /data/outer[1]/inner[1]/innerq1
+        assertThat(scenario.answerOf("/data/outer[1]/inner[2]/innercalcabs"), is(new IntegerData(21)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[2]/innercalcrel"), is(new IntegerData(21)));
     }
 }

--- a/src/test/java/org/javarosa/core/model/SelectCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectCachingTest.java
@@ -1,9 +1,5 @@
 package org.javarosa.core.model;
 
-import org.javarosa.core.test.Scenario;
-import org.javarosa.measure.Measure;
-import org.junit.Test;
-
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -21,6 +17,10 @@ import static org.javarosa.core.util.XFormsElement.repeat;
 import static org.javarosa.core.util.XFormsElement.select1Dynamic;
 import static org.javarosa.core.util.XFormsElement.t;
 import static org.javarosa.core.util.XFormsElement.title;
+
+import org.javarosa.core.test.Scenario;
+import org.javarosa.measure.Measure;
+import org.junit.Test;
 
 public class SelectCachingTest {
 
@@ -344,10 +344,10 @@ public class SelectCachingTest {
         int evaluations = Measure.withMeasure(asList("PredicateEvaluation", "IndexEvaluation"), () -> {
             scenario.answer("/data/filter", "a");
 
-            scenario.choicesOf("/data/repeat[0]/select");
+            scenario.choicesOf("/data/repeat[1]/select");
 
             scenario.createNewRepeat("/data/repeat");
-            scenario.choicesOf("/data/repeat[1]/select");
+            scenario.choicesOf("/data/repeat[2]/select");
         });
 
         // Check that we do just (size of secondary instance)
@@ -377,15 +377,15 @@ public class SelectCachingTest {
                         select1Dynamic("/data/outer/inner/select", "instance('choices')/root/item[value=current()/../../filter]"))
                 ))));
 
-        scenario.answer("/data/outer[0]/filter", "a");
-        scenario.createNewRepeat("/data/outer[0]/inner");
         scenario.answer("/data/outer[1]/filter", "a");
         scenario.createNewRepeat("/data/outer[1]/inner");
-        scenario.createNewRepeat("/data/outer[1]/inner");
+        scenario.answer("/data/outer[2]/filter", "a");
+        scenario.createNewRepeat("/data/outer[2]/inner");
+        scenario.createNewRepeat("/data/outer[2]/inner");
 
         int evaluations = Measure.withMeasure(asList("PredicateEvaluation", "IndexEvaluation"), () -> {
-            scenario.choicesOf("/data/outer[0]/inner[0]/select");
-            scenario.choicesOf("/data/outer[0]/inner[1]/select");
+            scenario.choicesOf("/data/outer[1]/inner[1]/select");
+            scenario.choicesOf("/data/outer[1]/inner[2]/select");
         });
 
         // Check that we do just (size of secondary instance)

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -487,13 +487,13 @@ public class TriggerableDagTest {
             XPathPathExpr.getRefValue(
                 scenario.getFormDef().getMainInstance(),
                 scenario.getEvaluationContext(),
-                scenario.expandSingle(getRef(("/data/node[1]/value")))
+                scenario.expandSingle(getRef(("/data/node[2]/value")))
             ),
             is("")
         );
         // ... as opposed to the value that we can get by resolving the same
         // reference with the main instance, which has the expected `2` value
-        assertThat(scenario.answerOf("/data/node[1]/value"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/node[2]/value"), is(intAnswer(2)));
     }
 
     @Test
@@ -806,8 +806,8 @@ public class TriggerableDagTest {
         scenario.next();
         scenario.answer(0);
 
-        assertThat(scenario.answerOf("/data/repeat[" + 0 + "]/inner2"), CoreMatchers.is(intAnswer(0)));
-        assertThat(scenario.answerOf("/data/repeat[" + 0 + "]/inner3"), CoreMatchers.is(intAnswer(0)));
+        assertThat(scenario.answerOf("/data/repeat[1]/inner2"), CoreMatchers.is(intAnswer(0)));
+        assertThat(scenario.answerOf("/data/repeat[1]/inner3"), CoreMatchers.is(intAnswer(0)));
 
         scenario.next();
         scenario.createNewRepeat();
@@ -815,8 +815,8 @@ public class TriggerableDagTest {
 
         scenario.answer(1);
 
-        assertThat(scenario.answerOf("/data/repeat[" + 1 + "]/inner2"), CoreMatchers.is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/repeat[" + 1 + "]/inner3"), CoreMatchers.is(intAnswer(4)));
+        assertThat(scenario.answerOf("/data/repeat[2]/inner2"), CoreMatchers.is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/repeat[2]/inner3"), CoreMatchers.is(intAnswer(4)));
     }
 
     @Test
@@ -845,13 +845,13 @@ public class TriggerableDagTest {
 
         scenario.next();
         scenario.next();
-        assertThat(scenario.answerOf("/data/repeat[" + 0 + "]/concatenated"), CoreMatchers.is(stringAnswer("2-4")));
+        assertThat(scenario.answerOf("/data/repeat[1]/concatenated"), CoreMatchers.is(stringAnswer("2-4")));
 
         scenario.next();
         scenario.createNewRepeat();
 
         scenario.next();
-        assertThat(scenario.answerOf("/data/repeat[" + 1 + "]/concatenated"), CoreMatchers.is(stringAnswer("4-4")));
+        assertThat(scenario.answerOf("/data/repeat[2]/concatenated"), CoreMatchers.is(stringAnswer("4-4")));
     }
 
     // Illustrates the second case in TriggerableDAG.getTriggerablesAffectingAllInstances
@@ -879,18 +879,18 @@ public class TriggerableDagTest {
 
         dagEvents.clear();
 
-        range(0, 5).forEach(n -> {
+        range(1, 6).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/count"), CoreMatchers.is(intAnswer(n + 1)));
+            assertThat(scenario.answerOf("/data/count"), CoreMatchers.is(intAnswer(n)));
             scenario.next();
         });
 
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
+        range(1, 6).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
 
-        scenario.removeRepeat("/data/repeat[3]");
+        scenario.removeRepeat("/data/repeat[5]");
 
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
+        range(1, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
     }
 
     // In this case, the count(/data/repeat) expression is represented by a single triggerable. The expression gets
@@ -918,18 +918,18 @@ public class TriggerableDagTest {
                 )
             )));
 
-        range(0, 5).forEach(n -> {
+        range(1, 6).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n + 1)));
+            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n)));
             scenario.next();
         });
 
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
+        range(1, 6).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
 
-        scenario.removeRepeat("/data/repeat[3]");
+        scenario.removeRepeat("/data/repeat[5]");
 
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
+        range(1, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
     }
 
     // In this case, /data/repeat in the count(/data/repeat) expression is given the context of the current repeat so the
@@ -954,18 +954,18 @@ public class TriggerableDagTest {
                 )
             )));
 
-        range(0, 5).forEach(n -> {
+        range(1, 6).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n + 1)));
+            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n)));
             scenario.next();
         });
 
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
+        range(1, 6).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
 
-        scenario.removeRepeat("/data/repeat[3]");
+        scenario.removeRepeat("/data/repeat[4]");
 
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
+        range(1, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
     }
 
     @Test
@@ -987,18 +987,18 @@ public class TriggerableDagTest {
                 )
             )));
 
-        range(0, 5).forEach(n -> {
+        range(1, 6).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n + 1)));
+            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(n)));
             scenario.next();
         });
 
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
+        range(1, 6).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(5))));
 
-        scenario.removeRepeat("/data/repeat[3]");
+        scenario.removeRepeat("/data/repeat[4]");
 
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
+        range(1, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-count"), CoreMatchers.is(intAnswer(4))));
     }
 
     @Test
@@ -1025,18 +1025,18 @@ public class TriggerableDagTest {
                 )
             )));
 
-        range(0, 5).forEach(n -> {
+        range(1, 6).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/sum"), CoreMatchers.is(intAnswer((n + 1) * (n + 2) / 2)));
+            assertThat(scenario.answerOf("/data/sum"), CoreMatchers.is(intAnswer(n * (n + 1) / 2)));
             scenario.next();
         });
 
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/position1"), CoreMatchers.is(intAnswer(n + 1))));
+        range(1, 6).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/position1"), CoreMatchers.is(intAnswer(n))));
 
-        scenario.removeRepeat("/data/repeat[3]");
+        scenario.removeRepeat("/data/repeat[5]");
 
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/position2"), CoreMatchers.is(intAnswer(n + 1))));
+        range(1, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/position2"), CoreMatchers.is(intAnswer(n))));
     }
 
 
@@ -1064,34 +1064,34 @@ public class TriggerableDagTest {
         scenario.next();
         scenario.answer(11);
 
-        assertThat(scenario.answerOf("/data/group[0]/prev-number"), is(nullValue()));
-        assertThat(scenario.answerOf("/data/group[0]/number"), is(intAnswer(11)));
+        assertThat(scenario.answerOf("/data/group[1]/prev-number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/group[1]/number"), is(intAnswer(11)));
 
         scenario.next();
         scenario.createNewRepeat();
         scenario.next();
         scenario.answer(22);
 
-        assertThat(scenario.answerOf("/data/group[0]/number"), is(intAnswer(11)));
-        assertThat(scenario.answerOf("/data/group[1]/number"), is(intAnswer(22)));
+        assertThat(scenario.answerOf("/data/group[1]/number"), is(intAnswer(11)));
+        assertThat(scenario.answerOf("/data/group[2]/number"), is(intAnswer(22)));
 
-        assertThat(scenario.answerOf("/data/group[0]/prev-number"), is(nullValue()));
-        assertThat(scenario.answerOf("/data/group[1]/prev-number"), is(intAnswer(11)));
+        assertThat(scenario.answerOf("/data/group[1]/prev-number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/group[2]/prev-number"), is(intAnswer(11)));
 
         scenario.next();
         scenario.createNewRepeat();
         scenario.next();
         scenario.answer(33);
 
-        assertThat(scenario.answerOf("/data/group[0]/prev-number"), is(nullValue()));
-        assertThat(scenario.answerOf("/data/group[1]/prev-number"), is(intAnswer(11)));
-        assertThat(scenario.answerOf("/data/group[2]/prev-number"), is(intAnswer(22)));
+        assertThat(scenario.answerOf("/data/group[1]/prev-number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/group[2]/prev-number"), is(intAnswer(11)));
+        assertThat(scenario.answerOf("/data/group[3]/prev-number"), is(intAnswer(22)));
 
-        scenario.removeRepeat("/data/group[1]");
+        scenario.removeRepeat("/data/group[2]");
 
-        assertThat(scenario.answerOf("/data/group[0]/prev-number"), is(nullValue()));
-        assertThat(scenario.answerOf("/data/group[1]/number"), is(intAnswer(33)));
-        assertThat(scenario.answerOf("/data/group[1]/prev-number"), is(intAnswer(11)));
+        assertThat(scenario.answerOf("/data/group[1]/prev-number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/group[2]/number"), is(intAnswer(33)));
+        assertThat(scenario.answerOf("/data/group[2]/prev-number"), is(intAnswer(11)));
     }
 
     @Test
@@ -1124,16 +1124,16 @@ public class TriggerableDagTest {
         scenario.next();
         scenario.createNewRepeat();
 
-        assertThat(scenario.getAnswerNode("/data/repeat[0]/group/in_group").isRelevant(), is(true));
+        assertThat(scenario.getAnswerNode("/data/repeat[1]/group/in_group").isRelevant(), is(true));
 
         scenario.createNewRepeat("/data/repeat");
 
+        assertThat(scenario.getAnswerNode("/data/repeat[2]/group/in_group").isRelevant(), is(false));
         assertThat(scenario.getAnswerNode("/data/repeat[1]/group/in_group").isRelevant(), is(false));
-        assertThat(scenario.getAnswerNode("/data/repeat[0]/group/in_group").isRelevant(), is(false));
 
-        scenario.removeRepeat("/data/repeat[1]");
+        scenario.removeRepeat("/data/repeat[2]");
 
-        assertThat(scenario.getAnswerNode("/data/repeat[0]/group/in_group").isRelevant(), is(true));
+        assertThat(scenario.getAnswerNode("/data/repeat[1]/group/in_group").isRelevant(), is(true));
     }
     //endregion
 
@@ -1152,27 +1152,27 @@ public class TriggerableDagTest {
             ),
             body(group("/data/house", repeat("/data/house", input("number"))))
         )).onDagEvent(dagEvents::add);
-        range(0, 5).forEach(__ -> {
+        range(1, 6).forEach(__ -> {
             scenario.next();
             scenario.createNewRepeat();
             scenario.next();
         });
-        assertThat(scenario.answerOf("/data/house[0]/number"), is(intAnswer(1)));
-        assertThat(scenario.answerOf("/data/house[1]/number"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/house[2]/number"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/house[3]/number"), is(intAnswer(4)));
-        assertThat(scenario.answerOf("/data/house[4]/number"), is(intAnswer(5)));
+        assertThat(scenario.answerOf("/data/house[1]/number"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/house[2]/number"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/house[3]/number"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/house[4]/number"), is(intAnswer(4)));
+        assertThat(scenario.answerOf("/data/house[5]/number"), is(intAnswer(5)));
 
         // Start recording DAG events now
         dagEvents.clear();
 
-        scenario.removeRepeat("/data/house[1]");
+        scenario.removeRepeat("/data/house[2]");
 
-        assertThat(scenario.answerOf("/data/house[0]/number"), is(intAnswer(1)));
-        assertThat(scenario.answerOf("/data/house[1]/number"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/house[2]/number"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/house[3]/number"), is(intAnswer(4)));
-        assertThat(scenario.answerOf("/data/house[4]/number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/house[1]/number"), is(intAnswer(1)));
+        assertThat(scenario.answerOf("/data/house[2]/number"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/house[3]/number"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/house[4]/number"), is(intAnswer(4)));
+        assertThat(scenario.answerOf("/data/house[5]/number"), is(nullValue()));
         assertDagEvents(dagEvents,
             "Processing 'Recalculate' for number [1_1] (1.0), number [2_1] (2.0), number [3_1] (3.0), number [4_1] (4.0)",
             "Processing 'Deleted: number [2_1]: 1 triggerables were fired.' for "
@@ -1199,28 +1199,28 @@ public class TriggerableDagTest {
             ),
             body(group("/data/house", repeat("/data/house", input("/data/house/name"))))
         )).onDagEvent(dagEvents::add);
-        range(0, 5).forEach(n -> {
+        range(1, 6).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
             scenario.next();
-            scenario.answer((char) (65 + n));
+            scenario.answer((char) (64 + n));
         });
-        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("A1")));
-        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("B2")));
-        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("C3")));
-        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("D4")));
-        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(stringAnswer("E5")));
+        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("A1")));
+        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("B2")));
+        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("C3")));
+        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(stringAnswer("D4")));
+        assertThat(scenario.answerOf("/data/house[5]/name_and_number"), is(stringAnswer("E5")));
 
         // Start recording DAG events now
         dagEvents.clear();
 
-        scenario.removeRepeat("/data/house[1]");
+        scenario.removeRepeat("/data/house[2]");
 
-        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("A1")));
-        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("C2")));
-        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("D3")));
-        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("E4")));
-        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("A1")));
+        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("C2")));
+        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("D3")));
+        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(stringAnswer("E4")));
+        assertThat(scenario.answerOf("/data/house[5]/name_and_number"), is(nullValue()));
         assertDagEvents(dagEvents,
             "Processing 'Recalculate' for number [1_1] (1.0), number [2_1] (2.0), number [3_1] (3.0), number [4_1] (4.0)",
             "Processing 'Recalculate' for name_and_number [1_1] (A1), name_and_number [2_1] (C2), name_and_number [3_1] (D3), name_and_number [4_1] (E4)",
@@ -1250,28 +1250,28 @@ public class TriggerableDagTest {
             ),
             body(group("/data/house", repeat("/data/house", input("/data/house/name"))))
         )).onDagEvent(dagEvents::add);
-        range(0, 5).forEach(n -> {
+        range(1, 6).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
             scenario.next();
-            scenario.answer((char) (65 + n));
+            scenario.answer((char) (64 + n));
         });
-        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("AX")));
-        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("BX")));
-        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("CX")));
-        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("DX")));
-        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(stringAnswer("EX")));
+        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("AX")));
+        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("BX")));
+        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("CX")));
+        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(stringAnswer("DX")));
+        assertThat(scenario.answerOf("/data/house[5]/name_and_number"), is(stringAnswer("EX")));
 
         // Start recording DAG events now
         dagEvents.clear();
 
-        scenario.removeRepeat("/data/house[1]");
+        scenario.removeRepeat("/data/house[2]");
 
-        assertThat(scenario.answerOf("/data/house[0]/name_and_number"), is(stringAnswer("AX")));
-        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("CX")));
-        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("DX")));
-        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("EX")));
-        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/house[1]/name_and_number"), is(stringAnswer("AX")));
+        assertThat(scenario.answerOf("/data/house[2]/name_and_number"), is(stringAnswer("CX")));
+        assertThat(scenario.answerOf("/data/house[3]/name_and_number"), is(stringAnswer("DX")));
+        assertThat(scenario.answerOf("/data/house[4]/name_and_number"), is(stringAnswer("EX")));
+        assertThat(scenario.answerOf("/data/house[5]/name_and_number"), is(nullValue()));
         assertDagEvents(dagEvents,
             "Processing 'Recalculate' for number [1_1] (1.0), number [2_1] (2.0), number [3_1] (3.0), number [4_1] (4.0)",
             "Processing 'Deleted: number [2_1]: 1 triggerables were fired.' for ",
@@ -1304,7 +1304,7 @@ public class TriggerableDagTest {
         });
         assertThat(scenario.answerOf("/data/summary"), is(intAnswer(55)));
 
-        scenario.removeRepeat("/data/house[2]");
+        scenario.removeRepeat("/data/house[3]");
 
         assertThat(scenario.answerOf("/data/summary"), is(intAnswer(45)));
     }
@@ -1327,7 +1327,7 @@ public class TriggerableDagTest {
             ),
             body(group("/data/house", repeat("/data/house", input("number"))))
         )).onDagEvent(dagEvents::add);
-        range(0, 10).forEach(n -> {
+        range(1, 11).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
             scenario.next();
@@ -1336,7 +1336,7 @@ public class TriggerableDagTest {
         // Start recording DAG events now
         dagEvents.clear();
 
-        scenario.removeRepeat("/data/house[2]");
+        scenario.removeRepeat("/data/house[3]");
 
         assertThat(scenario.answerOf("/data/summary"), is(intAnswer(45)));
         assertDagEvents(dagEvents,
@@ -1366,7 +1366,7 @@ public class TriggerableDagTest {
             ),
             body(group("/data/repeat", repeat("/data/repeat", input("number"))))
         )).onDagEvent(dagEvents::add);
-        range(0, 10).forEach(n -> {
+        range(1, 11).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
             scenario.next();
@@ -1375,7 +1375,7 @@ public class TriggerableDagTest {
         // Start recording DAG events now
         dagEvents.clear();
 
-        scenario.removeRepeat("/data/repeat[2]");
+        scenario.removeRepeat("/data/repeat[3]");
 
         assertDagEvents(dagEvents,
             "Processing 'Recalculate' for numberx2 [3_1] (NaN)",
@@ -1410,18 +1410,18 @@ public class TriggerableDagTest {
             ),
             body(group("/data/house", repeat("/data/house", input("/data/house/name"))))
         )).onDagEvent(dagEvents::add);
-        range(0, 5).forEach(n -> {
+        range(1, 6).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
             scenario.next();
-            scenario.answer((char) (65 + n));
+            scenario.answer((char) (64 + n));
         });
         assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("ABCDE")));
 
         // Start recording DAG events now
         dagEvents.clear();
 
-        scenario.removeRepeat("/data/house[2]");
+        scenario.removeRepeat("/data/house[3]");
 
         assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("ABDE")));
         assertDagEvents(dagEvents,
@@ -1455,7 +1455,7 @@ public class TriggerableDagTest {
 
         assertThat(scenario.answerOf("/data/repeat-count"), is(intAnswer(3)));
 
-        scenario.removeRepeat("/data/repeat[2]");
+        scenario.removeRepeat("/data/repeat[3]");
         assertThat(scenario.answerOf("/data/repeat-count"), is(intAnswer(2)));
     }
 
@@ -1484,7 +1484,7 @@ public class TriggerableDagTest {
 
         assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("abc")));
 
-        scenario.removeRepeat("/data/repeat[2]");
+        scenario.removeRepeat("/data/repeat[3]");
         assertThat(scenario.answerOf("/data/summary"), is(stringAnswer("ab")));
     }
     //endregion
@@ -1593,18 +1593,18 @@ public class TriggerableDagTest {
                 )
             )));
 
-        range(0, 5).forEach(n -> {
+        range(1, 6).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-sum"), CoreMatchers.is(intAnswer((n + 1) * 5)));
+            assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-sum"), CoreMatchers.is(intAnswer(n * 5)));
             scenario.next();
         });
 
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-sum"), CoreMatchers.is(intAnswer(25))));
+        range(1, 6).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-sum"), CoreMatchers.is(intAnswer(25))));
 
-        scenario.removeRepeat("/data/repeat[3]");
+        scenario.removeRepeat("/data/repeat[4]");
 
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-sum"), CoreMatchers.is(intAnswer(20))));
+        range(1, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-sum"), CoreMatchers.is(intAnswer(20))));
     }
 
     @Ignore("Fails on v2.17.0 (before DAG simplification)")
@@ -1635,18 +1635,18 @@ public class TriggerableDagTest {
                 )
             )));
 
-        range(0, 5).forEach(n -> {
+        range(1, 6).forEach(n -> {
             scenario.next();
             scenario.createNewRepeat();
-            assertThat(scenario.answerOf("/data/sum"), CoreMatchers.is(intAnswer((n + 1) * 5)));
+            assertThat(scenario.answerOf("/data/sum"), CoreMatchers.is(intAnswer(n * 5)));
             scenario.next();
         });
 
-        range(0, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-sum"), CoreMatchers.is(intAnswer(25))));
+        range(1, 6).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-sum"), CoreMatchers.is(intAnswer(25))));
 
-        scenario.removeRepeat("/data/repeat[3]");
+        scenario.removeRepeat("/data/repeat[4]");
 
-        range(0, 4).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-sum"), CoreMatchers.is(intAnswer(20))));
+        range(1, 5).forEach(n -> assertThat(scenario.answerOf("/data/repeat[" + n + "]/inner-sum"), CoreMatchers.is(intAnswer(20))));
     }
 
     @Ignore("Fails on v2.17.0 (before DAG simplification)")
@@ -1677,20 +1677,20 @@ public class TriggerableDagTest {
         scenario.next();
         scenario.answer(11);
 
-        assertThat(scenario.answerOf("/data/group[0]/next-number"), is(nullValue()));
-        assertThat(scenario.answerOf("/data/group[0]/number"), is(intAnswer(11)));
+        assertThat(scenario.answerOf("/data/group[1]/next-number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/group[1]/number"), is(intAnswer(11)));
 
         scenario.next();
         scenario.createNewRepeat();
         scenario.next();
         scenario.answer(22);
 
-        assertThat(scenario.answerOf("/data/group[0]/number"), is(intAnswer(11)));
-        assertThat(scenario.answerOf("/data/group[1]/number"), is(intAnswer(22)));
+        assertThat(scenario.answerOf("/data/group[1]/number"), is(intAnswer(11)));
+        assertThat(scenario.answerOf("/data/group[2]/number"), is(intAnswer(22)));
 
         // This assertion is false because setting the answer to 22 didn't trigger recomputation across repeat instances
-        assertThat(scenario.answerOf("/data/group[0]/next-number"), is(intAnswer(22)));
-        assertThat(scenario.answerOf("/data/group[1]/next-number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/group[1]/next-number"), is(intAnswer(22)));
+        assertThat(scenario.answerOf("/data/group[2]/next-number"), is(nullValue()));
 
         scenario.next();
         scenario.createNewRepeat();
@@ -1698,10 +1698,10 @@ public class TriggerableDagTest {
         scenario.answer(33);
 
         // This assertion is true because adding a new repeat triggered recomputation across repeat instances
-        assertThat(scenario.answerOf("/data/group[0]/next-number"), is(intAnswer(22)));
+        assertThat(scenario.answerOf("/data/group[1]/next-number"), is(intAnswer(22)));
         // This assertion is false because setting the answer to 33 didn't trigger recomputation across repeat instances
-        assertThat(scenario.answerOf("/data/group[1]/next-number"), is(intAnswer(33)));
-        assertThat(scenario.answerOf("/data/group[2]/next-number"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/group[2]/next-number"), is(intAnswer(33)));
+        assertThat(scenario.answerOf("/data/group[3]/next-number"), is(nullValue()));
     }
 
     @Ignore("Fails on v2.17.0 (before DAG simplification)")
@@ -1823,8 +1823,8 @@ public class TriggerableDagTest {
         scenario.next();
         scenario.answer("Some field 1-1");
         scenario.next();
-        assertThat(scenario.countRepeatInstancesOf("/data/outer[0]/inner"), is(3));
-        assertThat(scenario.countRepeatInstancesOf("/data/outer[1]/inner"), is(2));
+        assertThat(scenario.countRepeatInstancesOf("/data/outer[1]/inner"), is(3));
+        assertThat(scenario.countRepeatInstancesOf("/data/outer[2]/inner"), is(2));
     }
 
     @Test
@@ -1854,18 +1854,18 @@ public class TriggerableDagTest {
                 ))
             )));
         scenario.createNewRepeat("/data/outer");
-        scenario.createNewRepeat("/data/outer[0]/inner");
-        scenario.createNewRepeat("/data/outer[0]/inner");
-        scenario.createNewRepeat("/data/outer[0]/inner");
+        scenario.createNewRepeat("/data/outer[1]/inner");
+        scenario.createNewRepeat("/data/outer[1]/inner");
+        scenario.createNewRepeat("/data/outer[1]/inner");
         scenario.createNewRepeat("/data/outer");
-        scenario.createNewRepeat("/data/outer[1]/inner");
-        scenario.createNewRepeat("/data/outer[1]/inner");
+        scenario.createNewRepeat("/data/outer[2]/inner");
+        scenario.createNewRepeat("/data/outer[2]/inner");
 
-        assertThat(scenario.answerOf("/data/outer[0]/inner[0]/count"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/outer[0]/inner[1]/count"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/outer[0]/inner[2]/count"), is(intAnswer(3)));
-        assertThat(scenario.answerOf("/data/outer[1]/inner[0]/count"), is(intAnswer(2)));
-        assertThat(scenario.answerOf("/data/outer[1]/inner[1]/count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[1]/count"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[2]/count"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/outer[1]/inner[3]/count"), is(intAnswer(3)));
+        assertThat(scenario.answerOf("/data/outer[2]/inner[1]/count"), is(intAnswer(2)));
+        assertThat(scenario.answerOf("/data/outer[2]/inner[2]/count"), is(intAnswer(2)));
     }
 
     @Test

--- a/src/test/java/org/javarosa/core/model/actions/InstanceLoadEventsTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/InstanceLoadEventsTest.java
@@ -111,10 +111,10 @@ public class InstanceLoadEventsTest {
             )
         ));
 
-        assertThat(scenario.answerOf("/data/repeat[0]/q1"), CoreMatchers.is(stringAnswer("16")));
+        assertThat(scenario.answerOf("/data/repeat[1]/q1"), CoreMatchers.is(stringAnswer("16")));
 
         scenario.createNewRepeat("/data/repeat");
-        assertThat(scenario.answerOf("/data/repeat[1]/q1"), CoreMatchers.is(nullValue()));
+        assertThat(scenario.answerOf("/data/repeat[2]/q1"), CoreMatchers.is(nullValue()));
     }
 
     @Test
@@ -138,10 +138,10 @@ public class InstanceLoadEventsTest {
             )
         ));
 
-        assertThat(scenario.answerOf("/data/repeat[0]/q1"), CoreMatchers.is(stringAnswer("16")));
         assertThat(scenario.answerOf("/data/repeat[1]/q1"), CoreMatchers.is(stringAnswer("16")));
+        assertThat(scenario.answerOf("/data/repeat[2]/q1"), CoreMatchers.is(stringAnswer("16")));
 
         scenario.createNewRepeat("/data/repeat");
-        assertThat(scenario.answerOf("/data/repeat[2]/q1"), CoreMatchers.is(nullValue()));
+        assertThat(scenario.answerOf("/data/repeat[3]/q1"), CoreMatchers.is(nullValue()));
     }
 }

--- a/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
@@ -42,12 +42,12 @@ public class OdkNewRepeatEventTest {
         Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
 
         scenario.createNewRepeat("/data/my-repeat");
-        assertThat(scenario.answerOf("/data/my-repeat[0]/defaults-to-position").getDisplayText(), is("1"));
+        assertThat(scenario.answerOf("/data/my-repeat[1]/defaults-to-position").getDisplayText(), is("1"));
 
         scenario.createNewRepeat("/data/my-repeat");
-        assertThat(scenario.answerOf("/data/my-repeat[1]/defaults-to-position").getDisplayText(), is("2"));
+        assertThat(scenario.answerOf("/data/my-repeat[2]/defaults-to-position").getDisplayText(), is("2"));
 
-        assertThat(scenario.answerOf("/data/my-repeat[0]/defaults-to-position").getDisplayText(), is("1"));
+        assertThat(scenario.answerOf("/data/my-repeat[1]/defaults-to-position").getDisplayText(), is("1"));
     }
 
     @Test
@@ -72,10 +72,10 @@ public class OdkNewRepeatEventTest {
 
         assertThat(scenario.countRepeatInstancesOf("/data/my-jr-count-repeat"), is(4));
 
-        assertThat(scenario.answerOf("/data/my-jr-count-repeat[0]/defaults-to-position-again").getDisplayText(), is("1"));
-        assertThat(scenario.answerOf("/data/my-jr-count-repeat[1]/defaults-to-position-again").getDisplayText(), is("2"));
-        assertThat(scenario.answerOf("/data/my-jr-count-repeat[2]/defaults-to-position-again").getDisplayText(), is("3"));
-        assertThat(scenario.answerOf("/data/my-jr-count-repeat[3]/defaults-to-position-again").getDisplayText(), is("4"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[1]/defaults-to-position-again").getDisplayText(), is("1"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[2]/defaults-to-position-again").getDisplayText(), is("2"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[3]/defaults-to-position-again").getDisplayText(), is("3"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[4]/defaults-to-position-again").getDisplayText(), is("4"));
 
         // Adding repeats should trigger odk-new-repeat for those new nodes
         scenario.answer("/data/repeat-count", 6);
@@ -85,7 +85,7 @@ public class OdkNewRepeatEventTest {
             scenario.next();
         }
         assertThat(scenario.countRepeatInstancesOf("/data/my-jr-count-repeat"), is(6));
-        assertThat(scenario.answerOf("/data/my-jr-count-repeat[5]/defaults-to-position-again").getDisplayText(), is("6"));
+        assertThat(scenario.answerOf("/data/my-jr-count-repeat[6]/defaults-to-position-again").getDisplayText(), is("6"));
 
     }
 
@@ -121,11 +121,11 @@ public class OdkNewRepeatEventTest {
     public void repeatInFormDefInstance_neverFiresNewRepeatEvent() throws XFormParser.ParseException {
         Scenario scenario = Scenario.init(r("event-odk-new-repeat.xml"));
 
-        assertThat(scenario.answerOf("/data/my-repeat-without-template[0]/my-value"), is(nullValue()));
         assertThat(scenario.answerOf("/data/my-repeat-without-template[1]/my-value"), is(nullValue()));
+        assertThat(scenario.answerOf("/data/my-repeat-without-template[2]/my-value"), is(nullValue()));
 
         scenario.createNewRepeat("/data/my-repeat-without-template");
-        assertThat(scenario.answerOf("/data/my-repeat-without-template[2]/my-value").getDisplayText(), is("2"));
+        assertThat(scenario.answerOf("/data/my-repeat-without-template[3]/my-value").getDisplayText(), is("2"));
     }
 
     @Test
@@ -160,11 +160,11 @@ public class OdkNewRepeatEventTest {
         scenario.createNewRepeat("/data/repeat2");
         scenario.createNewRepeat("/data/repeat2");
 
-        assertThat(scenario.answerOf("/data/repeat1[1]/q1").getDisplayText(), is("foobar"));
         assertThat(scenario.answerOf("/data/repeat1[2]/q1").getDisplayText(), is("foobar"));
+        assertThat(scenario.answerOf("/data/repeat1[3]/q1").getDisplayText(), is("foobar"));
 
-        assertThat(scenario.answerOf("/data/repeat2[1]/q1").getDisplayText(), is("barbaz"));
         assertThat(scenario.answerOf("/data/repeat2[2]/q1").getDisplayText(), is("barbaz"));
+        assertThat(scenario.answerOf("/data/repeat2[3]/q1").getDisplayText(), is("barbaz"));
     }
 
     @Test
@@ -199,9 +199,9 @@ public class OdkNewRepeatEventTest {
         scenario.next();
         scenario.createNewRepeat();
         scenario.next();
-        assertThat(scenario.answerOf("/data/repeat[0]/q"), is(intAnswer(7)));
-        assertThat(scenario.answerOf("/data/repeat[1]/q"), is(intAnswer(8)));
+        assertThat(scenario.answerOf("/data/repeat[1]/q"), is(intAnswer(7)));
         assertThat(scenario.answerOf("/data/repeat[2]/q"), is(intAnswer(8)));
+        assertThat(scenario.answerOf("/data/repeat[3]/q"), is(intAnswer(8)));
     }
 
     // Not part of ODK XForms so throws parse exception.

--- a/src/test/java/org/javarosa/core/model/actions/RecordAudioActionTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/RecordAudioActionTest.java
@@ -103,7 +103,7 @@ public class RecordAudioActionTest {
             )
         ));
 
-        assertThat(listener.getAbsoluteTargetRef(), is(getRef("/data/repeat[0]/recording")));
+        assertThat(listener.getAbsoluteTargetRef(), is(getRef("/data/repeat[1]/recording")));
     }
 
     @Test

--- a/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
@@ -215,17 +215,17 @@ public class SetValueActionTest {
 
         final int REPEAT_COUNT = 5;
 
-        for (int i = 0; i < REPEAT_COUNT; i++) {
+        for (int i = 1; i <= REPEAT_COUNT; i++) {
             scenario.createNewRepeat("/data/repeat");
             assertThat(scenario.answerOf("/data/repeat[" + i + "]/destination"), is(nullValue()));
         }
 
-        for (int i = 0; i < REPEAT_COUNT; i++) {
+        for (int i = 1; i <= REPEAT_COUNT; i++) {
             scenario.answer("/data/repeat[" + i + "]/source", 7);
         }
 
-        for (int i = 0; i < REPEAT_COUNT; i++) {
-            assertThat(scenario.answerOf("/data/repeat[" + i + "]/destination"), is(intAnswer(4 * (i + 1))));
+        for (int i = 1; i <= REPEAT_COUNT; i++) {
+            assertThat(scenario.answerOf("/data/repeat[" + i + "]/destination"), is(intAnswer(4 * i)));
         }
     }
 
@@ -255,7 +255,7 @@ public class SetValueActionTest {
         scenario.createNewRepeat("/data/repeat");
 
         scenario.answer("/data/source", "foo");
-        assertThat(scenario.answerOf("/data/repeat[0]/destination").getDisplayText(), is("foo"));
+        assertThat(scenario.answerOf("/data/repeat[1]/destination").getDisplayText(), is("foo"));
     }
 
     @Ignore("TODO: verifyActions seems like it may be overzealous")
@@ -285,7 +285,7 @@ public class SetValueActionTest {
         scenario.createNewRepeat("/data/repeat");
 
         scenario.answer("/data/source", "foo");
-        assertThat(scenario.answerOf("/data/repeat[1]/destination").getDisplayText(), is("foo"));
+        assertThat(scenario.answerOf("/data/repeat[2]/destination").getDisplayText(), is("foo"));
     }
 
     @Test
@@ -345,14 +345,14 @@ public class SetValueActionTest {
 
         final int REPEAT_COUNT = 5;
 
-        for (int i = 0; i < REPEAT_COUNT; i++) {
+        for (int i = 1; i <= REPEAT_COUNT; i++) {
             scenario.createNewRepeat("/data/repeat");
             assertThat(scenario.answerOf("/data/destination"), is(intAnswer(0)));
         }
 
-        for (int i = 0; i < REPEAT_COUNT; i++) {
+        for (int i = 1; i <= REPEAT_COUNT; i++) {
             scenario.answer("/data/repeat[" + i + "]/source", 7);
-            assertThat(scenario.answerOf("/data/destination"), is(intAnswer(i + 1)));
+            assertThat(scenario.answerOf("/data/destination"), is(intAnswer(i)));
         }
     }
 

--- a/src/test/java/org/javarosa/core/model/condition/EvaluationContextExpandReferenceTest.java
+++ b/src/test/java/org/javarosa/core/model/condition/EvaluationContextExpandReferenceTest.java
@@ -17,6 +17,7 @@
 package org.javarosa.core.model.condition;
 
 import static java.util.stream.IntStream.range;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
@@ -33,7 +34,6 @@ import static org.javarosa.core.util.XFormsElement.model;
 import static org.javarosa.core.util.XFormsElement.repeat;
 import static org.javarosa.core.util.XFormsElement.t;
 import static org.javarosa.core.util.XFormsElement.title;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import org.javarosa.core.model.instance.TreeReference;
@@ -74,23 +74,23 @@ public class EvaluationContextExpandReferenceTest {
         // Using the String representation to simplify things, since TreeReference.equals
         // wouldn't work the way we want, and TestHelpers.buildRef() has its limitations
         assertThat(ec.expandReference(getRef("/data/group/number")), hasItems(
-            getRef("/data/group[0]/number[0]"),
-            getRef("/data/group[1]/number[0]"),
-            getRef("/data/group[2]/number[0]"),
-            getRef("/data/group[3]/number[0]"),
-            getRef("/data/group[4]/number[0]")
+            getRef("/data/group[1]/number[1]"),
+            getRef("/data/group[2]/number[1]"),
+            getRef("/data/group[3]/number[1]"),
+            getRef("/data/group[4]/number[1]"),
+            getRef("/data/group[5]/number[1]")
         ));
     }
 
     @Test
     public void test_include_templates_case() {
         assertThat(ec.expandReference(getRef("/data/group/number"), true), contains(
-            getRef("/data/group[0]/number[0]"),
-            getRef("/data/group[1]/number[0]"),
-            getRef("/data/group[2]/number[0]"),
-            getRef("/data/group[3]/number[0]"),
-            getRef("/data/group[4]/number[0]"),
-            getRef("/data/group[@template]/number[0]")
+            getRef("/data/group[1]/number[1]"),
+            getRef("/data/group[2]/number[1]"),
+            getRef("/data/group[3]/number[1]"),
+            getRef("/data/group[4]/number[1]"),
+            getRef("/data/group[5]/number[1]"),
+            getRef("/data/group[@template]/number[1]")
         ));
     }
 
@@ -101,25 +101,25 @@ public class EvaluationContextExpandReferenceTest {
 
     @Test
     public void returns_itself_if_fully_qualified() {
-        TreeReference numberRef = getRef("/data/group[3]/number[0]");
+        TreeReference numberRef = getRef("/data/group[4]/number[1]");
         assertThat(ec.expandReference(numberRef), contains(numberRef));
 
-        TreeReference groupRef = getRef("/data/group[3]");
+        TreeReference groupRef = getRef("/data/group[4]");
         assertThat(ec.expandReference(groupRef), contains(groupRef));
     }
 
     @Test
     public void expands_partially_qualified_refs() {
         assertThat(
-            ec.expandReference(getRef("/data/group[3]/number")),
-            contains(getRef("/data/group[3]/number[0]"))
+            ec.expandReference(getRef("/data/group[4]/number")),
+            contains(getRef("/data/group[4]/number[1]"))
         );
         assertThat(ec.expandReference(getRef("/data/group")), contains(
-            getRef("/data/group[0]"),
             getRef("/data/group[1]"),
             getRef("/data/group[2]"),
             getRef("/data/group[3]"),
-            getRef("/data/group[4]")
+            getRef("/data/group[4]"),
+            getRef("/data/group[5]")
         ));
     }
 }

--- a/src/test/java/org/javarosa/core/model/instance/TreeReferenceGenericizeTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeReferenceGenericizeTest.java
@@ -27,7 +27,7 @@ public class TreeReferenceGenericizeTest {
     public void genericize_sets_all_steps_with_unbound_multiplicity() {
         assertThat(getRef("/foo/bar").genericize(), is(getRef("/foo/bar")));
 
-        TreeReference originalRef = getRef("/foo[2]/bar[3]");
+        TreeReference originalRef = getRef("/foo[3]/bar[4]");
         assertThat(originalRef.getMultiplicity(0), is(2));
         assertThat(originalRef.getMultiplicity(1), is(3));
 

--- a/src/test/java/org/javarosa/core/model/instance/TreeReferenceIsAncestorOfTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/TreeReferenceIsAncestorOfTest.java
@@ -16,9 +16,9 @@
 
 package org.javarosa.core.model.instance;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.Scenario.getRef;
-import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -76,49 +76,49 @@ public class TreeReferenceIsAncestorOfTest {
             // Multiplicity scenario: undefined ancestor is ancestor of any other multiplicity, regardless of level
             {"/foo is ancestor of /foo/bar", "/foo", "/foo/bar", IRRELEVANT, true},
             {"/foo is ancestor of /foo[-1]/bar", "/foo", "/foo[-1]/bar", IRRELEVANT, true},
-            {"/foo is ancestor of /foo[0]/bar", "/foo", "/foo[0]/bar", IRRELEVANT, true},
-            {"/foo is ancestor of /foo[2]/bar", "/foo", "/foo[2]/bar", IRRELEVANT, true},
+            {"/foo is ancestor of /foo[1]/bar", "/foo", "/foo[1]/bar", IRRELEVANT, true},
+            {"/foo is ancestor of /foo[3]/bar", "/foo", "/foo[3]/bar", IRRELEVANT, true},
             {"/foo/bar is ancestor of /foo/bar/baz", "/foo/bar", "/foo/bar/baz", IRRELEVANT, true},
             {"/foo/bar is ancestor of /foo/bar[-1]/baz", "/foo/bar", "/foo/bar[-1]/baz", IRRELEVANT, true},
-            {"/foo/bar is ancestor of /foo/bar[0]/baz", "/foo/bar", "/foo/bar[0]/baz", IRRELEVANT, true},
-            {"/foo/bar is ancestor of /foo/bar[2]/baz", "/foo/bar", "/foo/bar[2]/baz", IRRELEVANT, true},
+            {"/foo/bar is ancestor of /foo/bar[1]/baz", "/foo/bar", "/foo/bar[1]/baz", IRRELEVANT, true},
+            {"/foo/bar is ancestor of /foo/bar[3]/baz", "/foo/bar", "/foo/bar[3]/baz", IRRELEVANT, true},
 
             // Multiplicity scenario: [-1] ancestor is ancestor of any other multiplity, regardless of level
             {"/foo[-1] is ancestor of /foo/bar", "/foo[-1]", "/foo/bar", IRRELEVANT, true},
             {"/foo[-1] is ancestor of /foo[-1]/bar", "/foo[-1]", "/foo[-1]/bar", IRRELEVANT, true},
-            {"/foo[-1] is ancestor of /foo[0]/bar", "/foo[-1]", "/foo[0]/bar", IRRELEVANT, true},
-            {"/foo[-1] is ancestor of /foo[2]/bar", "/foo[-1]", "/foo[2]/bar", IRRELEVANT, true},
+            {"/foo[-1] is ancestor of /foo[1]/bar", "/foo[-1]", "/foo[1]/bar", IRRELEVANT, true},
+            {"/foo[-1] is ancestor of /foo[3]/bar", "/foo[-1]", "/foo[3]/bar", IRRELEVANT, true},
             {"/foo/bar[-1] is ancestor of /foo/bar/baz", "/foo/bar[-1]", "/foo/bar/baz", IRRELEVANT, true},
             {"/foo/bar[-1] is ancestor of /foo/bar[-1]/baz", "/foo/bar[-1]", "/foo/bar[-1]/bzr", IRRELEVANT, true},
-            {"/foo/bar[-1] is ancestor of /foo/bar[0]/baz", "/foo/bar[-1]", "/foo/bar[0]/bzr", IRRELEVANT, true},
-            {"/foo/bar[-1] is ancestor of /foo/bar[2]/baz", "/foo/bar[-1]", "/foo/bar[2]/bzr", IRRELEVANT, true},
+            {"/foo/bar[-1] is ancestor of /foo/bar[1]/baz", "/foo/bar[-1]", "/foo/bar[1]/bzr", IRRELEVANT, true},
+            {"/foo/bar[-1] is ancestor of /foo/bar[3]/baz", "/foo/bar[-1]", "/foo/bar[3]/bzr", IRRELEVANT, true},
 
             // Multiplicity scenario: [0] ancestor is ancestor of other special multiplicities only at first level
-            {"/foo[0] is ancestor of /foo/bar", "/foo[0]", "/foo/bar", IRRELEVANT, true},
-            {"/foo[0] is ancestor of /foo[-1]/bar", "/foo[0]", "/foo[-1]/bar", IRRELEVANT, true},
-            {"/foo[0] is ancestor of /foo[0]/bar", "/foo[0]", "/foo[0]/bar", IRRELEVANT, true},
-            {"/foo[0] is not ancestor of /foo[2]/bar", "/foo[0]", "/foo[2]/bar", IRRELEVANT, false},
-            {"/foo/bar[0] is not ancestor of /foo/bar/baz", "/foo/bar[0]", "/foo/bar/baz", IRRELEVANT, false},
-            {"/foo/bar[0] is not ancestor of /foo/bar[-1]/baz", "/foo/bar[0]", "/foo/bar[-1]/baz", IRRELEVANT, false},
-            {"/foo/bar[0] is ancestor of /foo/bar[0]/baz", "/foo/bar[0]", "/foo/bar[0]/baz", IRRELEVANT, true},
-            {"/foo/bar[0] is not ancestor of /foo/bar[2]/baz", "/foo/bar[0]", "/foo/bar[2]/baz", IRRELEVANT, false},
+            {"/foo[0] is ancestor of /foo/bar", "/foo[1]", "/foo/bar", IRRELEVANT, true},
+            {"/foo[0] is ancestor of /foo[-1]/bar", "/foo[1]", "/foo[-1]/bar", IRRELEVANT, true},
+            {"/foo[0] is ancestor of /foo[1]/bar", "/foo[1]", "/foo[1]/bar", IRRELEVANT, true},
+            {"/foo[0] is not ancestor of /foo[3]/bar", "/foo[1]", "/foo[3]/bar", IRRELEVANT, false},
+            {"/foo/bar[0] is not ancestor of /foo/bar/baz", "/foo/bar[1]", "/foo/bar/baz", IRRELEVANT, false},
+            {"/foo/bar[0] is not ancestor of /foo/bar[-1]/baz", "/foo/bar[1]", "/foo/bar[-1]/baz", IRRELEVANT, false},
+            {"/foo/bar[0] is ancestor of /foo/bar[1]/baz", "/foo/bar[1]", "/foo/bar[1]/baz", IRRELEVANT, true},
+            {"/foo/bar[0] is not ancestor of /foo/bar[3]/baz", "/foo/bar[1]", "/foo/bar[3]/baz", IRRELEVANT, false},
 
             // Multiplicity scenario: [2] ancestor is not ancestor of special multiplicities, regardless of level
-            {"/foo[2] is ancestor of /foo/bar", "/foo[2]", "/foo[0]/bar", IRRELEVANT, false},
-            {"/foo[2] is ancestor of /foo[-1]/bar", "/foo[2]", "/foo[-1]/bar", IRRELEVANT, false},
-            {"/foo[2] is ancestor of /foo[0]/bar", "/foo[2]", "/foo[0]/bar", IRRELEVANT, false},
-            {"/foo[2] is ancestor of /foo[2]/bar", "/foo[2]", "/foo[2]/bar", IRRELEVANT, true},
-            {"/foo/bar[2] is ancestor of /foo/bar/baz", "/foo/bar[2]", "/foo/bar[0]/baz", IRRELEVANT, false},
-            {"/foo/bar[2] is ancestor of /foo/bar[-1]/baz", "/foo/bar[2]", "/foo/bar[-1]/baz", IRRELEVANT, false},
-            {"/foo/bar[2] is ancestor of /foo/bar[0]/baz", "/foo/bar[2]", "/foo/bar[0]/baz", IRRELEVANT, false},
-            {"/foo/bar[2] is ancestor of /foo/bar[2]/baz", "/foo/bar[2]", "/foo/bar[2]/baz", IRRELEVANT, true},
+            {"/foo[2] is ancestor of /foo/bar", "/foo[3]", "/foo[1]/bar", IRRELEVANT, false},
+            {"/foo[2] is ancestor of /foo[-1]/bar", "/foo[3]", "/foo[-1]/bar", IRRELEVANT, false},
+            {"/foo[2] is ancestor of /foo[1]/bar", "/foo[3]", "/foo[1]/bar", IRRELEVANT, false},
+            {"/foo[2] is ancestor of /foo[3]/bar", "/foo[3]", "/foo[3]/bar", IRRELEVANT, true},
+            {"/foo/bar[2] is ancestor of /foo/bar/baz", "/foo/bar[3]", "/foo/bar[1]/baz", IRRELEVANT, false},
+            {"/foo/bar[2] is ancestor of /foo/bar[-1]/baz", "/foo/bar[3]", "/foo/bar[-1]/baz", IRRELEVANT, false},
+            {"/foo/bar[2] is ancestor of /foo/bar[1]/baz", "/foo/bar[3]", "/foo/bar[1]/baz", IRRELEVANT, false},
+            {"/foo/bar[2] is ancestor of /foo/bar[3]/baz", "/foo/bar[3]", "/foo/bar[3]/baz", IRRELEVANT, true},
 
             // Multiplicity scenario: Mixed bag of other interesting examples
-            {"/foo[-1]/bar[2] is ancestor of /foo/bar[2]/baz", "/foo[-1]/bar[2]", "/foo/bar[2]/baz", IRRELEVANT, true},
-            {"/foo[-1]/bar[2] is ancestor of /foo[-1]/bar[2]/baz", "/foo[-1]/bar[2]", "/foo[-1]/bar[2]/baz", IRRELEVANT, true},
-            {"/foo[-1]/bar[2] is ancestor of /foo[0]/bar[2]/baz", "/foo[-1]/bar[2]", "/foo[0]/bar[2]/baz", IRRELEVANT, true},
-            {"/foo[-1]/bar[2] is ancestor of /foo[2]/bar[2]/baz", "/foo[-1]/bar[2]", "/foo[2]/bar[2]/baz", IRRELEVANT, true},
-            {"/foo[2]/bar[2] is ancestor of /foo[3]/bar[2]/baz", "/foo[2]/bar[2]", "/foo[3]/bar[2]/baz", IRRELEVANT, false},
+            {"/foo[-1]/bar[2] is ancestor of /foo/bar[3]/baz", "/foo[-1]/bar[3]", "/foo/bar[3]/baz", IRRELEVANT, true},
+            {"/foo[-1]/bar[2] is ancestor of /foo[-1]/bar[3]/baz", "/foo[-1]/bar[3]", "/foo[-1]/bar[3]/baz", IRRELEVANT, true},
+            {"/foo[-1]/bar[2] is ancestor of /foo[1]/bar[3]/baz", "/foo[-1]/bar[3]", "/foo[1]/bar[3]/baz", IRRELEVANT, true},
+            {"/foo[-1]/bar[2] is ancestor of /foo[3]/bar[3]/baz", "/foo[-1]/bar[3]", "/foo[3]/bar[3]/baz", IRRELEVANT, true},
+            {"/foo[2]/bar[2] is ancestor of /foo[4]/bar[3]/baz", "/foo[3]/bar[3]", "/foo[4]/bar[3]/baz", IRRELEVANT, false},
         });
     }
 

--- a/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -16,6 +16,7 @@
 
 package org.javarosa.core.model.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
 import static org.javarosa.core.test.Scenario.AnswerResult.CONSTRAINT_VIOLATED;
@@ -35,13 +36,10 @@ import static org.javarosa.core.util.XFormsElement.select1;
 import static org.javarosa.core.util.XFormsElement.t;
 import static org.javarosa.core.util.XFormsElement.title;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
@@ -126,10 +124,10 @@ public class FormDefTest {
             )));
         FormDef formDef = scenario.getFormDef();
 
-        assertThat(formDef.isRepeatRelevant(getRef("/data/repeat1[0]")), is(false));
+        assertThat(formDef.isRepeatRelevant(getRef("/data/repeat1[1]")), is(false));
 
         scenario.answer("/data/selectYesNo", "yes");
-        assertThat(formDef.isRepeatRelevant(getRef("/data/repeat1[0]")), is(true));
+        assertThat(formDef.isRepeatRelevant(getRef("/data/repeat1[1]")), is(true));
     }
 
     @Test
@@ -251,27 +249,27 @@ public class FormDefTest {
 
         scenario.next();
 
-        // For ref /data/outer[0]/inner[0], the parent position is 1 so the boolean expression is false. That means
-        // none of the inner groups in /data/outer[0] can be relevant.
-        assertThat(scenario.refAtIndex(), is(getRef("/data/outer[0]")));
-
-        scenario.next();
+        // For ref /data/outer[1]/inner[1], the parent position is 1 so the boolean expression is false. That means
+        // none of the inner groups in /data/outer[1] can be relevant.
         assertThat(scenario.refAtIndex(), is(getRef("/data/outer[1]")));
 
         scenario.next();
-        assertThat(scenario.refAtIndex(), is(getRef("/data/outer[1]/inner[0]")));
+        assertThat(scenario.refAtIndex(), is(getRef("/data/outer[2]")));
 
         scenario.next();
-        assertThat(scenario.refAtIndex(), is(getRef("/data/outer[1]/inner[0]/q1[0]")));
+        assertThat(scenario.refAtIndex(), is(getRef("/data/outer[2]/inner[1]")));
+
+        scenario.next();
+        assertThat(scenario.refAtIndex(), is(getRef("/data/outer[2]/inner[1]/q1[1]")));
 
         scenario.answer("/data/relevance-condition", "1");
 
         scenario.jumpToBeginningOfForm();
         scenario.next();
-        assertThat(scenario.refAtIndex(), is(getRef("/data/outer[0]")));
+        assertThat(scenario.refAtIndex(), is(getRef("/data/outer[1]")));
 
         scenario.next();
-        assertThat(scenario.refAtIndex(), is(getRef("/data/outer[0]/inner[0]")));
+        assertThat(scenario.refAtIndex(), is(getRef("/data/outer[1]/inner[1]")));
     }
 
     @Test
@@ -298,8 +296,8 @@ public class FormDefTest {
 
 
         FormDef formDef = scenario.getFormDef();
-        // outer[1] does not exist at this moment, we only have outer[0]. Checking if its inner repeat group is relevant should be possible and return false.
-        assertThat(formDef.isRepeatRelevant(getRef("/data/outer[1]/inner[0]")), is(false));
+        // outer[2] does not exist at this moment, we only have outer[1]. Checking if its inner repeat group is relevant should be possible and return false.
+        assertThat(formDef.isRepeatRelevant(getRef("/data/outer[2]/inner[1]")), is(false));
     }
     //endregion
 
@@ -366,14 +364,14 @@ public class FormDefTest {
         scenario.next();
 
         FormEntryCaption caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
-        MatcherAssert.assertThat(caption.getQuestionText(), is("Position: 1"));
+        assertThat(caption.getQuestionText(), is("Position: 1"));
 
         scenario.next();
         scenario.createNewRepeat();
         scenario.next();
 
         caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
-        MatcherAssert.assertThat(caption.getQuestionText(), is("Position: 2"));
+        assertThat(caption.getQuestionText(), is("Position: 2"));
     }
 
     @Test
@@ -406,14 +404,14 @@ public class FormDefTest {
         scenario.next();
 
         FormEntryCaption caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
-        MatcherAssert.assertThat(caption.getQuestionText(), is("Position: 1"));
+        assertThat(caption.getQuestionText(), is("Position: 1"));
 
         scenario.next();
         scenario.createNewRepeat();
         scenario.next();
 
         caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
-        MatcherAssert.assertThat(caption.getQuestionText(), is("Position: 2"));
+        assertThat(caption.getQuestionText(), is("Position: 2"));
     }
 
     @Test

--- a/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseDateTimeTests.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/DateUtilsParseDateTimeTests.java
@@ -17,9 +17,9 @@
 package org.javarosa.core.model.utils.test;
 
 import static java.util.TimeZone.getTimeZone;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.test.utils.SystemHelper.withTimeZone;
-import static org.junit.Assert.assertThat;
 
 import java.time.Instant;
 import java.time.LocalDateTime;

--- a/src/test/java/org/javarosa/core/test/Scenario.java
+++ b/src/test/java/org/javarosa/core/test/Scenario.java
@@ -16,6 +16,41 @@
 
 package org.javarosa.core.test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createTempDirectory;
+import static java.nio.file.Files.createTempFile;
+import static java.nio.file.Files.delete;
+import static java.nio.file.Files.newInputStream;
+import static java.nio.file.Files.newOutputStream;
+import static java.nio.file.Files.write;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.util.stream.Collectors.joining;
+import static org.javarosa.core.model.instance.TreeReference.INDEX_TEMPLATE;
+import static org.javarosa.form.api.FormEntryController.EVENT_BEGINNING_OF_FORM;
+import static org.javarosa.form.api.FormEntryController.EVENT_END_OF_FORM;
+import static org.javarosa.form.api.FormEntryController.EVENT_GROUP;
+import static org.javarosa.form.api.FormEntryController.EVENT_PROMPT_NEW_REPEAT;
+import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
+import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
+import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT_JUNCTURE;
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.javarosa.xpath.expr.XPathPathExpr.INIT_CONTEXT_RELATIVE;
+import static org.javarosa.xpath.expr.XPathStep.AXIS_ATTRIBUTE;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.javarosa.core.model.CoreModelModule;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
@@ -60,42 +95,6 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.file.Path;
-import java.sql.Date;
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.Files.createTempDirectory;
-import static java.nio.file.Files.createTempFile;
-import static java.nio.file.Files.delete;
-import static java.nio.file.Files.newInputStream;
-import static java.nio.file.Files.newOutputStream;
-import static java.nio.file.Files.write;
-import static java.nio.file.StandardOpenOption.CREATE;
-import static java.util.stream.Collectors.joining;
-import static org.javarosa.core.model.instance.TreeReference.INDEX_TEMPLATE;
-import static org.javarosa.form.api.FormEntryController.EVENT_BEGINNING_OF_FORM;
-import static org.javarosa.form.api.FormEntryController.EVENT_END_OF_FORM;
-import static org.javarosa.form.api.FormEntryController.EVENT_GROUP;
-import static org.javarosa.form.api.FormEntryController.EVENT_PROMPT_NEW_REPEAT;
-import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
-import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
-import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT_JUNCTURE;
-import static org.javarosa.test.utils.ResourcePathHelper.r;
-import static org.javarosa.xpath.expr.XPathPathExpr.INIT_CONTEXT_RELATIVE;
-import static org.javarosa.xpath.expr.XPathStep.AXIS_ATTRIBUTE;
 
 /**
  * <div style="border: 1px 1px 1px 1px; background-color: #556B2F; color: white; padding: 20px">
@@ -193,18 +192,21 @@ public class Scenario {
      * For this reason, this method will try to detect these predicates,
      * turn them into multiplicity values, and remove them from the output
      * reference.
+     * <p>
+     * These multiplicities use 1-based indexing to match user-facing XPath expressions. To match JR's internal
+     * representation, 1 is subtracted.
      *
      * When using the result of this method for test assertions against {@link FormIndex#getReference()} we need to
      * specify multiplicity on all steps. For example the following would pass for a form index pointing at a
      * question at the top level of the form:
      *
      * <code>
-     * assertThat(formIndex.getReference(), is(getRef("/data/question[0]")));
+     * assertThat(formIndex.getReference(), is(getRef("/data/question[1]")));
      * </code>
      *
      * This is because <code>getRef</code> has no way of knowing if a node without multiplicity (<code>[x]</code>) is
      * a question/group or an unbounded repeat (which would have a multiplicity of <code>-1</code>). Adding the
-     * explicit <code>[0]</code> lets <code>getRef</code> know that the node is not an unbounded repeat and that it,
+     * explicit <code>[1]</code> lets <code>getRef</code> know that the node is not an unbounded repeat and that it,
      * like a real question or group, should have the default multiplicity of <code>0</code>.
      */
     public static TreeReference getRef(String xpath) {
@@ -364,7 +366,7 @@ public class Scenario {
 
         if (isPositiveNumberPredicate(predicates))
             return Optional.ofNullable(predicates.get(0))
-                .map(p -> ((XPathNumericLiteral) p).d)
+                .map(p -> ((XPathNumericLiteral) p).d - 1)
                 .map(Double::intValue);
 
         if (isNegativeNumberPredicate(predicates))

--- a/src/test/java/org/javarosa/form/api/FormEntryControllerTest.java
+++ b/src/test/java/org/javarosa/form/api/FormEntryControllerTest.java
@@ -1,8 +1,5 @@
 package org.javarosa.form.api;
 
-import org.javarosa.core.test.Scenario;
-import org.junit.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.Scenario.getRef;
@@ -20,6 +17,9 @@ import static org.javarosa.core.util.XFormsElement.title;
 import static org.javarosa.form.api.FormEntryController.EVENT_GROUP;
 import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
 import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
+
+import org.javarosa.core.test.Scenario;
+import org.junit.Test;
 
 public class FormEntryControllerTest {
 
@@ -55,10 +55,10 @@ public class FormEntryControllerTest {
 
         assertThat(controller.stepToNextEvent(), is(EVENT_REPEAT));
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
-        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[0]/question1[0]")));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[1]/question1[1]")));
 
         controller.jumpToNewRepeatPrompt();
-        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[1]")));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[2]")));
     }
 
     @Test
@@ -102,10 +102,10 @@ public class FormEntryControllerTest {
 
         assertThat(controller.stepToNextEvent(), is(EVENT_REPEAT));
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
-        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[0]/question1[0]")));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[1]/question1[1]")));
 
         controller.jumpToNewRepeatPrompt();
-        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[1]")));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[2]")));
     }
 
     @Test
@@ -152,10 +152,10 @@ public class FormEntryControllerTest {
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
         assertThat(controller.stepToNextEvent(), is(EVENT_REPEAT));
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
-        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[0]/repeat2[0]/question3[0]")));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[1]/repeat2[1]/question3[1]")));
 
         controller.jumpToNewRepeatPrompt();
-        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[0]/repeat2[1]")));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat1[1]/repeat2[2]")));
     }
 
     @Test
@@ -195,10 +195,10 @@ public class FormEntryControllerTest {
         assertThat(controller.stepToNextEvent(), is(EVENT_REPEAT));
         assertThat(controller.stepToNextEvent(), is(EVENT_GROUP));
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
-        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[0]/group[0]/question1[0]")));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[1]/group[1]/question1[1]")));
 
         controller.jumpToNewRepeatPrompt();
-        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[1]")));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/repeat[2]")));
     }
 
     @Test
@@ -225,9 +225,9 @@ public class FormEntryControllerTest {
 
         FormEntryController controller = new FormEntryController(new FormEntryModel(scenario.getFormDef()));
         assertThat(controller.stepToNextEvent(), is(EVENT_QUESTION));
-        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/question1[0]")));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/question1[1]")));
 
         controller.jumpToNewRepeatPrompt();
-        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/question1[0]")));
+        assertThat(controller.getModel().getFormIndex().getReference(), is(getRef("/data/question1[1]")));
     }
 }

--- a/src/test/java/org/javarosa/regression/IndexedRepeatRelativeRefsTest.java
+++ b/src/test/java/org/javarosa/regression/IndexedRepeatRelativeRefsTest.java
@@ -104,9 +104,9 @@ public class IndexedRepeatRelativeRefsTest {
             )
         ));
 
-        scenario.answer("/data/some-group[0]/item[0]/value", 11);
-        scenario.answer("/data/some-group[0]/item[1]/value", 22);
-        scenario.answer("/data/some-group[0]/item[2]/value", 33);
+        scenario.answer("/data/some-group[1]/item[1]/value", 11);
+        scenario.answer("/data/some-group[1]/item[2]/value", 22);
+        scenario.answer("/data/some-group[1]/item[3]/value", 33);
 
         assertThat(scenario.answerOf("/data/total-items"), is(intAnswer(3)));
         assertThat(scenario.answerOf("/data/some-group/last-value"), is(intAnswer(33)));

--- a/src/test/java/org/javarosa/smoketests/ChildVaccinationTest.java
+++ b/src/test/java/org/javarosa/smoketests/ChildVaccinationTest.java
@@ -18,6 +18,7 @@ package org.javarosa.smoketests;
 
 
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.Scenario.getRef;
@@ -29,7 +30,6 @@ import static org.javarosa.smoketests.ChildVaccinationTest.Vaccines.DIPHTERIA_FI
 import static org.javarosa.smoketests.ChildVaccinationTest.Vaccines.DIPHTERIA_FIRST_AND_MEASLES;
 import static org.javarosa.smoketests.ChildVaccinationTest.Vaccines.MEASLES;
 import static org.javarosa.smoketests.ChildVaccinationTest.Vaccines.NONE;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.time.LocalDate;

--- a/src/test/java/org/javarosa/xpath/expr/CurrentFieldRefTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/CurrentFieldRefTest.java
@@ -15,9 +15,9 @@
  */
 package org.javarosa.xpath.expr;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
-import static org.junit.Assert.assertThat;
 
 import org.javarosa.core.test.Scenario;
 import org.javarosa.xform.parse.XFormParser;
@@ -34,17 +34,17 @@ public class CurrentFieldRefTest {
 
     @Test
     public void current_in_a_field_ref_should_be_the_same_as_a_relative_ref() {
-        // The ref on /data/my_group[0]/name uses current()/name instead of an absolute path
-        scenario.answer("/data/my_group[0]/name", "Bob");
-        scenario.answer("/data/my_group[1]/name", "Janet");
+        // The ref on /data/my_group[1]/name uses current()/name instead of an absolute path
+        scenario.answer("/data/my_group[1]/name", "Bob");
+        scenario.answer("/data/my_group[2]/name", "Janet");
 
         assertThat(
-            scenario.answerOf("/data/my_group[0]/name"),
+            scenario.answerOf("/data/my_group[1]/name"),
             is(stringAnswer("Bob"))
         );
 
         assertThat(
-            scenario.answerOf("/data/my_group[1]/name"),
+            scenario.answerOf("/data/my_group[2]/name"),
             is(stringAnswer("Janet"))
         );
     }

--- a/src/test/java/org/javarosa/xpath/expr/CurrentGroupCountRefTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/CurrentGroupCountRefTest.java
@@ -15,9 +15,9 @@
  */
 package org.javarosa.xpath.expr;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
-import static org.junit.Assert.assertThat;
 
 import org.javarosa.core.test.Scenario;
 import org.javarosa.xform.parse.XFormParser;
@@ -47,9 +47,9 @@ public class CurrentGroupCountRefTest {
         scenario.answer("Kim");
         scenario.next();
 
-        assertThat(scenario.answerOf("/data/my_group[0]/name"), is(stringAnswer("Janet")));
-        assertThat(scenario.answerOf("/data/my_group[1]/name"), is(stringAnswer("Bob")));
-        assertThat(scenario.answerOf("/data/my_group[2]/name"), is(stringAnswer("Kim")));
+        assertThat(scenario.answerOf("/data/my_group[1]/name"), is(stringAnswer("Janet")));
+        assertThat(scenario.answerOf("/data/my_group[2]/name"), is(stringAnswer("Bob")));
+        assertThat(scenario.answerOf("/data/my_group[3]/name"), is(stringAnswer("Kim")));
         assertThat(scenario.atTheEndOfForm(), is(true));
         assertThat(scenario.countRepeatInstancesOf("/data/my_group"), is(3));
     }


### PR DESCRIPTION
Branched off https://github.com/getodk/javarosa/pull/750, opening as draft so we don't accidentally merge before the other but they should be reviewed together.

This is spiritually similar to #750: it changes tests to better align with the underlying specifications. This one makes path expressions used by `Scenario` match XPath path expressions which are 1-based. Prior to this PR, the path expressions used the implementation indexing which is 0-based.

The only substantive change is at https://github.com/getodk/javarosa/compare/master...lognaturel:javarosa:1based?expand=1#diff-fa4dad517d1a9e3ea5c8bc127f8d49875cf949b535fae121056c22e3c16e9553R369, the rest are adapting existing tests to match.

#### What has been done to verify that this works as intended?
I started by making the code change at https://github.com/getodk/javarosa/compare/master...lognaturel:javarosa:1based?expand=1#diff-fa4dad517d1a9e3ea5c8bc127f8d49875cf949b535fae121056c22e3c16e9553R369 Then I selected a test I knew should fail, ensured it failed, and adjusted it as I expected by adding 1 to each position predicate. I verified that passed. After that sanity check, I ran all tests and adjusted the ones that failed.

#### Why is this the best possible solution? Were any other approaches considered?
This leaves 0 indexes in a bit of a weird spot because they'll be interpreted as -1 which is unbound. That seems like a fine default to me but we could consider treating 0 differently. I like this solution because it's simple to understand.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No risk I can think of.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.