### PR TITLE
Add commit SHA to SNAPSHOT versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         server-password: MAVEN_CENTRAL_TOKEN
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
-    - run: mvn clean deploy
+    - run: mvn -Drevision=$(git rev-parse --short HEAD) clean deploy
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -53,18 +53,6 @@ targetCompatibility = '1.8'
 sourceCompatibility = '1.8'
 
 if (!project.hasProperty("android")) {
-    jar {
-        // Be sure to update version in pom.xml to match
-        // snapshot release = x.x.x-SNAPSHOT
-        // production release = x.x.x
-        archiveVersion = '5.5.0-SNAPSHOT'
-        archiveBaseName = "javarosa"
-
-        manifest {
-            attributes 'Manifest-Version': "$jar.archiveVersion"
-        }
-    }
-
     // TODO: does not build UML diagrams
     javadoc {
         failOnError = false

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
   <groupId>org.getodk</groupId>
   <artifactId>javarosa</artifactId>
   <!-- Be sure to update version in build.gradle to match -->
-  <!-- snapshot release = x.x.x-SNAPSHOT -->
+  <!-- snapshot release = x.x.x-SNAPSHOT-${revision} -->
   <!-- production release = x.x.x -->
-  <version>5.0.0-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT-${revision}</version>
   <packaging>jar</packaging>
   <name>javarosa</name>
   <description>A Java library for rendering forms that are compliant with ODK XForms spec</description>
@@ -41,6 +41,7 @@
   </distributionManagement>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <revision/>
   </properties>
   <dependencies>
     <!-- Be sure to update dependencies in build.gradle to match -->


### PR DESCRIPTION
This means we'll end up with versions like `5.0.0-SNAPSHOT-8ad757e` which will allow clients to explicitly update rather than end up potentially getting a new version every build.

This should also allow clients to relax their caching strategies to hold versions for longer and not rely on constantly checking dependency infrastructure for new "versions" of a snapshot.

My understanding is that this approach **should** work with OSSRH, but please correct me if I'm wrong.