### PR TITLE
Add way of providing external instances without an existing file

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -25,6 +25,7 @@ Inspect the `FormEntryModel` after finalization (or "post processing") and attac
 Inspect external instances (their ID and parsed XML) after parsing or provide custom parsers for specific instances or file types.
 
 ### API
+- `ExternalInstanceParser#addInstanceProvider`
 - `ExternalInstanceParser#addFileInstanceParser`
 
 The default `ExternalInstanceParser` can be overridden by creating an implementation of `ExternalInstanceParserFactory` and calling `XFormUtils.setExternalInstanceParserFactory` with it.

--- a/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
@@ -46,7 +46,7 @@ public class CsvExternalInstance implements ExternalInstanceParser.FileInstanceP
     }
 
     @Override
-    public boolean isSupported(String instanceId, String instanceSrc) {
+    public boolean isSupported(@NotNull String instanceId, @NotNull String instanceSrc) {
         return instanceSrc.contains("file-csv");
     }
 

--- a/src/main/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstance.java
@@ -74,7 +74,7 @@ public class GeoJsonExternalInstance implements ExternalInstanceParser.FileInsta
     }
 
     @Override
-    public boolean isSupported(String instanceId, String instanceSrc) {
+    public boolean isSupported(@NotNull String instanceId, @NotNull String instanceSrc) {
         return instanceSrc.endsWith("geojson");
     }
 }

