### PR TITLE
Add partial elements

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -26,6 +26,5 @@ Inspect external instances (their ID and parsed XML) after parsing or provide cu
 
 ### API
 - `ExternalInstanceParser#addFileInstanceParser`
-- `ExternalInstanceparsser#addProcessor`
 
 The default `ExternalInstanceParser` can be overridden by creating an implementation of `ExternalInstanceParserFactory` and calling `XFormUtils.setExternalInstanceParserFactory` with it.

--- a/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
@@ -6,6 +6,7 @@ import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.input.BOMInputStream;
 import org.javarosa.core.model.data.UncastData;
 import org.javarosa.xform.parse.ExternalInstanceParser;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -16,7 +17,7 @@ import java.io.Reader;
 
 public class CsvExternalInstance implements ExternalInstanceParser.FileInstanceParser {
 
-    public TreeElement parse(String instanceId, String path) throws IOException {
+    public TreeElement parse(@NotNull String instanceId, @NotNull String path) throws IOException {
         final TreeElement root = new TreeElement("root", 0);
         root.setInstanceName(instanceId);
 

--- a/src/main/java/org/javarosa/core/model/instance/DataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/DataInstance.java
@@ -1,17 +1,17 @@
 package org.javarosa.core.model.instance;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.javarosa.core.model.IDataReference;
 import org.javarosa.core.services.storage.Persistable;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A data instance represents a tree structure of abstract tree
@@ -81,6 +81,10 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
         AbstractTreeElement<T> node = getBase();
         T result = null;
         for (int i = 0; i < ref.size(); i++) {
+            if (node instanceof TreeElement && ((TreeElement) node).isPartial()) {
+                throw new PartialElementEncounteredException();
+            }
+
             String name = ref.getName(i);
             int mult = ref.getMultiplicity(i);
 
@@ -299,4 +303,18 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
 
     public abstract void initialize(InstanceInitializationFactory initializer, String instanceId);
 
+    public void replacePartialElements(List<TreeElement> elements) {
+        for (TreeElement element : elements) {
+            TreeElement root = (TreeElement) getRoot();
+            TreeElement matchingChild = root.getChild(element.getName(), element.getMultiplicity());
+
+            if (matchingChild != null) {
+                matchingChild.populatePartial(element);
+            }
+        }
+    }
+
+    public static class PartialElementEncounteredException extends RuntimeException {
+
+    }
 }

--- a/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -106,6 +106,7 @@ import java.util.List;
      * instance or null for the primary instance.
      */
     private String instanceName = null;
+    private boolean isPartial;
 
     /**
      * TreeElement with null name and 0 multiplicity? (a "hidden root" node?)
@@ -123,6 +124,11 @@ import java.util.List;
         this.multiplicity = multiplicity;
         this.parent = null;
         attributes = new ArrayList<TreeElement>(0);
+    }
+
+    public TreeElement(String name, int multiplicity, boolean isPartial) {
+        this(name, multiplicity);
+        this.isPartial = isPartial;
     }
 
     /**
@@ -1140,5 +1146,21 @@ import java.util.List;
 
     public void setNamespacePrefix(String namespacePrefix) {
         this.namespacePrefix = namespacePrefix;
+    }
+
+    public boolean isPartial() {
+        return isPartial;
+    }
+
+    public void populatePartial(TreeElement element) {
+        if (isPartial) {
+            children.clear();
+
+            for (int i = 0; i < element.getNumChildren(); i++) {
+                addChild(element.getChildAt(i));
+            }
+
+            isPartial = false;
+        }
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstance.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.xform.parse.ExternalInstanceParser;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -28,7 +29,7 @@ import java.util.Objects;
 
 public class GeoJsonExternalInstance implements ExternalInstanceParser.FileInstanceParser {
 
-    public TreeElement parse(String instanceId, String path) throws IOException {
+    public TreeElement parse(@NotNull String instanceId, @NotNull String path) throws IOException {
         final TreeElement root = new TreeElement("root", 0);
         root.setInstanceName(instanceId);
 

--- a/src/main/java/org/javarosa/test/TempFileUtils.java
+++ b/src/main/java/org/javarosa/test/TempFileUtils.java
@@ -13,7 +13,7 @@ public class TempFileUtils {
         return subDir;
     }
 
-    static File createTempFile(String prefix, String suffix) {
+    public static File createTempFile(String prefix, String suffix) {
         return createTempFile(null, prefix, suffix);
     }
 

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -184,6 +184,7 @@ public class XFormParser implements IXFormParserFunctions {
     private final List<ModelAttributeProcessor> modelAttributeProcessors = new ArrayList<>();
     private final List<QuestionProcessor> questionProcessors = new ArrayList<>();
     private final List<XPathProcessor> xpathProcessors = new ArrayList<>();
+    private final List<ExternalDataInstanceProcessor> externalDataInstanceProcessors = new ArrayList<>();;
 
     public static final List<XPathProcessor> tempXPathProcessors = new ArrayList<>();
 
@@ -459,6 +460,10 @@ public class XFormParser implements IXFormParserFunctions {
         if (processor instanceof XPathProcessor) {
             xpathProcessors.add((XPathProcessor) processor);
         }
+
+        if (processor instanceof ExternalDataInstanceProcessor) {
+            externalDataInstanceProcessors.add((ExternalDataInstanceProcessor) processor);
+        }
     }
 
     public void addBindAttributeProcessor(BindAttributeProcessor bindAttributeProcessor) {
@@ -577,6 +582,10 @@ public class XFormParser implements IXFormParserFunctions {
                         ExternalDataInstance externalDataInstance;
                         try {
                             externalDataInstance = ExternalDataInstance.build(instanceSrc, instanceId);
+                            for (ExternalDataInstanceProcessor processor : externalDataInstanceProcessors) {
+                                processor.processInstance(externalDataInstance);
+                            }
+
                         } catch (IOException | UnfullfilledRequirementsException | InvalidStructureException | XmlPullParserException e) {
                             String msg = "Unable to parse external secondary instance";
                             logger.error(msg, e);
@@ -2486,6 +2495,10 @@ public class XFormParser implements IXFormParserFunctions {
 
     public interface QuestionProcessor extends Processor {
         void processQuestion(@NotNull QuestionDef question);
+    }
+
+    public interface ExternalDataInstanceProcessor extends Processor {
+        void processInstance(@NotNull ExternalDataInstance instance);
     }
 
     public static class ParseException extends Exception {

--- a/src/main/java/org/javarosa/xform/util/XFormUtils.java
+++ b/src/main/java/org/javarosa/xform/util/XFormUtils.java
@@ -179,8 +179,12 @@ public class XFormUtils {
         return returnForm;
     }
 
+    public static TreeElement getExternalInstance(ReferenceManager referenceManager, String id, String instanceSrc, boolean partial) throws UnfullfilledRequirementsException, InvalidStructureException, XmlPullParserException, IOException, InvalidReferenceException {
+        return externalInstanceParserFactory.getExternalInstanceParser().parse(referenceManager, id, instanceSrc, partial);
+    }
+
     public static TreeElement getExternalInstance(ReferenceManager referenceManager, String id, String instanceSrc) throws UnfullfilledRequirementsException, InvalidStructureException, XmlPullParserException, IOException, InvalidReferenceException {
-        return externalInstanceParserFactory.getExternalInstanceParser().parse(referenceManager, id, instanceSrc);
+        return getExternalInstance(referenceManager, id, instanceSrc, false);
     }
 
     /////Parser Attribute warning stuff

--- a/src/test/java/org/javarosa/plugins/InstancePluginTest.java
+++ b/src/test/java/org/javarosa/plugins/InstancePluginTest.java
@@ -1,0 +1,271 @@
+package org.javarosa.plugins;
+
+import kotlin.Pair;
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.test.Scenario;
+import org.javarosa.test.TempFileUtils;
+import org.javarosa.xform.parse.ExternalInstanceParser;
+import org.javarosa.xform.parse.ExternalInstanceParserFactory;
+import org.javarosa.xform.parse.XFormParser;
+import org.javarosa.xform.util.XFormUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.javarosa.core.reference.ReferenceManagerTestUtils.setUpSimpleReferenceManager;
+import static org.javarosa.test.BindBuilderXFormsElement.bind;
+import static org.javarosa.test.XFormsElement.body;
+import static org.javarosa.test.XFormsElement.head;
+import static org.javarosa.test.XFormsElement.html;
+import static org.javarosa.test.XFormsElement.mainInstance;
+import static org.javarosa.test.XFormsElement.model;
+import static org.javarosa.test.XFormsElement.select1Dynamic;
+import static org.javarosa.test.XFormsElement.t;
+import static org.javarosa.test.XFormsElement.title;
+
+public class InstancePluginTest {
+
+    private final SwitchableExternalInstanceParserFactory externalInstanceParserFactory = new SwitchableExternalInstanceParserFactory();
+
+    @Before
+    public void setup() {
+        XFormUtils.setExternalInstanceParserFactory(externalInstanceParserFactory);
+    }
+
+    @After
+    public void teardown() {
+        XFormUtils.setExternalInstanceParserFactory(ExternalInstanceParser::new);
+    }
+
+    @Test
+    public void supportsPartialElements() throws IOException, XFormParser.ParseException {
+        externalInstanceParserFactory.setFileInstanceParser(new FakeFileInstanceParser(asList(
+            new Pair<>("0", "Item 0"),
+            new Pair<>("1", "Item 1")
+        ), true));
+
+        File tempFile = TempFileUtils.createTempFile("fake-instance", "fake");
+        setUpSimpleReferenceManager(tempFile, "file-csv", "file");
+
+        Scenario scenario = Scenario.init("Fake instance form", html(
+                head(
+                    title("Fake instance form"),
+                    model(
+                        mainInstance(
+                            t("data id=\"fake-instance-form\"",
+                                t("question")
+                            )
+                        ),
+                        t("instance id=\"fake-instance\" src=\"jr://file-csv/fake-instance.fake\""),
+                        bind("/data/question").type("string")
+                    )
+                ),
+                body(
+                    select1Dynamic("/data/question", "instance('fake-instance')/root/item")
+                )
+            )
+        );
+
+        HashMap<String, DataInstance> instances = scenario.getFormDef().getFormInstances();
+        DataInstance fakeInstance = instances.get("fake-instance");
+        assertThat(fakeInstance.getRoot().getNumChildren(), equalTo(2));
+
+        TreeElement firstItem = (TreeElement) fakeInstance.getRoot().getChild("item", 0);
+        assertThat(firstItem.isPartial(), equalTo(true));
+        assertThat(firstItem.getNumChildren(), equalTo(2));
+        assertThat(firstItem.getChildAt(0).getName(), equalTo("value"));
+        assertThat(firstItem.getChildAt(0).getValue(), equalTo(null));
+        assertThat(firstItem.getChildAt(1).getName(), equalTo("label"));
+        assertThat(firstItem.getChildAt(1).getValue(), equalTo(null));
+
+        List<SelectChoice> selectChoices = scenario.choicesOf("/data/question");
+        assertThat(selectChoices.size(), equalTo(2));
+
+        assertThat(selectChoices.get(0).getValue(), equalTo("0"));
+        firstItem = (TreeElement) fakeInstance.getRoot().getChild("item", 0);
+        assertThat(firstItem.isPartial(), equalTo(false));
+        assertThat(firstItem.getNumChildren(), equalTo(2));
+        assertThat(firstItem.getChildAt(0).getName(), equalTo("value"));
+        assertThat(firstItem.getChildAt(0).getValue(), equalTo(new StringData("0")));
+        assertThat(firstItem.getChildAt(1).getName(), equalTo("label"));
+        assertThat(firstItem.getChildAt(1).getValue(), equalTo(new StringData("Item 0")));
+    }
+
+    @Test
+    public void supportsReplacingPartialElements() throws IOException, XFormParser.ParseException {
+        externalInstanceParserFactory.setFileInstanceParser(new FakeFileInstanceParser(asList(
+            new Pair<>("0", "Item 0"),
+            new Pair<>("1", "Item 1")
+        ), true));
+
+        File tempFile = TempFileUtils.createTempFile("fake-instance", "fake");
+        setUpSimpleReferenceManager(tempFile, "file-csv", "file");
+
+        Scenario scenario = Scenario.init("Fake instance form", html(
+                head(
+                    title("Fake instance form"),
+                    model(
+                        mainInstance(
+                            t("data id=\"fake-instance-form\"",
+                                t("question")
+                            )
+                        ),
+                        t("instance id=\"fake-instance\" src=\"jr://file-csv/fake-instance.fake\""),
+                        bind("/data/question").type("string")
+                    )
+                ),
+                body(
+                    select1Dynamic("/data/question", "instance('fake-instance')/root/item")
+                )
+            )
+        );
+
+        HashMap<String, DataInstance> instances = scenario.getFormDef().getFormInstances();
+        DataInstance fakeInstance = instances.get("fake-instance");
+
+        TreeElement item = new TreeElement("item", 0);
+        TreeElement value = new TreeElement("value");
+        TreeElement label = new TreeElement("label");
+        value.setValue(new StringData("0"));
+        label.setValue(new StringData("Item 0"));
+        item.addChild(value);
+        item.addChild(label);
+        fakeInstance.replacePartialElements(asList(item));
+
+        TreeElement firstItem = (TreeElement) fakeInstance.getRoot().getChild("item", 0);
+        assertThat(firstItem.isPartial(), equalTo(false));
+        assertThat(firstItem.getNumChildren(), equalTo(2));
+        assertThat(firstItem.getChildAt(0).getName(), equalTo("value"));
+        assertThat(firstItem.getChildAt(0).getValue(), equalTo(new StringData("0")));
+        assertThat(firstItem.getChildAt(1).getName(), equalTo("label"));
+        assertThat(firstItem.getChildAt(1).getValue(), equalTo(new StringData("Item 0")));
+        TreeElement secondItem = (TreeElement) fakeInstance.getRoot().getChild("item", 1);
+        assertThat(secondItem.isPartial(), equalTo(true));
+        assertThat(secondItem.getNumChildren(), equalTo(2));
+        assertThat(secondItem.getChildAt(0).getName(), equalTo("value"));
+        assertThat(secondItem.getChildAt(0).getValue(), equalTo(null));
+        assertThat(secondItem.getChildAt(1).getName(), equalTo("label"));
+        assertThat(secondItem.getChildAt(1).getValue(), equalTo(null));
+    }
+
+    @Test
+    public void replacePartialElements_DoesNotOverrideNonPartialElements() throws IOException, XFormParser.ParseException {
+        externalInstanceParserFactory.setFileInstanceParser(new FakeFileInstanceParser(asList(
+            new Pair<>("0", "Item 0")
+        ), false));
+
+        File tempFile = TempFileUtils.createTempFile("fake-instance", "fake");
+        setUpSimpleReferenceManager(tempFile, "file-csv", "file");
+
+        Scenario scenario = Scenario.init("Fake instance form", html(
+                head(
+                    title("Fake instance form"),
+                    model(
+                        mainInstance(
+                            t("data id=\"fake-instance-form\"",
+                                t("question")
+                            )
+                        ),
+                        t("instance id=\"fake-instance\" src=\"jr://file-csv/fake-instance.fake\""),
+                        bind("/data/question").type("string")
+                    )
+                ),
+                body(
+                    select1Dynamic("/data/question", "instance('fake-instance')/root/item")
+                )
+            )
+        );
+
+        HashMap<String, DataInstance> instances = scenario.getFormDef().getFormInstances();
+        DataInstance fakeInstance = instances.get("fake-instance");
+
+        TreeElement item = new TreeElement("item", 0);
+        TreeElement value = new TreeElement("value");
+        TreeElement label = new TreeElement("label");
+        value.setValue(new StringData("1"));
+        label.setValue(new StringData("Item 1"));
+        item.addChild(value);
+        item.addChild(label);
+        fakeInstance.replacePartialElements(asList(item));
+
+        TreeElement firstItem = (TreeElement) fakeInstance.getRoot().getChild("item", 0);
+        assertThat(firstItem.isPartial(), equalTo(false));
+        assertThat(firstItem.getNumChildren(), equalTo(2));
+        assertThat(firstItem.getChildAt(0).getName(), equalTo("value"));
+        assertThat(firstItem.getChildAt(0).getValue(), equalTo(new StringData("0")));
+        assertThat(firstItem.getChildAt(1).getName(), equalTo("label"));
+        assertThat(firstItem.getChildAt(1).getValue(), equalTo(new StringData("Item 0")));
+    }
+
+    private static class SwitchableExternalInstanceParserFactory implements ExternalInstanceParserFactory {
+        private ExternalInstanceParser.FileInstanceParser fileInstanceParser;
+
+        @Override
+        public ExternalInstanceParser getExternalInstanceParser() {
+            ExternalInstanceParser externalInstanceParser = new ExternalInstanceParser();
+            externalInstanceParser.addFileInstanceParser(fileInstanceParser);
+            return externalInstanceParser;
+        }
+
+        public void setFileInstanceParser(ExternalInstanceParser.FileInstanceParser fileInstanceParser) {
+            this.fileInstanceParser = fileInstanceParser;
+        }
+    }
+
+    public static class FakeFileInstanceParser implements ExternalInstanceParser.FileInstanceParser {
+
+        private final List<Pair<String, String>> items;
+        private final boolean partialParse;
+
+        public FakeFileInstanceParser(List<Pair<String, String>> items, boolean partialParse) {
+            this.items = items;
+            this.partialParse = partialParse;
+        }
+
+        @Override
+        public TreeElement parse(@NotNull String instanceId, @NotNull String path) throws IOException {
+            return parse(instanceId, path, false);
+        }
+
+        @Override
+        public TreeElement parse(@NotNull String instanceId, @NotNull String path, boolean partial) throws IOException {
+            boolean isPartial = partialParse && partial;
+            TreeElement root = new TreeElement("root", 0);
+
+            for (int i = 0; i < items.size(); i++) {
+                TreeElement value = new TreeElement("value");
+                TreeElement label = new TreeElement("label");
+
+                if (!isPartial) {
+                    value.setValue(new StringData(items.get(i).getFirst()));
+                    label.setValue(new StringData(items.get(i).getSecond()));
+                }
+
+                TreeElement item = new TreeElement("item", i, isPartial);
+                item.addChild(value);
+                item.addChild(label);
+
+                root.addChild(item);
+            }
+
+            return root;
+        }
+
+        @Override
+        public boolean isSupported(String instanceId, String instanceSrc) {
+            return instanceSrc.endsWith(".fake");
+        }
+    }
+}


### PR DESCRIPTION
Work towards https://github.com/getodk/collect/issues/5623

This adds the ability to provide "partial" parses of external instances using a custom `FileInstanceParser`:


```java
class MyFileInstanceParser implements ExternalInstanceParser.FileInstanceParser {

        @Override
        public TreeElement parse(@NotNull String instanceId, @NotNull String path) throws IOException {
            return parse(instanceId, path, false);
        }

        @Override
        public TreeElement parse(@NotNull String instanceId, @NotNull String path, boolean partial) throws IOException {
            TreeElement root = new TreeElement("root", 0);

            TreeElement value = new TreeElement("value");
            TreeElement label = new TreeElement("label");

            if (!partial) {
                value.setValue(new StringData("blah"));
                label.setValue(new StringData("Blah"));
            }

            TreeElement item = new TreeElement("item", 0, partial);
            item.addChild(value);
            item.addChild(label);

            root.addChild(item);
        }
}
```

JavaRosa will allow partial parses for parsing/deserializing forms (by passing `partial` as `true`), but will require a "full" parse (`partial` as `false`) if it needs to resolve a reference currently involving a partial `TreeElement`. 

Clients can also populate partial elements at an instance level by calling `DataInstance#populatePartialElements`. This will allow plugins to populate partials before they are resolved to avoid full parses (from a `FilterStrategy` for example).

#### What has been done to verify that this works as intended?

New tests. I've also built a toy implementation in Collect to validate that the API feels correct.

#### Why is this the best possible solution? Were any other approaches considered?

There's a few different approaches that I've discussed in different chats and also in https://github.com/getodk/collect/issues/5623 (like fallbacks for individual elements rather than full parses for example). This approach has ended up winning out, so unless there's anything that feels incorrect here I don't think there's that much that needs to be pointed out.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There should be very little risk here as the new code will only kick in if "activated" by a client. The big risk is that there's some edge case I've missed that we'll run into down the road when adding in these new features.
