### PR TITLE
Add indexed-repeat tests

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -970,15 +970,15 @@ public class XPathFuncExpr extends XPathExpression {
     }
 
     /**
-     * This provides a method of indexing fields stored in prior repeat groups.
+     * Provides a method of indexing fields stored in a repeat without writing an XPath filter expression.
      * <p>
-     * args[0] = generic XPath expression to index
-     * args[1] = generic XPath expression for group to index
-     * args[2] = index number for group
-     * args[3] = generic XPath expression for add'l group to index (if 5 or 7 parameters passed)
-     * args[4] = index number for group (if 5 or 7 parameters passed)
-     * args[5] = generic XPath expression for add'l group to index (if 7 parameters passed)
-     * args[6] = index number for group (if 7 parameters passed)
+     * args[0] = reference to a field inside one or more repeats
+     * args[1] = generic XPath expression for repeat to index
+     * args[2] = index number for repeat instance
+     * args[3] = generic XPath expression for add'l repeat to index (if 5 or 7 parameters passed)
+     * args[4] = index number for repeat (if 5 or 7 parameters passed)
+     * args[5] = generic XPath expression for add'l repeat to index (if 7 parameters passed)
+     * args[6] = index number for repeat (if 7 parameters passed)
      */
     public static Object indexedRepeat(DataInstance model, EvaluationContext ec, XPathExpression[] args, Object[] argVals) throws XPathTypeMismatchException {
         // initialize target and context references
@@ -994,7 +994,7 @@ public class XPathFuncExpr extends XPathExpression {
         for (int pathargi = 1, idxargi = 2; idxargi < args.length; pathargi += 2, idxargi += 2) {
             // confirm that we were passed an XPath
             if (!(args[pathargi] instanceof XPathPathExpr)) {
-                throw new XPathTypeMismatchException("indexed-repeat(): parameter " + (pathargi + 1) + " must be XPath repeat-group reference");
+                throw new XPathTypeMismatchException("indexed-repeat(): parameter " + (pathargi + 1) + " must be a reference to a repeat");
             }
             // confirm that the passed XPath is a parent of our overall target path
             // Ensure we can deal with relative group refs by contextualizing with the EC's context ref

--- a/src/test/java/org/javarosa/xpath/expr/IndexedRepeatTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/IndexedRepeatTest.java
@@ -1,8 +1,12 @@
 package org.javarosa.xpath.expr;
 
+import org.javarosa.test.Scenario;
+import org.javarosa.xpath.XPathTypeMismatchException;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
 import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
 import static org.javarosa.test.BindBuilderXFormsElement.bind;
 import static org.javarosa.test.XFormsElement.body;
@@ -16,10 +20,6 @@ import static org.javarosa.test.XFormsElement.repeat;
 import static org.javarosa.test.XFormsElement.t;
 import static org.javarosa.test.XFormsElement.title;
 import static org.junit.Assert.fail;
-
-import org.javarosa.test.Scenario;
-import org.javarosa.xpath.XPathTypeMismatchException;
-import org.junit.Test;
 
 public class IndexedRepeatTest {
     @Test
@@ -35,7 +35,7 @@ public class IndexedRepeatTest {
                                 t("inside")),
                             t("calc")
                         )),
-                        bind("calc").calculate("indexed-repeat(/data/outside, /data/repeat, 1)")
+                        bind("/data/calc").calculate("indexed-repeat(/data/outside, /data/repeat, 1)")
                     )
                 ),
                 body(
@@ -113,7 +113,7 @@ public class IndexedRepeatTest {
                     input("/data/repeat1/inside1")),
 
                 repeat("/data/repeat2",
-                    input("/data/repeat2"))
+                    input("/data/repeat2/inside2"))
             ))
         );
 

