### PR TITLE
Close CSVParser properly and switch to record wise parsing to reduce memory use

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
@@ -24,24 +24,25 @@ public class CsvExternalInstance implements ExternalInstanceParser.FileInstanceP
             .withDelimiter(getDelimiter(path))
             .withFirstRecordAsHeader();
         Reader reader = new InputStreamReader(new BOMInputStream(new FileInputStream(path)));
-        final CSVParser csvParser = new CSVParser(reader, csvFormat);
-        final String[] fieldNames = csvParser.getHeaderMap().keySet().toArray(new String[0]);
-        int multiplicity = 0;
+        try (final CSVParser csvParser = new CSVParser(reader, csvFormat)) {
+            final String[] fieldNames = csvParser.getHeaderMap().keySet().toArray(new String[0]);
+            int multiplicity = 0;
 
-        for (CSVRecord csvRecord : csvParser.getRecords()) {
-            TreeElement item = new TreeElement("item", multiplicity);
+            for (CSVRecord csvRecord : csvParser) {
+                TreeElement item = new TreeElement("item", multiplicity);
 
-            for (int i = 0; i < fieldNames.length; ++i) {
-                TreeElement field = new TreeElement(fieldNames[i], 0);
-                field.setValue(new UncastData(i < csvRecord.size() ? csvRecord.get(i) : ""));
-                item.addChild(field);
+                for (int i = 0; i < fieldNames.length; ++i) {
+                    TreeElement field = new TreeElement(fieldNames[i], 0);
+                    field.setValue(new UncastData(i < csvRecord.size() ? csvRecord.get(i) : ""));
+                    item.addChild(field);
+                }
+
+                root.addChild(item);
+                multiplicity++;
             }
 
-            root.addChild(item);
-            multiplicity++;
+            return root;
         }
-
-        return root;
     }
 
     @Override


### PR DESCRIPTION
Does what it says on the tin! It seems like the CSV parsing code we had was using a different approach from the one we'd want for low memory (possibly to optimize for speed). It was clear from reading [the docs](https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVParser.html) that we were firstly not closing the resource properly, and secondly could be parsing files on a record-by-record basis. 

I'd initially been looking to just write up an issue for this, but then realized the changes needed were very small.

I've created a `v4.4.x` branch for this to merge into as I'm thinking that we could do a hotfix release here and a corresponding one in Collect.