### PR TITLE
Fix interaction between function and filter plugins

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -28,3 +28,17 @@ Inspect external instances (their ID and parsed XML) after parsing or provide cu
 - `ExternalInstanceParser#addFileInstanceParser`
 
 The default `ExternalInstanceParser` can be overridden by creating an implementation of `ExternalInstanceParserFactory` and calling `XFormUtils.setExternalInstanceParserFactory` with it.
+
+## Function
+
+Add custom functions that can be called from XPath.
+
+### API
+- `FormEntryController#addFunctionHandler`
+
+## Predicate evaluation
+
+Add custom strategies for filtering nodes for predicate expressions.
+
+### API
+- `FormEntryController#addFilterStrategy`

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -166,6 +166,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     private final FilterStrategy comparisonExpressionCacheFilterStrategy = new ComparisonExpressionCacheFilterStrategy();
     private final FilterStrategy equalityExpressionIndexFilterStrategy = new EqualityExpressionIndexFilterStrategy();
     private final Queue<FilterStrategy> customFilterStrategies = new LinkedList<>();
+    private final List<IFunctionHandler> customFunctionHandlers = new ArrayList<>();
 
     private QuestionPreloader preloader = new QuestionPreloader();
 
@@ -836,6 +837,10 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 ).collect(Collectors.toList());
 
                 evaluationContext = new EvaluationContext(evaluationContext, filters);
+            }
+
+            for (IFunctionHandler functionHandler : customFunctionHandlers) {
+                evaluationContext.addFunctionHandler(functionHandler);
             }
         }
 
@@ -1633,6 +1638,12 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     public void addFilterStrategy(FilterStrategy filterStrategy) {
         customFilterStrategies.add(filterStrategy);
+        resetEvaluationContext();
+    }
+
+    public void addFunctionHandler(IFunctionHandler functionHandler) {
+        customFunctionHandlers.add(functionHandler);
+        resetEvaluationContext();
     }
 
     private void resetEvaluationContext() {

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -16,25 +16,6 @@
 
 package org.javarosa.core.model;
 
-import static java.util.Collections.emptyList;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Queue;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.javarosa.core.model.TriggerableDag.EventNotifierAccessor;
 import org.javarosa.core.model.actions.ActionController;
 import org.javarosa.core.model.actions.Actions;
@@ -84,6 +65,26 @@ import org.javarosa.xform.util.XFormAnswerDataSerializer;
 import org.javarosa.xml.InternalDataInstanceParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
 
 /**
  * Definition of a form. This has some meta data about the form definition and a
@@ -162,7 +163,6 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     private TriggerableDag dagImpl;
 
-    private boolean predicateCaching = true;
     private final FilterStrategy comparisonExpressionCacheFilterStrategy = new ComparisonExpressionCacheFilterStrategy();
     private final FilterStrategy equalityExpressionIndexFilterStrategy = new EqualityExpressionIndexFilterStrategy();
     private final Queue<FilterStrategy> customFilterStrategies = new LinkedList<>();
@@ -830,14 +830,12 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 evaluationContext.addFunctionHandler(new ChoiceNameFunctionHandler(this) );
             }
 
-            if (predicateCaching) {
-                List<FilterStrategy> filters = Stream.concat(
-                    customFilterStrategies.stream(),
-                    Stream.of(equalityExpressionIndexFilterStrategy, comparisonExpressionCacheFilterStrategy)
-                ).collect(Collectors.toList());
+            List<FilterStrategy> filters = Stream.concat(
+                customFilterStrategies.stream(),
+                Stream.of(equalityExpressionIndexFilterStrategy, comparisonExpressionCacheFilterStrategy)
+            ).collect(Collectors.toList());
 
-                evaluationContext = new EvaluationContext(evaluationContext, filters);
-            }
+            evaluationContext = new EvaluationContext(evaluationContext, filters);
 
             for (IFunctionHandler functionHandler : customFunctionHandlers) {
                 evaluationContext.addFunctionHandler(functionHandler);
@@ -1629,11 +1627,6 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     public Extras<Externalizable> getExtras() {
         return extras;
-    }
-
-    public void disablePredicateCaching() {
-        predicateCaching = false;
-        dagImpl.disablePredicateCaching();
     }
 
     public void addFilterStrategy(FilterStrategy filterStrategy) {

--- a/src/main/java/org/javarosa/form/api/FormEntryController.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryController.java
@@ -22,6 +22,7 @@ import org.javarosa.core.model.GroupDef;
 import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.condition.FilterStrategy;
+import org.javarosa.core.model.condition.IFunctionHandler;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.InvalidReferenceException;
 import org.javarosa.core.model.instance.TreeElement;
@@ -353,5 +354,9 @@ public class FormEntryController {
 
     public void addFilterStrategy(FilterStrategy filterStrategy) {
         model.getForm().addFilterStrategy(filterStrategy);
+    }
+
+    public void addFunctionHandler(IFunctionHandler functionHandler) {
+        model.getForm().addFunctionHandler(functionHandler);
     }
 }

--- a/src/main/java/org/javarosa/form/api/FormEntryController.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryController.java
@@ -348,10 +348,6 @@ public class FormEntryController {
         }
     }
 
-    public void disablePredicateCaching() {
-        model.getForm().disablePredicateCaching();
-    }
-
     public void addFilterStrategy(FilterStrategy filterStrategy) {
         model.getForm().addFilterStrategy(filterStrategy);
     }


### PR DESCRIPTION
Before this, it was basically impossible to add a custom filter strategy as `EvaluationContext` would get created before calls to `adFilterStrategy`. The fix for that (resetting the evaluation context when adding strategies) would then remove any previously added custom function handlers.

This change makes the API for both more consistent, and reworks function handlers to be added as part of the evaluation context recreation to avoid them being lost.