### PR TITLE
Use first repeat instance(s) for jr:choice-name choices

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -16,6 +16,25 @@
 
 package org.javarosa.core.model;
 
+import static java.util.Collections.emptyList;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.javarosa.core.log.WrappedException;
 import org.javarosa.core.model.TriggerableDag.EventNotifierAccessor;
 import org.javarosa.core.model.actions.ActionController;
@@ -66,26 +85,6 @@ import org.javarosa.xform.util.XFormAnswerDataSerializer;
 import org.javarosa.xml.InternalDataInstanceParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Queue;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.Collections.emptyList;
 
 /**
  * Definition of a form. This has some meta data about the form definition and a
@@ -866,10 +865,18 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                                 // the situations where that context would be used don't make sense for trying to reverse a
                                 // select value back to a label in an unrelated expression
                                 if (ref.isAmbiguous()) {
-                                    // SurveyCTO: We need a absolute "ref" to populate the dynamic choices,
-                                    // like we do when we populate those at FormEntryPrompt (line 251).
-                                    // The "ref" here is ambiguous, so we need to make it concrete first.
+                                    // ref, the reference used to specify where choices are defined, could be an absolute
+                                    // reference to a repeat nodeset. In that case, we need to convert that nodeset ref
+                                    // into a node ref. First try to contextualize based on the current repeat in case the
+                                    // choice-name call is from inside a repeat. Then use position 1 for any repeats that
+                                    // weren't contextualized (this is what a standards-compliant XPath engine would always do).
                                     ref = ref.contextualize(ec.getContextRef());
+
+                                    for (int i = 0; i < ref.size(); i++) {
+                                        if (ref.getMultiplicity(i) == TreeReference.INDEX_UNBOUND) {
+                                            ref.setMultiplicity(i, TreeReference.DEFAULT_MULTIPLICITY);
+                                        }
+                                    }
                                 }
                                 choices = itemset.getChoices(f, ref);
                             } else { // static choices

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -35,10 +35,10 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.javarosa.core.log.WrappedException;
 import org.javarosa.core.model.TriggerableDag.EventNotifierAccessor;
 import org.javarosa.core.model.actions.ActionController;
 import org.javarosa.core.model.actions.Actions;
+import org.javarosa.core.model.condition.ChoiceNameFunctionHandler;
 import org.javarosa.core.model.condition.Constraint;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.FilterStrategy;
@@ -57,7 +57,6 @@ import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.core.model.instance.InvalidReferenceException;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.core.model.util.restorable.RestoreUtils;
 import org.javarosa.core.model.utils.QuestionPreloader;
 import org.javarosa.core.services.locale.Localizable;
 import org.javarosa.core.services.locale.Localizer;
@@ -827,106 +826,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
              * compile-time-static fields, for use inside an <output>
              */
             if (!evaluationContext.getFunctionHandlers().containsKey("jr:choice-name")) {
-                final FormDef f = this;
-                evaluationContext.addFunctionHandler(new IFunctionHandler() {
-                    @Override
-                    public String getName() {
-                        return "jr:choice-name";
-                    }
-
-                    @Override
-                    public Object eval(Object[] args, EvaluationContext ec) {
-                        try {
-                            String value = (String) args[0];
-                            String questionXpath = (String) args[1];
-                            TreeReference ref = RestoreUtils.xfFact.ref(questionXpath);
-                            ref = ref.anchor(ec.getContextRef());
-
-                            QuestionDef q = findQuestionByRef(ref, f);
-                            if (q == null
-                                || (q.getControlType() != Constants.CONTROL_SELECT_ONE
-                                && q.getControlType() != Constants.CONTROL_SELECT_MULTI
-                                && q.getControlType() != Constants.CONTROL_RANK)) {
-                                return "";
-                            }
-
-                            List<SelectChoice> choices;
-
-                            ItemsetBinding itemset = q.getDynamicChoices();
-                            if (itemset != null) {
-                                // 2019-HM: See ChoiceNameTest for test and more explanation
-
-                                // NOTE: We have no context against which to evaluate a dynamic selection list. This will
-                                // generally cause that evaluation to break if any filtering is done, or, worst case, give
-                                // unexpected results.
-                                //
-                                // We should hook into the existing code (FormEntryPrompt) for pulling display text for select
-                                // choices. however, it's hard, because we don't really have any context to work with, and all
-                                // the situations where that context would be used don't make sense for trying to reverse a
-                                // select value back to a label in an unrelated expression
-                                if (ref.isAmbiguous()) {
-                                    // ref, the reference used to specify where choices are defined, could be an absolute
-                                    // reference to a repeat nodeset. In that case, we need to convert that nodeset ref
-                                    // into a node ref. First try to contextualize based on the current repeat in case the
-                                    // choice-name call is from inside a repeat. Then use position 1 for any repeats that
-                                    // weren't contextualized (this is what a standards-compliant XPath engine would always do).
-                                    ref = ref.contextualize(ec.getContextRef());
-
-                                    for (int i = 0; i < ref.size(); i++) {
-                                        if (ref.getMultiplicity(i) == TreeReference.INDEX_UNBOUND) {
-                                            ref.setMultiplicity(i, TreeReference.DEFAULT_MULTIPLICITY);
-                                        }
-                                    }
-                                }
-                                choices = itemset.getChoices(f, ref);
-                            } else { // static choices
-                                choices = q.getChoices();
-                            }
-                            if (choices != null) {
-                                for (SelectChoice ch : choices) {
-                                    if (ch.getValue().equals(value)) {
-                                        // this is really not ideal. we should hook into the existing code (FormEntryPrompt)
-                                        // for pulling display text for select choices. however, it's hard, because we don't
-                                        // really have any context to work with, and all the situations where that context
-                                        // would be used don't make sense for trying to reverse a select value back to a
-                                        // label in an unrelated expression
-
-                                        String textID = ch.getTextID();
-                                        String templateStr;
-                                        if (textID != null) {
-                                            templateStr = f.getLocalizer().getText(textID);
-                                        } else {
-                                            templateStr = ch.getLabelInnerText();
-                                        }
-                                        return fillTemplateString(templateStr, ref);
-                                    }
-                                }
-                            }
-                            return "";
-                        } catch (Exception e) {
-                            throw new WrappedException("error in evaluation of xpath function [choice-name]",
-                                e);
-                        }
-                    }
-
-                    @Override
-                    public List<Class[]> getPrototypes() {
-                        Class[] proto = {String.class, String.class};
-                        List<Class[]> v = new ArrayList<>(1);
-                        v.add(proto);
-                        return v;
-                    }
-
-                    @Override
-                    public boolean rawArgs() {
-                        return false;
-                    }
-
-                    @Override
-                    public boolean realTime() {
-                        return false;
-                    }
-                });
+                evaluationContext.addFunctionHandler(new ChoiceNameFunctionHandler(this) );
             }
 
             if (predicateCaching) {

--- a/src/main/java/org/javarosa/core/model/condition/ChoiceNameFunctionHandler.java
+++ b/src/main/java/org/javarosa/core/model/condition/ChoiceNameFunctionHandler.java
@@ -1,0 +1,120 @@
+package org.javarosa.core.model.condition;
+
+import static org.javarosa.core.model.FormDef.findQuestionByRef;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.javarosa.core.log.WrappedException;
+import org.javarosa.core.model.Constants;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.ItemsetBinding;
+import org.javarosa.core.model.QuestionDef;
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.model.util.restorable.RestoreUtils;
+
+public class ChoiceNameFunctionHandler implements IFunctionHandler {
+    FormDef f;
+
+    public ChoiceNameFunctionHandler(final FormDef f) {
+        this.f = f;
+    }
+
+    @Override
+    public String getName() {
+        return "jr:choice-name";
+    }
+
+    @Override
+    public Object eval(Object[] args, EvaluationContext ec) {
+        try {
+            String value = (String) args[0];
+            String questionXpath = (String) args[1];
+            TreeReference ref = RestoreUtils.xfFact.ref(questionXpath);
+            ref = ref.anchor(ec.getContextRef());
+
+            QuestionDef q = findQuestionByRef(ref, f);
+            if (q == null
+                || (q.getControlType() != Constants.CONTROL_SELECT_ONE
+                && q.getControlType() != Constants.CONTROL_SELECT_MULTI
+                && q.getControlType() != Constants.CONTROL_RANK)) {
+                return "";
+            }
+
+            List<SelectChoice> choices;
+
+            ItemsetBinding itemset = q.getDynamicChoices();
+            if (itemset != null) {
+                // 2019-HM: See ChoiceNameTest for test and more explanation
+
+                // NOTE: We have no context against which to evaluate a dynamic selection list. This will
+                // generally cause that evaluation to break if any filtering is done, or, worst case, give
+                // unexpected results.
+                //
+                // We should hook into the existing code (FormEntryPrompt) for pulling display text for select
+                // choices. however, it's hard, because we don't really have any context to work with, and all
+                // the situations where that context would be used don't make sense for trying to reverse a
+                // select value back to a label in an unrelated expression
+                if (ref.isAmbiguous()) {
+                    // ref, the reference used to specify where choices are defined, could be an absolute
+                    // reference to a repeat nodeset. In that case, we need to convert that nodeset ref
+                    // into a node ref. First try to contextualize based on the current repeat in case the
+                    // choice-name call is from inside a repeat. Then use position 1 for any repeats that
+                    // weren't contextualized (this is what a standards-compliant XPath engine would always do).
+                    ref = ref.contextualize(ec.getContextRef());
+
+                    for (int i = 0; i < ref.size(); i++) {
+                        if (ref.getMultiplicity(i) == TreeReference.INDEX_UNBOUND) {
+                            ref.setMultiplicity(i, TreeReference.DEFAULT_MULTIPLICITY);
+                        }
+                    }
+                }
+                choices = itemset.getChoices(f, ref);
+            } else { // static choices
+                choices = q.getChoices();
+            }
+            if (choices != null) {
+                for (SelectChoice ch : choices) {
+                    if (ch.getValue().equals(value)) {
+                        // this is really not ideal. we should hook into the existing code (FormEntryPrompt)
+                        // for pulling display text for select choices. however, it's hard, because we don't
+                        // really have any context to work with, and all the situations where that context
+                        // would be used don't make sense for trying to reverse a select value back to a
+                        // label in an unrelated expression
+
+                        String textID = ch.getTextID();
+                        String templateStr;
+                        if (textID != null) {
+                            templateStr = f.getLocalizer().getText(textID);
+                        } else {
+                            templateStr = ch.getLabelInnerText();
+                        }
+                        return f.fillTemplateString(templateStr, ref);
+                    }
+                }
+            }
+            return "";
+        } catch (Exception e) {
+            throw new WrappedException("error in evaluation of xpath function [choice-name]",
+                e);
+        }
+    }
+
+    @Override
+    public List<Class[]> getPrototypes() {
+        Class[] proto = {String.class, String.class};
+        List<Class[]> v = new ArrayList<>(1);
+        v.add(proto);
+        return v;
+    }
+
+    @Override
+    public boolean rawArgs() {
+        return false;
+    }
+
+    @Override
+    public boolean realTime() {
+        return false;
+    }
+}


### PR DESCRIPTION
Closes #757

#### What has been done to verify that this works as intended?
Added tests

#### Why is this the best possible solution? Were any other approaches considered?
My initial instinct was that using a reference to a repeat nodeset rather than a specific repeat instance to specify where choices should be taken from is a form design issue. But then I realized that a standards-compliant XPath engine would use the first repeat instance(s) when given a nodeset reference where it needs a single node reference. 

This doesn't work well with choice filters but I think that's ok because it also wouldn't have been possible before. My priority here is to ensure that XLSForms that used to work continue to work without modification.

My recommendation for writing these kinds of `choice-name` calls would be to make them relative from within the repeat instance rather than making it from outside. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This only affects `choice-name` calls given a reference parameter that is a nodeset reference. I think the case in the test is the only one in which this kind of reference would make sense. There's also the analogous nested case and that's why there's a for loop to qualify every unboud reference level.

#### Do we need any specific form for testing your changes? If so, please attach one.
https://docs.google.com/spreadsheets/d/1MZvF9ynsOdGMWeZF8YsjuoUK9E0t83LZMi5-RsBOEiI/edit#gid=1068911091

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.