--- a/src/test/java/org/javarosa/xpath/expr/IndexedRepeatTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/IndexedRepeatTest.java
@@ -1,0 +1,132 @@
+package org.javarosa.xpath.expr;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
+import static org.javarosa.test.BindBuilderXFormsElement.bind;
+import static org.javarosa.test.XFormsElement.body;
+import static org.javarosa.test.XFormsElement.head;
+import static org.javarosa.test.XFormsElement.html;
+import static org.javarosa.test.XFormsElement.input;
+import static org.javarosa.test.XFormsElement.mainInstance;
+import static org.javarosa.test.XFormsElement.model;
+import static org.javarosa.test.XFormsElement.repeat;
+import static org.javarosa.test.XFormsElement.t;
+import static org.javarosa.test.XFormsElement.title;
+import static org.junit.Assert.fail;
+
+import org.javarosa.test.Scenario;
+import org.javarosa.xpath.XPathTypeMismatchException;
+import org.junit.Test;
+
+public class IndexedRepeatTest {
+    @Test
+    public void firstArgNotChildOfRepeat_throwsException() throws Exception {
+        try {
+            Scenario.init("indexed-repeat", html(
+                head(
+                    title("indexed-repeat"),
+                    model(
+                        mainInstance(t("data id=\"indexed-repeat\"",
+                            t("outside"),
+                            t("repeat",
+                                t("inside")),
+                            t("calc")
+                        )),
+                        bind("calc").calculate("indexed-repeat(/data/outside, /data/repeat, 1)")
+                    )
+                ),
+                body(
+                    input("/data/outside"),
+                    repeat("/data/repeat",
+                        input("/data/repeat/inside"))
+                ))
+            );
+
+            fail("RuntimeException caused by XPathTypeMismatchException expected");
+        } catch (RuntimeException e) {
+            assertThat(e.getCause(), instanceOf(XPathTypeMismatchException.class));
+        }
+    }
+
+    @Test
+    public void getsIndexedValueInSingleRepeat() throws Exception {
+        Scenario scenario = Scenario.init("indexed-repeat", html(
+            head(
+                title("indexed-repeat"),
+                model(
+                    mainInstance(t("data id=\"indexed-repeat\"",
+                        t("index"),
+                        t("repeat",
+                            t("inside")),
+                        t("calc")
+                    )),
+                    bind("/data/calc").calculate("indexed-repeat(/data/repeat/inside, /data/repeat, /data/index)")
+                )
+            ),
+            body(
+                input("/data/index"),
+                repeat("/data/repeat",
+                    input("/data/repeat/inside"))
+            ))
+        );
+
+        scenario.createNewRepeat("/data/repeat");
+        scenario.answer("/data/repeat[1]/inside", "index1");
+
+        scenario.createNewRepeat("/data/repeat");
+        scenario.answer("/data/repeat[2]/inside", "index2");
+
+        scenario.createNewRepeat("/data/repeat");
+        scenario.answer("/data/repeat[3]/inside", "index3");
+
+        scenario.answer("/data/index", "2");
+        assertThat(scenario.answerOf("/data/calc"), is(stringAnswer("index2")));
+
+        scenario.answer("/data/index", "1");
+        assertThat(scenario.answerOf("/data/calc"), is(stringAnswer("index1")));
+    }
+
+    @Test
+    public void getsIndexedValueUsingParallelRepeatPosition() throws Exception {
+        Scenario scenario = Scenario.init("indexed-repeat", html(
+            head(
+                title("indexed-repeat"),
+                model(
+                    mainInstance(t("data id=\"indexed-repeat\"",
+                        t("repeat1",
+                            t("inside1")),
+
+                        t("repeat2",
+                            t("inside2"),
+                            t("from_repeat1"))
+                    )),
+                    bind("/data/repeat2/from_repeat1").calculate("indexed-repeat(/data/repeat1/inside1, /data/repeat1, position(..))")
+                )
+            ),
+            body(
+                repeat("/data/repeat1",
+                    input("/data/repeat1/inside1")),
+
+                repeat("/data/repeat2",
+                    input("/data/repeat2"))
+            ))
+        );
+
+        scenario.createNewRepeat("/data/repeat1");
+        scenario.createNewRepeat("/data/repeat2");
+        scenario.answer("/data/repeat1[1]/inside1", "index1");
+
+        scenario.createNewRepeat("/data/repeat1");
+        scenario.createNewRepeat("/data/repeat2");
+        scenario.answer("/data/repeat1[2]/inside1", "index2");
+
+        scenario.createNewRepeat("/data/repeat1");
+        scenario.createNewRepeat("/data/repeat2");
+        scenario.answer("/data/repeat1[3]/inside1", "index3");
+
+        assertThat(scenario.answerOf("/data/repeat2[1]/from_repeat1"), is(stringAnswer("index1")));
+        assertThat(scenario.answerOf("/data/repeat2[2]/from_repeat1"), is(stringAnswer("index2")));
+    }
+}

