### PR TITLE
Trim values stored in choices

### DIFF
--- a/src/main/java/org/javarosa/core/model/SelectChoice.java
+++ b/src/main/java/org/javarosa/core/model/SelectChoice.java
@@ -95,7 +95,7 @@ public class SelectChoice implements Externalizable, Localizable {
             throw new XFormParseException("SelectChoice{id,innerText}:{" + labelID + "," + labelInnerText + "}, has null Value!");
         }
 
-        this.value = value;
+        this.value = value.trim();
         this.isLocalizable = isLocalizable;
         this.textID = labelID;
         this.labelInnerText = labelInnerText;

--- a/src/test/java/org/javarosa/core/model/SelectChoiceTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectChoiceTest.java
@@ -78,6 +78,13 @@ public class SelectChoiceTest {
     }
 
     @Test
+    public void value_should_be_trimmed_when_select_choice_object_constructed() {
+        SelectChoice choice = new SelectChoice(null, "Label", " value ", false);
+
+        assertThat(choice.getValue(), is("value"));
+    }
+
+    @Test
     public void getChild_returnsNamedChild_whenChoicesAreFromSecondaryInstance() throws XFormParser.ParseException {
         setUpSimpleReferenceManager(r("external-select-geojson.xml").getParent(), "file");
 


### PR DESCRIPTION
Closes #https://github.com/getodk/collect/issues/5692

#### What has been done to verify that this works as intended?
I've added a new test and tested the form attached to https://github.com/getodk/collect/issues/5692 manually.

#### Why is this the best possible solution? Were any other approaches considered?
There are multiple options when it comes to storing choices. They can be a part of a form file, they can be also stored in an external csv file using different mechanisms (the `search`/`pulldata` function, `select_one_from_file`/`select_one_external` question types). We don't want them to have values with redundant whitespace. The constructor is the common place used by all of the options so it seems to be the easiest way to make sure the values are trimmed no matter what option we use. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's rather a safe change so testing the form from https://github.com/getodk/collect/issues/5692 should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
There is a form attached to https://github.com/getodk/collect/issues/5692

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.
