### PR TITLE
Expose action with entity

### DIFF
--- a/src/main/java/org/javarosa/entities/Entity.java
+++ b/src/main/java/org/javarosa/entities/Entity.java
@@ -13,13 +13,15 @@ public class Entity {
 
     @Nullable
     public final String label;
-    public Integer version;
+    public final Integer version;
+    public final EntityAction action;
 
-    public Entity(String dataset, String id, @Nullable String label, Integer version, List<Pair<String, String>> properties) {
+    public Entity(EntityAction action, String dataset, String id, @Nullable String label, Integer version, List<Pair<String, String>> properties) {
         this.dataset = dataset;
         this.id = id;
         this.label = label;
         this.version = version;
         this.properties = properties;
+        this.action = action;
     }
 }

--- a/src/main/java/org/javarosa/entities/EntityAction.java
+++ b/src/main/java/org/javarosa/entities/EntityAction.java
@@ -1,0 +1,6 @@
+package org.javarosa.entities;
+
+public enum EntityAction {
+    CREATE,
+    UPDATE
+}

--- a/src/main/java/org/javarosa/entities/EntityFormFinalizationProcessor.java
+++ b/src/main/java/org/javarosa/entities/EntityFormFinalizationProcessor.java
@@ -31,16 +31,16 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
 
         TreeElement entityElement = EntityFormParser.getEntityElement(mainInstance);
         if (entityElement != null) {
-            EntityFormParser.EntityAction action = EntityFormParser.parseAction(entityElement);
+            EntityAction action = EntityFormParser.parseAction(entityElement);
             String dataset = EntityFormParser.parseDataset(entityElement);
 
-            if (action == EntityFormParser.EntityAction.CREATE) {
-                Entity entity = createEntity(entityElement, 1, dataset, saveTos, mainInstance);
+            if (action == EntityAction.CREATE) {
+                Entity entity = createEntity(entityElement, 1, dataset, saveTos, mainInstance, action);
                 formEntryModel.getExtras().put(new Entities(asList(entity)));
-            } else if (action == EntityFormParser.EntityAction.UPDATE){
+            } else if (action == EntityAction.UPDATE){
                 int baseVersion = EntityFormParser.parseBaseVersion(entityElement);
                 int newVersion = baseVersion + 1;
-                Entity entity = createEntity(entityElement, newVersion, dataset, saveTos, mainInstance);
+                Entity entity = createEntity(entityElement, newVersion, dataset, saveTos, mainInstance, action);
                 formEntryModel.getExtras().put(new Entities(asList(entity)));
             } else {
                 formEntryModel.getExtras().put(new Entities(emptyList()));
@@ -48,7 +48,7 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
         }
     }
 
-    private Entity createEntity(TreeElement entityElement, int version, String dataset, List<Pair<XPathReference, String>> saveTos, FormInstance mainInstance) {
+    private Entity createEntity(TreeElement entityElement, int version, String dataset, List<Pair<XPathReference, String>> saveTos, FormInstance mainInstance, EntityAction action) {
         List<Pair<String, String>> fields = saveTos.stream().map(saveTo -> {
             IDataReference reference = saveTo.getFirst();
             IAnswerData answerData = mainInstance.resolveReference(reference).getValue();
@@ -62,6 +62,6 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
 
         String id = EntityFormParser.parseId(entityElement);
         String label = EntityFormParser.parseLabel(entityElement);
-        return new Entity(dataset, id, label, version, fields);
+        return new Entity(action, dataset, id, label, version, fields);
     }
 }

--- a/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
+++ b/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
@@ -2,6 +2,7 @@ package org.javarosa.entities.internal;
 
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.entities.EntityAction;
 import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -69,10 +70,5 @@ public class EntityFormParser {
         }
 
         return null;
-    }
-
-    public enum EntityAction {
-        CREATE,
-        UPDATE
     }
 }

--- a/src/test/java/org/javarosa/entities/EntitiesTest.java
+++ b/src/test/java/org/javarosa/entities/EntitiesTest.java
@@ -124,6 +124,7 @@ public class EntitiesTest {
         assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
         assertThat(entities.get(0).version, equalTo(1));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
+        assertThat(entities.get(0).action, equalTo(EntityAction.CREATE));
     }
 
     @Test
@@ -168,6 +169,7 @@ public class EntitiesTest {
         assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
         assertThat(entities.get(0).version, equalTo(2));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
+        assertThat(entities.get(0).action, equalTo(EntityAction.UPDATE));
     }
 
     @Test
@@ -252,6 +254,7 @@ public class EntitiesTest {
         assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
         assertThat(entities.get(0).version, equalTo(2));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
+        assertThat(entities.get(0).action, equalTo(EntityAction.UPDATE));
     }
 
     @Test
@@ -295,6 +298,7 @@ public class EntitiesTest {
         assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
         assertThat(entities.get(0).version, equalTo(1));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
+        assertThat(entities.get(0).action, equalTo(EntityAction.UPDATE));
     }
 
     @Test

--- a/src/test/java/org/javarosa/entities/EntityFormParserTest.java
+++ b/src/test/java/org/javarosa/entities/EntityFormParserTest.java
@@ -52,8 +52,8 @@ public class EntityFormParserTest {
         XFormParser parser = new XFormParser(new InputStreamReader(new ByteArrayInputStream(form.asXml().getBytes())));
         FormDef formDef = parser.parse(null);
 
-        EntityFormParser.EntityAction dataset = EntityFormParser.parseAction(EntityFormParser.getEntityElement(formDef.getMainInstance()));
-        assertThat(dataset, equalTo(EntityFormParser.EntityAction.CREATE));
+        EntityAction dataset = EntityFormParser.parseAction(EntityFormParser.getEntityElement(formDef.getMainInstance()));
+        assertThat(dataset, equalTo(EntityAction.CREATE));
     }
 
     @Test
@@ -84,7 +84,7 @@ public class EntityFormParserTest {
         XFormParser parser = new XFormParser(new InputStreamReader(new ByteArrayInputStream(form.asXml().getBytes())));
         FormDef formDef = parser.parse(null);
 
-        EntityFormParser.EntityAction dataset = EntityFormParser.parseAction(EntityFormParser.getEntityElement(formDef.getMainInstance()));
-        assertThat(dataset, equalTo(EntityFormParser.EntityAction.UPDATE));
+        EntityAction dataset = EntityFormParser.parseAction(EntityFormParser.getEntityElement(formDef.getMainInstance()));
+        assertThat(dataset, equalTo(EntityAction.UPDATE));
     }
 }

--- a/src/test/java/org/javarosa/entities/EntityFormParserTest.java
+++ b/src/test/java/org/javarosa/entities/EntityFormParserTest.java
@@ -52,8 +52,8 @@ public class EntityFormParserTest {
         XFormParser parser = new XFormParser(new InputStreamReader(new ByteArrayInputStream(form.asXml().getBytes())));
         FormDef formDef = parser.parse(null);
 
-        EntityAction dataset = EntityFormParser.parseAction(EntityFormParser.getEntityElement(formDef.getMainInstance()));
-        assertThat(dataset, equalTo(EntityAction.CREATE));
+        EntityAction action = EntityFormParser.parseAction(EntityFormParser.getEntityElement(formDef.getMainInstance()));
+        assertThat(action, equalTo(EntityAction.CREATE));
     }
 
     @Test


### PR DESCRIPTION
Work for getodk/collect#6031

This will allow a client to determine that an exposed entity is an update and handle edge cases around that (like the one described in the attached issue).

#### What has been done to verify that this works as intended?

Updated tests.

#### Why is this the best possible solution? Were any other approaches considered?

This is quite a simple change. I considered also removing the versioning logic from JavaRosa now that clients will have access to the action and theoretically could handle it for themselves. However, I wanted to keep the entity exposed as simple to deal with as possible - an `UPDATE` is communicating "update the entity with this id to this version with this label and properties".

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't change anything on client side as the change is purely additive.
