### PR TITLE
Use same initialization order in Scenario as Collect

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1629,11 +1629,20 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         return extras;
     }
 
+    /**
+     * @deprecated use {@link FormEntryController#addFilterStrategy(FilterStrategy)} instead
+     */
+    @Deprecated
     public void addFilterStrategy(FilterStrategy filterStrategy) {
         customFilterStrategies.add(filterStrategy);
         resetEvaluationContext();
     }
 
+
+    /**
+     * @deprecated use {@link FormEntryController#addFunctionHandler(IFunctionHandler)} instead
+     */
+    @Deprecated
     public void addFunctionHandler(IFunctionHandler functionHandler) {
         customFunctionHandlers.add(functionHandler);
         resetEvaluationContext();

--- a/src/main/java/org/javarosa/test/Scenario.java
+++ b/src/main/java/org/javarosa/test/Scenario.java
@@ -143,10 +143,6 @@ public class Scenario {
         this.blankInstance = blankInstance;
     }
 
-    private Scenario(FormDef formDef, EvaluationContext evaluationContext, FormInstance blankInstance) {
-        this(formDef, formDef1 -> new FormEntryController(new FormEntryModel(formDef1)), evaluationContext, blankInstance);
-    }
-
     private static Scenario from(FormDef formDef, boolean newInstance) {
         return from(formDef, newInstance, formDef1 -> new FormEntryController(new FormEntryModel(formDef1)));
     }

--- a/src/main/java/org/javarosa/test/Scenario.java
+++ b/src/main/java/org/javarosa/test/Scenario.java
@@ -145,9 +145,14 @@ public class Scenario {
     private static Scenario from(FormDef formDef, boolean newInstance) {
         FormEntryModel formEntryModel = new FormEntryModel(formDef);
         FormEntryController formEntryController = new FormEntryController(formEntryModel);
-        formDef.initialize(newInstance, new InstanceInitializationFactory());
 
-        return new Scenario(formDef, formEntryController, formEntryModel, formDef.getEvaluationContext(), formDef.getMainInstance().clone());
+        Scenario scenario = new Scenario(formDef, formEntryController, formEntryModel, formDef.getEvaluationContext(), formDef.getMainInstance().clone());
+        scenario.init(newInstance);
+        return scenario;
+    }
+
+    public void init(boolean newInstance) {
+        formDef.initialize(newInstance, new InstanceInitializationFactory());
     }
 
     // region Miscellaneous

--- a/src/main/java/org/javarosa/test/Scenario.java
+++ b/src/main/java/org/javarosa/test/Scenario.java
@@ -142,9 +142,12 @@ public class Scenario {
         this.blankInstance = blankInstance;
     }
 
-    private static Scenario from(FormDef formDef) {
+    private static Scenario from(FormDef formDef, boolean newInstance) {
         FormEntryModel formEntryModel = new FormEntryModel(formDef);
-        return new Scenario(formDef, new FormEntryController(formEntryModel), formEntryModel, formDef.getEvaluationContext(), formDef.getMainInstance().clone());
+        FormEntryController formEntryController = new FormEntryController(formEntryModel);
+        formDef.initialize(newInstance, new InstanceInitializationFactory());
+
+        return new Scenario(formDef, formEntryController, formEntryModel, formDef.getEvaluationContext(), formDef.getMainInstance().clone());
     }
 
     // region Miscellaneous
@@ -227,10 +230,10 @@ public class Scenario {
      */
     public void newInstance() {
         formDef.setInstance(blankInstance.clone());
-        formDef.initialize(true, new InstanceInitializationFactory());
-        evaluationContext = formDef.getEvaluationContext();
         model = new FormEntryModel(formDef);
         controller = new FormEntryController(model);
+        formDef.initialize(true, new InstanceInitializationFactory());
+        evaluationContext = formDef.getEvaluationContext();
     }
 
     /**
@@ -274,8 +277,7 @@ public class Scenario {
         );
 
         tempFile.delete();
-        deserializedFormDef.initialize(false, new InstanceInitializationFactory());
-        return Scenario.from(deserializedFormDef);
+        return Scenario.from(deserializedFormDef, false);
     }
 
     // The fact that we need to pass in the same raw form definition that the current scenario is built around suggests
@@ -293,9 +295,7 @@ public class Scenario {
         XFormParser parser = new XFormParser(formReader, instanceReader);
         FormDef restoredFormDef = parser.parse();
 
-        Scenario restored = Scenario.from(restoredFormDef);
-
-        return restored;
+        return Scenario.from(restoredFormDef, false);
     }
 
     /**
@@ -460,13 +460,11 @@ public class Scenario {
      */
     public static Scenario init(File formFile) throws XFormParser.ParseException {
         FormDef formDef = createFormDef(formFile);
-        formDef.initialize(true, new InstanceInitializationFactory());
-        return Scenario.from(formDef);
+        return Scenario.from(formDef, true);
     }
 
     public static Scenario init(FormDef formDef) throws XFormParser.ParseException {
-        formDef.initialize(true, new InstanceInitializationFactory());
-        return Scenario.from(formDef);
+        return Scenario.from(formDef, true);
     }
 
     @NotNull

--- a/src/main/java/org/javarosa/test/Scenario.java
+++ b/src/main/java/org/javarosa/test/Scenario.java
@@ -134,24 +134,21 @@ public class Scenario {
     private FormEntryModel model;
     private final FormInstance blankInstance;
 
-    private Scenario(FormDef formDef, FormEntryController controller, FormEntryModel model, EvaluationContext evaluationContext, FormInstance blankInstance) {
+    private Scenario(FormDef formDef, EvaluationContext evaluationContext, FormInstance blankInstance) {
         this.formDef = formDef;
-        this.controller = controller;
         this.evaluationContext = evaluationContext;
-        this.model = model;
         this.blankInstance = blankInstance;
     }
 
     private static Scenario from(FormDef formDef, boolean newInstance) {
-        FormEntryModel formEntryModel = new FormEntryModel(formDef);
-        FormEntryController formEntryController = new FormEntryController(formEntryModel);
-
-        Scenario scenario = new Scenario(formDef, formEntryController, formEntryModel, formDef.getEvaluationContext(), formDef.getMainInstance().clone());
+        Scenario scenario = new Scenario(formDef, formDef.getEvaluationContext(), formDef.getMainInstance().clone());
         scenario.init(newInstance);
         return scenario;
     }
 
     public void init(boolean newInstance) {
+        model = new FormEntryModel(formDef);
+        controller = new FormEntryController(model);
         formDef.initialize(newInstance, new InstanceInitializationFactory());
     }
 
@@ -235,9 +232,7 @@ public class Scenario {
      */
     public void newInstance() {
         formDef.setInstance(blankInstance.clone());
-        model = new FormEntryModel(formDef);
-        controller = new FormEntryController(model);
-        formDef.initialize(true, new InstanceInitializationFactory());
+        init(true);
         evaluationContext = formDef.getEvaluationContext();
     }
 


### PR DESCRIPTION
This switches the initialization order in `Scenario` to match Collect (`FormDef#initialize` is called after creating the `FormEntryController`). It also makes it possible to pass in a custom function for constructing the `FormEntryController` to allow tests to use plugins (like `#addFilterStrategy`).