### PR TITLE
Add ability for for clients to provide their own instance parsing

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
@@ -1,19 +1,22 @@
 package org.javarosa.core.model.instance;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.io.input.BOMInputStream;
+import org.javarosa.core.model.data.UncastData;
+import org.javarosa.xform.parse.ExternalInstanceParser;
+
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
-import org.apache.commons.io.input.BOMInputStream;
-import org.javarosa.core.model.data.UncastData;
 
-public class CsvExternalInstance {
-    public static TreeElement parse(String instanceId, String path) throws IOException {
+public class CsvExternalInstance implements ExternalInstanceParser.FileInstanceParser {
+
+    public TreeElement parse(String instanceId, String path) throws IOException {
         final TreeElement root = new TreeElement("root", 0);
         root.setInstanceName(instanceId);
 
@@ -39,6 +42,11 @@ public class CsvExternalInstance {
         }
 
         return root;
+    }
+
+    @Override
+    public boolean isSupported(String instanceId, String instanceSrc) {
+        return instanceSrc.contains("file-csv");
     }
 
     private static char getDelimiter(String path) throws IOException {

--- a/src/main/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstance.java
@@ -19,13 +19,16 @@ package org.javarosa.core.model.instance.geojson;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.xform.parse.ExternalInstanceParser;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Objects;
-import org.javarosa.core.model.instance.TreeElement;
 
-public class GeoJsonExternalInstance {
-    public static TreeElement parse(String instanceId, String path) throws IOException {
+public class GeoJsonExternalInstance implements ExternalInstanceParser.FileInstanceParser {
+
+    public TreeElement parse(String instanceId, String path) throws IOException {
         final TreeElement root = new TreeElement("root", 0);
         root.setInstanceName(instanceId);
 
@@ -67,5 +70,10 @@ public class GeoJsonExternalInstance {
         }
 
         return root;
+    }
+
+    @Override
+    public boolean isSupported(String instanceId, String instanceSrc) {
+        return instanceSrc.endsWith("geojson");
     }
 }

--- a/src/main/java/org/javarosa/xform/parse/ExternalInstanceParser.java
+++ b/src/main/java/org/javarosa/xform/parse/ExternalInstanceParser.java
@@ -15,8 +15,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 
@@ -58,10 +56,7 @@ public class ExternalInstanceParser {
      * (via {@link FileInstanceParser#isSupported(String, String)}) first.
      */
     public void addFileInstanceParser(FileInstanceParser fileInstanceParser) {
-        fileInstanceParsers = Stream.concat(
-            Stream.of(fileInstanceParser),
-            fileInstanceParsers.stream()
-        ).collect(Collectors.toList());
+        fileInstanceParsers.add(0, fileInstanceParser);
     }
 
     /**

--- a/src/test/java/org/javarosa/core/model/instance/CsvExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/CsvExternalInstanceTest.java
@@ -1,15 +1,16 @@
 package org.javarosa.core.model.instance;
 
+import org.apache.commons.io.input.BOMInputStream;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.assertEquals;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import org.apache.commons.io.input.BOMInputStream;
-import org.junit.Before;
-import org.junit.Test;
 
 public class CsvExternalInstanceTest {
     private TreeElement commaSeparated;
@@ -17,8 +18,8 @@ public class CsvExternalInstanceTest {
 
     @Before
     public void setUp() throws IOException {
-        commaSeparated = CsvExternalInstance.parse("id", r("external-secondary-comma-complex.csv").toString());
-        semiColonSeparated = CsvExternalInstance.parse("id", r("external-secondary-semicolon-complex.csv").toString());
+        commaSeparated = new CsvExternalInstance().parse("id", r("external-secondary-comma-complex.csv").toString());
+        semiColonSeparated = new CsvExternalInstance().parse("id", r("external-secondary-semicolon-complex.csv").toString());
     }
 
     @Test
@@ -58,13 +59,13 @@ public class CsvExternalInstanceTest {
         BOMInputStream bomIs = new BOMInputStream(new FileInputStream(r("external-secondary-csv-bom.csv").toFile()));
         assertThat(bomIs.hasBOM(), is(true));
 
-        TreeElement bomCsv = CsvExternalInstance.parse("id", r("external-secondary-csv-bom.csv").toString());
+        TreeElement bomCsv = new CsvExternalInstance().parse("id", r("external-secondary-csv-bom.csv").toString());
         assertThat(bomCsv.getChildAt(0).getChildAt(0).getName(), is("name"));
     }
 
     @Test
     public void parses_utf8_characters() throws IOException {
-        TreeElement bomCsv = CsvExternalInstance.parse("id", r("external-secondary-csv-bom.csv").toString());
+        TreeElement bomCsv = new CsvExternalInstance().parse("id", r("external-secondary-csv-bom.csv").toString());
         assertThat(bomCsv.getChildAt(0).getChild("elevation", 0).getValue().getValue(), is("testé"));
     }
 }

--- a/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
@@ -16,21 +16,22 @@
 
 package org.javarosa.core.model.instance.geojson;
 
+import org.javarosa.core.model.instance.TreeElement;
+import org.junit.Test;
+
+import java.io.IOException;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.javarosa.test.utils.ResourcePathHelper.r;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
-import org.javarosa.core.model.instance.TreeElement;
-import org.junit.Test;
-
 public class GeoJsonExternalInstanceTest {
 
     @Test
     public void parse_addsGeometriesAsChildren_forMultipleFeatures() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection.geojson").toString());
+        TreeElement featureCollection = new GeoJsonExternalInstance().parse("id", r("feature-collection.geojson").toString());
         assertThat(featureCollection.getNumChildren(), is(3));
         assertThat(featureCollection.getChildAt(0).getChild("geometry", 0).getValue().getValue(), is("0.5 102 0 0"));
         assertThat(featureCollection.getChildAt(1).getChild("geometry", 0).getValue().getValue(), is("0.5 104 0 0; 0.5 105 0 0"));
@@ -40,7 +41,7 @@ public class GeoJsonExternalInstanceTest {
     @Test
     public void parse_throwsException_ifNoTopLevelObject() {
         try {
-            GeoJsonExternalInstance.parse("id", r("not-object.geojson").toString());
+            new GeoJsonExternalInstance().parse("id", r("not-object.geojson").toString());
             fail("Exception expected");
         } catch (IOException e) {
             // expected
@@ -50,7 +51,7 @@ public class GeoJsonExternalInstanceTest {
     @Test
     public void parse_throwsException_ifTopLevelObjectTypeNotFeatureCollection() {
         try {
-            GeoJsonExternalInstance.parse("id", r("invalid-type.geojson").toString());
+            new GeoJsonExternalInstance().parse("id", r("invalid-type.geojson").toString());
             fail("Exception expected");
         } catch (IOException e) {
             // expected
@@ -59,20 +60,20 @@ public class GeoJsonExternalInstanceTest {
 
     @Test
     public void parse_ignoresExtraTopLevelProperties() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-extra-toplevel.geojson").toString());
+        TreeElement featureCollection = new GeoJsonExternalInstance().parse("id", r("feature-collection-extra-toplevel.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(3));
     }
 
     @Test
     public void parse_acceptsAnyToplevelPropertyOrder() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-toplevel-order.geojson").toString());
+        TreeElement featureCollection = new GeoJsonExternalInstance().parse("id", r("feature-collection-toplevel-order.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(3));
     }
 
     @Test
     public void parse_throwsException_ifNoFeaturesArray() {
         try {
-            GeoJsonExternalInstance.parse("id", r("bad-futures-collection.geojson").toString());
+            new GeoJsonExternalInstance().parse("id", r("bad-futures-collection.geojson").toString());
             fail("Exception expected");
         } catch (IOException e) {
             // expected
@@ -82,7 +83,7 @@ public class GeoJsonExternalInstanceTest {
     @Test
     public void parse_throwsException_ifFeaturesNotArray() {
         try {
-            GeoJsonExternalInstance.parse("id", r("bad-features-not-array.geojson").toString());
+            new GeoJsonExternalInstance().parse("id", r("bad-features-not-array.geojson").toString());
             fail("Exception expected");
         } catch (IOException e) {
             // expected
@@ -92,7 +93,7 @@ public class GeoJsonExternalInstanceTest {
     @Test
     public void parse_throwsException_ifSingleFeatureNotOfFeatureType() {
         try {
-            GeoJsonExternalInstance.parse("id", r("bad-feature-not-feature.geojson").toString());
+            new GeoJsonExternalInstance().parse("id", r("bad-feature-not-feature.geojson").toString());
             fail("Exception expected");
         } catch (IOException e) {
             // expected
@@ -101,7 +102,7 @@ public class GeoJsonExternalInstanceTest {
 
     @Test
     public void parse_addsAllOtherPropertiesAsChildren() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection.geojson").toString());
+        TreeElement featureCollection = new GeoJsonExternalInstance().parse("id", r("feature-collection.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
         assertThat(featureCollection.getChildAt(0).getChild("name", 0).getValue().getValue(), is("My cool point"));
 
@@ -111,7 +112,7 @@ public class GeoJsonExternalInstanceTest {
 
     @Test
     public void parse_usesTopLevelId() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-id-toplevel.geojson").toString());
+        TreeElement featureCollection = new GeoJsonExternalInstance().parse("id", r("feature-collection-id-toplevel.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
         assertThat(featureCollection.getChildAt(0).getChild("id", 0).getValue().getValue(), is("top-level-id"));
 
@@ -119,14 +120,14 @@ public class GeoJsonExternalInstanceTest {
 
     @Test
     public void parse_prioritizesTopLevelId() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-id-twice.geojson").toString());
+        TreeElement featureCollection = new GeoJsonExternalInstance().parse("id", r("feature-collection-id-twice.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
         assertThat(featureCollection.getChildAt(0).getChild("id", 0).getValue().getValue(), is("top-level-id"));
     }
 
     @Test
     public void parse_allowsIntegerId() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-integer-id.geojson").toString());
+        TreeElement featureCollection = new GeoJsonExternalInstance().parse("id", r("feature-collection-integer-id.geojson").toString());
 
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
         assertThat(featureCollection.getChildAt(0).getChild("id", 0).getValue().getValue(), is("77"));
@@ -134,21 +135,21 @@ public class GeoJsonExternalInstanceTest {
 
     @Test
     public void parse_ignoresUnknownToplevelProperties() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-extra-feature-toplevel.geojson").toString());
+        TreeElement featureCollection = new GeoJsonExternalInstance().parse("id", r("feature-collection-extra-feature-toplevel.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(3));
         assertThat(featureCollection.getChildAt(0).getChild("ignored", 0), nullValue());
     }
 
     @Test
     public void parse_addsFeaturesWithNoProperties() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-no-properties.geojson").toString());
+        TreeElement featureCollection = new GeoJsonExternalInstance().parse("id", r("feature-collection-no-properties.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(1));
     }
 
     @Test
     public void parse_throwsException_whenGeometryNotSupported() {
         try {
-            GeoJsonExternalInstance.parse("id", r("feature-collection-with-unsupported-type.geojson").toString());
+            new GeoJsonExternalInstance().parse("id", r("feature-collection-with-unsupported-type.geojson").toString());
             fail("Exception expected");
         } catch (IOException e) {
             // expected
@@ -157,7 +158,7 @@ public class GeoJsonExternalInstanceTest {
 
     @Test
     public void parse_allowsNullFeaturePropertyValues() throws IOException {
-        TreeElement featureCollection = GeoJsonExternalInstance.parse("id", r("feature-collection-with-null.geojson").toString());
+        TreeElement featureCollection = new GeoJsonExternalInstance().parse("id", r("feature-collection-with-null.geojson").toString());
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
         assertThat(featureCollection.getChildAt(0).getChild("extra", 0).getValue().getDisplayText(), is(""));
     }


### PR DESCRIPTION
Work towards https://github.com/getodk/collect/issues/6029

This adds a new `FilterInstanceParser` interface that is now used by `GeoJsonExternalInstance` and `CsvExternalInstance` and allows clients to add their own implementations.

#### What has been done to verify that this works as intended?

Verified with a spike in Collect.

#### Why is this the best possible solution? Were any other approaches considered?

I tired using an "interceptor"/"preprocessor" approach, but then realised that the way we parse CSV and GeoJSON files is already a "chain" of parsers so formalising that made the most sense.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't change behaviour - it adds the ability for clients to change behaviour from their side.
