### PR TITLE
Use Maven plugin for local publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ out
 # mvn
 target
 secrets.xml
-pom-local.xml
 
 # logging
 logback.xml

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,18 @@ if (!project.hasProperty("android")) {
 
         duplicateClassesStrategy = DuplicatesStrategy.WARN
     }
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                groupId = 'org.getodk'
+                artifactId = 'javarosa'
+                version = 'local'
+
+                from components.java
+            }
+        }
+    }
 } else {
     android {
         namespace 'com.example'
@@ -126,18 +138,6 @@ if (!project.hasProperty("android")) {
             release {
                 minifyEnabled false
             }
-        }
-    }
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            groupId = 'org.getodk'
-            artifactId = 'javarosa'
-            version = 'local'
-
-            from components.java
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ if (!project.hasProperty("android")) {
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'me.champeau.jmh'
+    apply plugin: 'maven-publish'
 } else {
     apply plugin: 'com.android.library'
 }
@@ -50,32 +51,6 @@ compileTestJava {
 
 targetCompatibility = '1.8'
 sourceCompatibility = '1.8'
-
-tasks.register('installLocal') {
-    def lines = []
-    new File('pom.xml').withReader { reader ->
-        reader.eachLine {
-            lines.add(it)
-        }
-    }
-
-    def changedVersion = false
-    new File('pom-local.xml').withWriter { writer ->
-        lines.forEach {
-            if (it.trim().startsWith('<version>') && !changedVersion) {
-                writer.write('<version>local</version>')
-                changedVersion = true
-            } else {
-                writer.write(it)
-            }
-        }
-    }
-
-    exec {
-        executable 'mvn'
-        args '-f', 'pom-local.xml', '-Dgpg.skip', 'install'
-    }
-}
 
 if (!project.hasProperty("android")) {
     jar {
@@ -151,6 +126,18 @@ if (!project.hasProperty("android")) {
             release {
                 minifyEnabled false
             }
+        }
+    }
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId = 'org.getodk'
+            artifactId = 'javarosa'
+            version = 'local'
+
+            from components.java
         }
     }
 }


### PR DESCRIPTION
This replaces `installLocal` with `publishToMavenLocal`. This is a good baby step towards replacing Maven entirely with Gradle which will simplify development workflows.

We'll need to make a few updates on the Collect side after this, but that's fine to do after (and won't make sense to do before).