--- a/src/main/java/org/javarosa/test/XFormsElement.java
+++ b/src/main/java/org/javarosa/test/XFormsElement.java
@@ -44,7 +44,7 @@ public interface XFormsElement {
         Map<String, String> attributes = new HashMap<>();
         String[] words = name.split(" ");
         for (String word : asList(words).subList(1, words.length)) {
-            String[] parts = word.split("(?<!\\))=(\"|')");
+            String[] parts = word.split("(?<!\\))=(\"|')", 2);
             attributes.put(parts[0], parts[1].substring(0, parts[1].length() - 1));
         }
         return attributes;

--- a/src/main/java/org/javarosa/xform/parse/ExternalInstanceParser.java
+++ b/src/main/java/org/javarosa/xform/parse/ExternalInstanceParser.java
@@ -101,10 +101,10 @@ public class ExternalInstanceParser {
     }
 
     public interface InstanceProvider {
-        TreeElement get(@NotNull String instanceId, @NotNull String path) throws IOException;
+        TreeElement get(@NotNull String instanceId, @NotNull String instanceSrc) throws IOException;
 
-        default TreeElement get(@NotNull String instanceId, @NotNull String path, boolean partial) throws IOException {
-            return get(instanceId, path);
+        default TreeElement get(@NotNull String instanceId, @NotNull String instanceSrc, boolean partial) throws IOException {
+            return get(instanceId, instanceSrc);
         }
 
         boolean isSupported(@NotNull String instanceId, @NotNull String instanceSrc);

--- a/src/test/java/org/javarosa/plugins/InstancePluginTest.java
+++ b/src/test/java/org/javarosa/plugins/InstancePluginTest.java
@@ -50,7 +50,61 @@ public class InstancePluginTest {
     }
 
     @Test
-    public void supportsPartialElements() throws IOException, XFormParser.ParseException {
+    public void instanceProvider_supportsPartialElements() throws IOException, XFormParser.ParseException {
+        externalInstanceParserFactory.setInstanceProvider(new FakeFileInstanceParser(asList(
+            new Pair<>("0", "Item 0"),
+            new Pair<>("1", "Item 1")
+        ), true));
+
+        File tempFile = TempFileUtils.createTempFile("fake-instance", "fake");
+        setUpSimpleReferenceManager(tempFile, "file-csv", "file");
+
+        Scenario scenario = Scenario.init("Fake instance form", html(
+                head(
+                    title("Fake instance form"),
+                    model(
+                        mainInstance(
+                            t("data id=\"fake-instance-form\"",
+                                t("question")
+                            )
+                        ),
+                        t("instance id=\"fake-instance\" src=\"jr://file-csv/fake-instance.fake\""),
+                        bind("/data/question").type("string")
+                    )
+                ),
+                body(
+                    select1Dynamic("/data/question", "instance('fake-instance')/root/item")
+                )
+            )
+        );
+
+        HashMap<String, DataInstance> instances = scenario.getFormDef().getFormInstances();
+        DataInstance fakeInstance = instances.get("fake-instance");
+        assertThat(fakeInstance.getRoot().getNumChildren(), equalTo(2));
+
+        TreeElement firstItem = (TreeElement) fakeInstance.getRoot().getChild("item", 0);
+        assertThat(firstItem.isPartial(), equalTo(true));
+        assertThat(firstItem.getNumChildren(), equalTo(2));
+        assertThat(firstItem.getChildAt(0).getName(), equalTo("value"));
+        assertThat(firstItem.getChildAt(0).getValue(), equalTo(null));
+        assertThat(firstItem.getChildAt(1).getName(), equalTo("label"));
+        assertThat(firstItem.getChildAt(1).getValue(), equalTo(null));
+
+        List<SelectChoice> selectChoices = scenario.choicesOf("/data/question");
+        assertThat(selectChoices.size(), equalTo(2));
+
+        assertThat(selectChoices.get(0).getValue(), equalTo("0"));
+        firstItem = (TreeElement) fakeInstance.getRoot().getChild("item", 0);
+        assertThat(firstItem.isPartial(), equalTo(false));
+        assertThat(firstItem.getNumChildren(), equalTo(2));
+        assertThat(firstItem.getChildAt(0).getName(), equalTo("value"));
+        assertThat(firstItem.getChildAt(0).getValue(), equalTo(new StringData("0")));
+        assertThat(firstItem.getChildAt(1).getName(), equalTo("label"));
+        assertThat(firstItem.getChildAt(1).getValue(), equalTo(new StringData("Item 0")));
+    }
+
+    @Test
+    public void fileInstanceParser_supportsPartialElements() throws IOException, XFormParser.ParseException {
         externalInstanceParserFactory.setFileInstanceParser(new FakeFileInstanceParser(asList(
             new Pair<>("0", "Item 0"),
             new Pair<>("1", "Item 1")
@@ -211,20 +265,33 @@ public class InstancePluginTest {
 
     private static class SwitchableExternalInstanceParserFactory implements ExternalInstanceParserFactory {
         private ExternalInstanceParser.FileInstanceParser fileInstanceParser;
+        private ExternalInstanceParser.InstanceProvider instanceProvider;
 
         @Override
         public ExternalInstanceParser getExternalInstanceParser() {
             ExternalInstanceParser externalInstanceParser = new ExternalInstanceParser();
-            externalInstanceParser.addFileInstanceParser(fileInstanceParser);
+
+            if (fileInstanceParser != null) {
+                externalInstanceParser.addFileInstanceParser(fileInstanceParser);
+            }
+
+            if (instanceProvider != null) {
+                externalInstanceParser.addInstanceProvider(instanceProvider);
+            }
+
             return externalInstanceParser;
         }
 
         public void setFileInstanceParser(ExternalInstanceParser.FileInstanceParser fileInstanceParser) {
             this.fileInstanceParser = fileInstanceParser;
         }
+
+        public void setInstanceProvider(ExternalInstanceParser.InstanceProvider instanceProvider) {
+            this.instanceProvider = instanceProvider;
+        }
     }
 
-    public static class FakeFileInstanceParser implements ExternalInstanceParser.FileInstanceParser {
+    public static class FakeFileInstanceParser implements ExternalInstanceParser.FileInstanceParser, ExternalInstanceParser.InstanceProvider {
 
         private final List<Pair<String, String>> items;
         private final boolean partialParse;
@@ -241,6 +308,25 @@ public class InstancePluginTest {
 
         @Override
         public TreeElement parse(@NotNull String instanceId, @NotNull String path, boolean partial) throws IOException {
+            return createRoot(partial);
+        }
+
+        @Override
+        public TreeElement get(@NotNull String instanceId, @NotNull String instanceSrc) throws IOException {
+            return get(instanceId, instanceSrc, false);
+        }
+
+        @Override
+        public TreeElement get(@NotNull String instanceId, @NotNull String path, boolean partial) throws IOException {
+            return createRoot(partial);
+        }
+
+        @Override
+        public boolean isSupported(@NotNull String instanceId, @NotNull String instanceSrc) {
+            return instanceSrc.endsWith(".fake");
+        }
+
+        private @NotNull TreeElement createRoot(boolean partial) {
             boolean isPartial = partialParse && partial;
             TreeElement root = new TreeElement("root", 0);
 
@@ -261,11 +347,6 @@ public class InstancePluginTest {
             }
 
             return root;
-        }
-
-        @Override
-        public boolean isSupported(@NotNull String instanceId, @NotNull String instanceSrc) {
-            return instanceSrc.endsWith(".fake");
         }
     }
 }

--- a/src/test/java/org/javarosa/plugins/InstancePluginTest.java
+++ b/src/test/java/org/javarosa/plugins/InstancePluginTest.java
@@ -264,7 +264,7 @@ public class InstancePluginTest {
         }
 
         @Override
-        public boolean isSupported(String instanceId, String instanceSrc) {
+        public boolean isSupported(@NotNull String instanceId, @NotNull String instanceSrc) {
             return instanceSrc.endsWith(".fake");
         }
     }


### PR DESCRIPTION
This adds a new interface `InstanceProvider` which can be used to provide custom instance "parsing", but without needing an actual file to be referenced by `src`. This makes it a lot easier to write tests for custom parsing (we don't need to deal with `ReferenceManager`) that don't actually care about the file in `src`, and will allow us to also provide instances without an underlying file. 

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

We alternatively could have made `FileInstanceParser` implementations handle converting `src` to an actual file path, but this would have meant changing that interface and also duplicating a bunch of code that's currently shared.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This just adds a new plugin interface, so there's not a lot of risk.