--- a/src/test/java/org/javarosa/xpath/expr/IndexedRepeatTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/IndexedRepeatTest.java
@@ -1,8 +1,11 @@
 package org.javarosa.xpath.expr;
 
 import org.javarosa.test.Scenario;
+import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.junit.Test;
+
+import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -131,5 +134,146 @@ public class IndexedRepeatTest {
 
         assertThat(scenario.answerOf("/data/repeat2[1]/from_repeat1"), is(stringAnswer("index1")));
         assertThat(scenario.answerOf("/data/repeat2[2]/from_repeat1"), is(stringAnswer("index2")));
+    }
+
+    @Test
+    public void handlesTopLevelRepeats() throws IOException, XFormParser.ParseException {
+        Scenario scenario = buildNestedRepeatForm();
+        assertThat(scenario.answerOf("/data/r2-d1[1]/from-r1-d1"), is(stringAnswer("[1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/from-r1-d1"), is(stringAnswer("[2]")));
+    }
+
+    @Test
+    public void handlesRepeatsTwoDeep() throws IOException, XFormParser.ParseException {
+        Scenario scenario = buildNestedRepeatForm();
+
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[1]/from-r1-d2-a"), is(stringAnswer("[1][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[2]/from-r1-d2-a"), is(stringAnswer("[1][2]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[1]/from-r1-d2-a"), is(stringAnswer("[2][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[2]/from-r1-d2-a"), is(stringAnswer("[2][2]")));
+
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[1]/from-r1-d2-b"), is(stringAnswer("[1][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[2]/from-r1-d2-b"), is(stringAnswer("[1][2]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[1]/from-r1-d2-b"), is(stringAnswer("[2][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[2]/from-r1-d2-b"), is(stringAnswer("[2][2]")));
+    }
+
+    @Test
+    public void handlesRepeatsThreeDeep() throws IOException, XFormParser.ParseException {
+        Scenario scenario = buildNestedRepeatForm();
+
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[1]/r2-d3[1]/from-r1-d3-a"), is(stringAnswer("[1][1][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[1]/r2-d3[2]/from-r1-d3-a"), is(stringAnswer("[1][1][2]")));
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[2]/r2-d3[1]/from-r1-d3-a"), is(stringAnswer("[1][2][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[2]/r2-d3[2]/from-r1-d3-a"), is(stringAnswer("[1][2][2]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[1]/r2-d3[1]/from-r1-d3-a"), is(stringAnswer("[2][1][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[1]/r2-d3[2]/from-r1-d3-a"), is(stringAnswer("[2][1][2]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[2]/r2-d3[1]/from-r1-d3-a"), is(stringAnswer("[2][2][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[2]/r2-d3[2]/from-r1-d3-a"), is(stringAnswer("[2][2][2]")));
+
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[1]/r2-d3[1]/from-r1-d3-b"), is(stringAnswer("[1][1][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[1]/r2-d3[2]/from-r1-d3-b"), is(stringAnswer("[1][1][2]")));
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[2]/r2-d3[1]/from-r1-d3-b"), is(stringAnswer("[1][2][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[1]/r2-d2[2]/r2-d3[2]/from-r1-d3-b"), is(stringAnswer("[1][2][2]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[1]/r2-d3[1]/from-r1-d3-b"), is(stringAnswer("[2][1][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[1]/r2-d3[2]/from-r1-d3-b"), is(stringAnswer("[2][1][2]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[2]/r2-d3[1]/from-r1-d3-b"), is(stringAnswer("[2][2][1]")));
+        assertThat(scenario.answerOf("/data/r2-d1[2]/r2-d2[2]/r2-d3[2]/from-r1-d3-b"), is(stringAnswer("[2][2][2]")));
+    }
+
+    public static Scenario buildNestedRepeatForm() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("indexed-repeat", html(
+            head(
+                title("indexed-repeat"),
+                model(
+                    mainInstance(t("data id=\"indexed-repeat\"",
+                        t("r1-d1 jr:template=\"\"",
+                            t("inside-r1-d1"),
+                            t("r1-d2 jr:template=\"\"",
+                                t("inside-r1-d2"),
+                                t("r1-d3 jr:template=\"\"",
+                                    t("inside-r1-d3")))),
+                        t("r2-d1 jr:template=\"\"",
+                            t("inside-r2-d1"),
+                            t("from-r1-d1"),
+                            t("r2-d2 jr:template=\"\"",
+                                t("inside-r2-d2"),
+                                t("from-r1-d2-a"),
+                                t("from-r1-d2-b"),
+                                t("r2-d3 jr:template=\"\"",
+                                    t("inside-r2-d3"),
+                                    t("from-r1-d3-a"),
+                                    t("from-r1-d3-b"))))
+                    )),
+                    bind("/data/r1-d1/inside-r1-d1")
+                        .calculate("concat('[', position(..), ']')"),
+                    bind("/data/r1-d1/r1-d2/inside-r1-d2")
+                        .calculate("concat('[', position(../..), ']', '[', position(..), ']')"),
+                    bind("/data/r1-d1/r1-d2/r1-d3/inside-r1-d3")
+                        .calculate("concat('[', position(../../..), ']', '[', position(../..), ']', '[', position(..), ']')"),
+                    bind("/data/r2-d1/from-r1-d1")
+                        .calculate("indexed-repeat(/data/r1-d1/inside-r1-d1, /data/r1-d1, position(..))"),
+                    bind("/data/r2-d1/r2-d2/from-r1-d2-a")
+                        .calculate("indexed-repeat(/data/r1-d1/r1-d2/inside-r1-d2, /data/r1-d1, position(../..), /data/r1-d1/r1-d2, position(..))"),
+                    bind("/data/r2-d1/r2-d2/from-r1-d2-b")
+                        // Same as from-r1-d2-a with the repeatN/indexN pairs swapped
+                        .calculate("indexed-repeat(/data/r1-d1/r1-d2/inside-r1-d2, /data/r1-d1/r1-d2, position(..), /data/r1-d1, position(../..))"),
+                    bind("/data/r2-d1/r2-d2/r2-d3/from-r1-d3-a")
+                        .calculate("indexed-repeat(/data/r1-d1/r1-d2/r1-d3/inside-r1-d3, /data/r1-d1, position(../../..), /data/r1-d1/r1-d2, position(../..), /data/r1-d1/r1-d2/r1-d3, position(..))"),
+                    bind("/data/r2-d1/r2-d2/r2-d3/from-r1-d3-b")
+                        // Same as from-r1-d3-a with the repeatN/indexN pairs reordered
+                        .calculate("indexed-repeat(/data/r1-d1/r1-d2/r1-d3/inside-r1-d3, /data/r1-d1/r1-d2, position(../..), /data/r1-d1, position(../../..), /data/r1-d1/r1-d2/r1-d3, position(..))")
+                )
+            ),
+            body(
+                repeat("/data/r1-d1",
+                    input("/data/r1-d1/inside-r1-d1"),
+                    repeat("/data/r1-d1/r1-d2",
+                        input("/data/r1-d1/r1-d2/inside-r1-d2"),
+                        repeat("/data/r1-d1/r1-d2/r1-d3",
+                            input("/data/r1-d1/r1-d2/r1-d3/inside-r1-d3")))),
+                repeat("/data/r2-d1",
+                    input("/data/r2-d1/inside-r2-d1"),
+                    repeat("/data/r2-d1/r2-d2",
+                        input("/data/r2-d1/r2-d2/inside-r2-d2"),
+                        repeat("/data/r2-d1/r2-d2/r2-d3",
+                            input("/data/r2-d1/r2-d2/r2-d3/inside-r2-d3"))))
+            )));
+
+        scenario.createNewRepeat("/data/r1-d1");
+        scenario.createNewRepeat("/data/r1-d1");
+
+        scenario.createNewRepeat("/data/r1-d1[1]/r1-d2");
+        scenario.createNewRepeat("/data/r1-d1[1]/r1-d2");
+        scenario.createNewRepeat("/data/r1-d1[2]/r1-d2");
+        scenario.createNewRepeat("/data/r1-d1[2]/r1-d2");
+
+        scenario.createNewRepeat("/data/r1-d1[1]/r1-d2[1]/r1-d3");
+        scenario.createNewRepeat("/data/r1-d1[1]/r1-d2[1]/r1-d3");
+        scenario.createNewRepeat("/data/r1-d1[1]/r1-d2[2]/r1-d3");
+        scenario.createNewRepeat("/data/r1-d1[1]/r1-d2[2]/r1-d3");
+        scenario.createNewRepeat("/data/r1-d1[2]/r1-d2[1]/r1-d3");
+        scenario.createNewRepeat("/data/r1-d1[2]/r1-d2[1]/r1-d3");
+        scenario.createNewRepeat("/data/r1-d1[2]/r1-d2[2]/r1-d3");
+        scenario.createNewRepeat("/data/r1-d1[2]/r1-d2[2]/r1-d3");
+
+        scenario.createNewRepeat("/data/r2-d1");
+        scenario.createNewRepeat("/data/r2-d1");
+
+        scenario.createNewRepeat("/data/r2-d1[1]/r2-d2");
+        scenario.createNewRepeat("/data/r2-d1[1]/r2-d2");
+        scenario.createNewRepeat("/data/r2-d1[2]/r2-d2");
+        scenario.createNewRepeat("/data/r2-d1[2]/r2-d2");
+
+        scenario.createNewRepeat("/data/r2-d1[1]/r2-d2[1]/r2-d3");
+        scenario.createNewRepeat("/data/r2-d1[1]/r2-d2[1]/r2-d3");
+        scenario.createNewRepeat("/data/r2-d1[1]/r2-d2[2]/r2-d3");
+        scenario.createNewRepeat("/data/r2-d1[1]/r2-d2[2]/r2-d3");
+        scenario.createNewRepeat("/data/r2-d1[2]/r2-d2[1]/r2-d3");
+        scenario.createNewRepeat("/data/r2-d1[2]/r2-d2[1]/r2-d3");
+        scenario.createNewRepeat("/data/r2-d1[2]/r2-d2[2]/r2-d3");
+        scenario.createNewRepeat("/data/r2-d1[2]/r2-d2[2]/r2-d3");
+
+        return scenario;
     }
 }

--- a/src/test/java/org/javarosa/xpath/expr/IndexedRepeatTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/IndexedRepeatTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.javarosa.core.test.AnswerDataMatchers.stringAnswer;
 import static org.javarosa.test.BindBuilderXFormsElement.bind;
 import static org.javarosa.test.XFormsElement.body;
+import static org.javarosa.test.XFormsElement.group;
 import static org.javarosa.test.XFormsElement.head;
 import static org.javarosa.test.XFormsElement.html;
 import static org.javarosa.test.XFormsElement.input;
@@ -58,28 +59,30 @@ public class IndexedRepeatTest {
                 model(
                     mainInstance(t("data id=\"indexed-repeat\"",
                         t("index"),
-                        t("repeat",
-                            t("inside")),
+                        t("outer_group", // included to clarify intended evaluation context for index references
+                            t("repeat",
+                                t("inside"))),
                         t("calc")
                     )),
-                    bind("/data/calc").calculate("indexed-repeat(/data/repeat/inside, /data/repeat, /data/index)")
+                    bind("/data/calc").calculate("indexed-repeat(/data/outer_group/repeat/inside, /data/outer_group/repeat, ../index)")
                 )
             ),
             body(
                 input("/data/index"),
-                repeat("/data/repeat",
-                    input("/data/repeat/inside"))
+                group("/data/outer_group",
+                    repeat("/data/outer_group/repeat",
+                        input("/data/outer_group/repeat/inside")))
             ))
         );
 
-        scenario.createNewRepeat("/data/repeat");
-        scenario.answer("/data/repeat[1]/inside", "index1");
+        scenario.createNewRepeat("/data/outer_group[1]/repeat");
+        scenario.answer("/data/outer_group[1]/repeat[1]/inside", "index1");
 
-        scenario.createNewRepeat("/data/repeat");
-        scenario.answer("/data/repeat[2]/inside", "index2");
+        scenario.createNewRepeat("/data/outer_group[1]/repeat");
+        scenario.answer("/data/outer_group[1]/repeat[2]/inside", "index2");
 
-        scenario.createNewRepeat("/data/repeat");
-        scenario.answer("/data/repeat[3]/inside", "index3");
+        scenario.createNewRepeat("/data/outer_group[1]/repeat");
+        scenario.answer("/data/outer_group[1]/repeat[3]/inside", "index3");
 
         scenario.answer("/data/index", "2");
         assertThat(scenario.answerOf("/data/calc"), is(stringAnswer("index2")));


### PR DESCRIPTION
- [x] Modify first test to use a relative reference for index and add a group around the repeat so the contextualization is clear
- [x] Add nested repeat tests
       https://github.com/getodk/web-forms/pull/195/commits/541cd1200818c3024eb98a5aa973dc6142acfecd#diff-d7f5e2a9fa88fc71566d393928de170be5700174a890bc68e5195a4f8c6e1657R335
- [x] Demonstrate that the order of the repeat/index pairs doesn't matter (included in nested repeat test above)
- [x] Multiple repeat/index pairs where the repeat refs are relative (existing in `IndexedRepeatRelativeRefsTest`)

#### What has been done to verify that this works as intended?
These are test-only additions intended to capture the intended `indexed-repeat` behavior. It also updates the function's comment to better reflect the language that we use these days to talk about repeats.

I wasn't there when the function was added by my understanding is that it was introduced so end users wouldn't have to write XPath predicates in the common case where they want to use a numeric index to access a specific repeat instance's value. XPath predicates are harder to reason about because the predicate expression is evaluated in the context of the path that's being filtered. It's particularly baffling when using parallel repeats because you end up having to write something like `position(.) = position(current()/..)`.

The `indexed-repeat` function makes it so the index expression is evaluated using the bound node's context which is intuitive to users. The first parameter is the full reference to a field that needs to get indexed, and then there are some number of pairs of repeat references and indexes.

A simple algorithm to think about the intended behavior (not exactly what JR does):
- contextualize all the parameters based on the single node binding
- evaluate all the index parameters (param 3, 5, 7, etc), these should now be literal integers
- for each repeat reference parameter (param 2, 4, 6, etc), add a positional predicate at that reference level in the base reference (param 1)

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
