### PR TITLE
Avoid using equality index for non-string values

### DIFF
--- a/src/main/java/org/javarosa/core/model/EqualityExpressionIndexFilterStrategy.java
+++ b/src/main/java/org/javarosa/core/model/EqualityExpressionIndexFilterStrategy.java
@@ -41,7 +41,12 @@ public class EqualityExpressionIndexFilterStrategy implements FilterStrategy {
                 buildIndexIfNeeded(sourceInstance, candidate, children, evaluationContext, section);
 
                 Object absoluteValue = candidate.evalContextSide(sourceInstance, evaluationContext);
-                return index.lookup(section, absoluteValue.toString());
+
+                if (absoluteValue instanceof String) {
+                    return index.lookup(section, (String) absoluteValue);
+                } else {
+                    return next.get();
+                }
             } else {
                 return next.get();
             }

--- a/src/test/java/org/javarosa/core/model/SelectCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectCachingTest.java
@@ -392,4 +392,32 @@ public class SelectCachingTest {
         assertThat(evaluations, equalTo(2));
     }
     //endregion
+
+    @Test
+    public void eqChoiceFiltersForIntsWork() throws Exception {
+        Scenario scenario = Scenario.init("Some form", html(
+            head(
+                title("Some form"),
+                model(
+                    mainInstance(t("data id=\"some-form\"",
+                        t("choice"),
+                        t("select")
+                    )),
+                    instance("instance",
+                        item("1", "One"),
+                        item("2", "Two")
+                    ),
+                    bind("/data/choice").type("int"),
+                    bind("/data/select").type("string")
+                )
+            ),
+            body(
+                input("/data/choice"),
+                select1Dynamic("/data/select", "instance('instance')/root/item[value=/data/choice]")
+            )
+        ));
+
+        scenario.answer("/data/choice", 1);
+        assertThat(scenario.choicesOf("/data/select").size(), equalTo(1));
+    }
 }


### PR DESCRIPTION
Fixes the problem described in [this forum post](https://forum.getodk.org/t/choice-filter-niveau-1-fails-with-collect-2024-1-1-but-niveau-1-is-ok/45580).

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

We could probably handle non-string values in our equality index, but we need to be really careful around how we carry out coercion to keep things consistent with `XPathEqExpr#eval` - I think that's something we can layer on later.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This will fix the described issue, but will also make predicates that use non-string equality expressions slower. I'd imagine the most common cases will be similar to the one in the new test: an integer question being compared to an untyped select choice node.
