### PR TITLE
Fix crash for non-`String` entity labels

### DIFF
--- a/src/main/java/org/javarosa/entities/internal/EntityConstants.java
+++ b/src/main/java/org/javarosa/entities/internal/EntityConstants.java
@@ -1,0 +1,15 @@
+package org.javarosa.entities.internal;
+
+public class EntityConstants {
+
+    private EntityConstants() {}
+
+    public static final String ELEMENT_ENTITY = "entity";
+    public static final String ELEMENT_LABEL = "label";
+
+    public static final String ATTRIBUTE_DATASET = "dataset";
+    public static final String ATTRIBUTE_ID = "id";
+    public static final String ATTRIBUTE_BASE_VERSION = "baseVersion";
+    public static final String ATTRIBUTE_CREATE = "create";
+    public static final String ATTRIBUTE_UPDATE = "update";
+}

--- a/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
+++ b/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
@@ -26,7 +26,7 @@ public class EntityFormParser {
             IAnswerData labelValue = labelElement.getValue();
 
             if (labelValue != null) {
-                return (String) labelValue.getValue();
+                return String.valueOf(labelValue.getValue());
             } else {
                 return null;
             }

--- a/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
+++ b/src/main/java/org/javarosa/entities/internal/EntityFormParser.java
@@ -8,6 +8,14 @@ import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.javarosa.entities.internal.EntityConstants.ATTRIBUTE_BASE_VERSION;
+import static org.javarosa.entities.internal.EntityConstants.ATTRIBUTE_CREATE;
+import static org.javarosa.entities.internal.EntityConstants.ATTRIBUTE_DATASET;
+import static org.javarosa.entities.internal.EntityConstants.ATTRIBUTE_ID;
+import static org.javarosa.entities.internal.EntityConstants.ATTRIBUTE_UPDATE;
+import static org.javarosa.entities.internal.EntityConstants.ELEMENT_ENTITY;
+import static org.javarosa.entities.internal.EntityConstants.ELEMENT_LABEL;
+
 public class EntityFormParser {
 
     private EntityFormParser() {
@@ -15,12 +23,12 @@ public class EntityFormParser {
     }
 
     public static String parseDataset(TreeElement entity) {
-        return entity.getAttributeValue(null, "dataset");
+        return entity.getAttributeValue(null, ATTRIBUTE_DATASET);
     }
 
     @Nullable
     public static String parseLabel(TreeElement entity) {
-        TreeElement labelElement = entity.getFirstChild("label");
+        TreeElement labelElement = entity.getFirstChild(ELEMENT_LABEL);
 
         if (labelElement != null) {
             IAnswerData labelValue = labelElement.getValue();
@@ -37,12 +45,12 @@ public class EntityFormParser {
 
     @Nullable
     public static String parseId(TreeElement entity) {
-        return entity.getAttributeValue("", "id");
+        return entity.getAttributeValue("", ATTRIBUTE_ID);
     }
 
     public static Integer parseBaseVersion(TreeElement entity) {
         try {
-            return Integer.valueOf(entity.getAttributeValue("", "baseVersion"));
+            return Integer.valueOf(entity.getAttributeValue("", ATTRIBUTE_BASE_VERSION));
         } catch (NumberFormatException e) {
             return 0;
         }
@@ -54,7 +62,7 @@ public class EntityFormParser {
         TreeElement meta = root.getFirstChild("meta");
 
         if (meta != null) {
-            return meta.getFirstChild("entity");
+            return meta.getFirstChild(ELEMENT_ENTITY);
         } else {
             return null;
         }
@@ -62,8 +70,8 @@ public class EntityFormParser {
 
     @Nullable
     public static EntityAction parseAction(@NotNull TreeElement entity) {
-        String create = entity.getAttributeValue(null, "create");
-        String update = entity.getAttributeValue(null, "update");
+        String create = entity.getAttributeValue(null, ATTRIBUTE_CREATE);
+        String update = entity.getAttributeValue(null, ATTRIBUTE_UPDATE);
 
         if (update != null) {
             if (XPathFuncExpr.boolStr(update)) {

--- a/src/test/java/org/javarosa/entities/EntityFormParserTest.java
+++ b/src/test/java/org/javarosa/entities/EntityFormParserTest.java
@@ -1,92 +1,30 @@
 package org.javarosa.entities;
 
-import kotlin.Pair;
-import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.core.util.XFormsElement;
 import org.javarosa.entities.internal.EntityFormParser;
-import org.javarosa.xform.parse.XFormParser;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStreamReader;
-
-import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.javarosa.core.util.BindBuilderXFormsElement.bind;
-import static org.javarosa.core.util.XFormsElement.body;
-import static org.javarosa.core.util.XFormsElement.head;
-import static org.javarosa.core.util.XFormsElement.input;
-import static org.javarosa.core.util.XFormsElement.mainInstance;
-import static org.javarosa.core.util.XFormsElement.model;
-import static org.javarosa.core.util.XFormsElement.t;
-import static org.javarosa.core.util.XFormsElement.title;
 
 public class EntityFormParserTest {
 
     @Test
-    public void parseAction_findsCreateWithTrueString() throws XFormParser.ParseException {
-        XFormsElement form = XFormsElement.html(
-            asList(
-                new Pair<>("entities", "http://www.opendatakit.org/xforms/entities")
-            ),
-            head(
-                title("Create entity form"),
-                model(
-                    mainInstance(
-                        t("data id=\"create-entity-form\"",
-                            t("name"),
-                            t("meta",
-                                t("entity dataset=\"people\" create=\"true\"")
-                            )
-                        )
-                    ),
-                    bind("/data/name").type("string").withAttribute("entities", "saveto", "name")
-                )
-            ),
-            body(
-                input("/data/name")
-            )
-        );
+    public void parseAction_findsCreateWithTrueString() {
+        TreeElement entityElement = new TreeElement("entity");
+        entityElement.setAttribute(null, "create", "true");
 
-        XFormParser parser = new XFormParser(new InputStreamReader(new ByteArrayInputStream(form.asXml().getBytes())));
-        FormDef formDef = parser.parse(null);
-
-        EntityAction action = EntityFormParser.parseAction(EntityFormParser.getEntityElement(formDef.getMainInstance()));
+        EntityAction action = EntityFormParser.parseAction(entityElement);
         assertThat(action, equalTo(EntityAction.CREATE));
     }
 
     @Test
-    public void parseAction_findsUpdateWithTrueString() throws XFormParser.ParseException {
-        XFormsElement form = XFormsElement.html(
-            asList(
-                new Pair<>("entities", "http://www.opendatakit.org/xforms/entities")
-            ),
-            head(
-                title("Create entity form"),
-                model(
-                    mainInstance(
-                        t("data id=\"create-entity-form\"",
-                            t("name"),
-                            t("meta",
-                                t("entity dataset=\"people\" update=\"true\"")
-                            )
-                        )
-                    ),
-                    bind("/data/name").type("string").withAttribute("entities", "saveto", "name")
-                )
-            ),
-            body(
-                input("/data/name")
-            )
-        );
+    public void parseAction_findsUpdateWithTrueString() {
+        TreeElement entityElement = new TreeElement("entity");
+        entityElement.setAttribute(null, "update", "true");
 
-        XFormParser parser = new XFormParser(new InputStreamReader(new ByteArrayInputStream(form.asXml().getBytes())));
-        FormDef formDef = parser.parse(null);
-
-        EntityAction dataset = EntityFormParser.parseAction(EntityFormParser.getEntityElement(formDef.getMainInstance()));
+        EntityAction dataset = EntityFormParser.parseAction(entityElement);
         assertThat(dataset, equalTo(EntityAction.UPDATE));
     }
 

--- a/src/test/java/org/javarosa/entities/EntityFormParserTest.java
+++ b/src/test/java/org/javarosa/entities/EntityFormParserTest.java
@@ -7,13 +7,17 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.javarosa.entities.internal.EntityConstants.ATTRIBUTE_CREATE;
+import static org.javarosa.entities.internal.EntityConstants.ATTRIBUTE_UPDATE;
+import static org.javarosa.entities.internal.EntityConstants.ELEMENT_ENTITY;
+import static org.javarosa.entities.internal.EntityConstants.ELEMENT_LABEL;
 
 public class EntityFormParserTest {
 
     @Test
     public void parseAction_findsCreateWithTrueString() {
-        TreeElement entityElement = new TreeElement("entity");
-        entityElement.setAttribute(null, "create", "true");
+        TreeElement entityElement = new TreeElement(ELEMENT_ENTITY);
+        entityElement.setAttribute(null, ATTRIBUTE_CREATE, "true");
 
         EntityAction action = EntityFormParser.parseAction(entityElement);
         assertThat(action, equalTo(EntityAction.CREATE));
@@ -21,8 +25,8 @@ public class EntityFormParserTest {
 
     @Test
     public void parseAction_findsUpdateWithTrueString() {
-        TreeElement entityElement = new TreeElement("entity");
-        entityElement.setAttribute(null, "update", "true");
+        TreeElement entityElement = new TreeElement(ELEMENT_ENTITY);
+        entityElement.setAttribute(null, ATTRIBUTE_UPDATE, "true");
 
         EntityAction dataset = EntityFormParser.parseAction(entityElement);
         assertThat(dataset, equalTo(EntityAction.UPDATE));
@@ -30,9 +34,9 @@ public class EntityFormParserTest {
 
     @Test
     public void parseLabel_whenLabelIsAnInt_convertsToString() {
-        TreeElement labelElement = new TreeElement("label");
+        TreeElement labelElement = new TreeElement(ELEMENT_LABEL);
         labelElement.setAnswer(new IntegerData(0));
-        TreeElement entityElement = new TreeElement("entity");
+        TreeElement entityElement = new TreeElement(ELEMENT_ENTITY);
         entityElement.addChild(labelElement);
 
         String label = EntityFormParser.parseLabel(entityElement);

--- a/src/test/java/org/javarosa/entities/EntityFormParserTest.java
+++ b/src/test/java/org/javarosa/entities/EntityFormParserTest.java
@@ -2,6 +2,8 @@ package org.javarosa.entities;
 
 import kotlin.Pair;
 import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.data.IntegerData;
+import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.util.XFormsElement;
 import org.javarosa.entities.internal.EntityFormParser;
 import org.javarosa.xform.parse.XFormParser;
@@ -86,5 +88,16 @@ public class EntityFormParserTest {
 
         EntityAction dataset = EntityFormParser.parseAction(EntityFormParser.getEntityElement(formDef.getMainInstance()));
         assertThat(dataset, equalTo(EntityAction.UPDATE));
+    }
+
+    @Test
+    public void parseLabel_whenLabelIsAnInt_convertsToString() {
+        TreeElement labelElement = new TreeElement("label");
+        labelElement.setAnswer(new IntegerData(0));
+        TreeElement entityElement = new TreeElement("entity");
+        entityElement.addChild(labelElement);
+
+        String label = EntityFormParser.parseLabel(entityElement);
+        assertThat(label, equalTo("0"));
     }
 }


### PR DESCRIPTION
Closes https://github.com/getodk/collect/issues/6167

#### What has been done to verify that this works as intended?

New tests!

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here. We now always convert to a string instead of casting, which should work for all the possible types.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The change is pretty specific, and will only affect entity forms.
