### PR TITLE
jr:count value should always be coerced to number

### DIFF
--- a/src/main/java/org/javarosa/core/model/data/helper/AnswerDataUtil.java
+++ b/src/main/java/org/javarosa/core/model/data/helper/AnswerDataUtil.java
@@ -15,6 +15,13 @@ public class AnswerDataUtil {
             return (int) Math.floor((Double) count);
         } else if (count instanceof Long) {
             return (int) ((Long) count).longValue();
+        } else if (count instanceof String) {
+            try {
+                double value = Double.parseDouble((String) count);
+                return (int) Math.floor(value);
+            } catch (NumberFormatException e) {
+                return 0;
+            }
         } else {
             return 0;
         }

--- a/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
@@ -98,7 +98,7 @@ public class OdkNewRepeatEventTest {
         while (!scenario.atTheEndOfForm()) {
             scenario.next();
         }
-        assertThat(scenario.countRepeatInstancesOf("/data/my-jr-count-repeat"), is(0));
+        assertThat(scenario.countRepeatInstancesOf("/data/my-jr-count-repeat"), is(1));
 
         // Decimal
         scenario.jumpToBeginningOfForm();

--- a/src/test/java/org/javarosa/core/model/data/helper/AnswerDataUtilTest.java
+++ b/src/test/java/org/javarosa/core/model/data/helper/AnswerDataUtilTest.java
@@ -16,27 +16,64 @@ import static org.junit.Assert.assertEquals;
 public class AnswerDataUtilTest {
 
     @Test
-    public void NumericalDataReturnsProperValueWhenConvertedToInt() {
+    public void answerDataToInt_returnsCorrectValueForIntegerData() {
+        assertEquals(1, AnswerDataUtil.answerDataToInt(new IntegerData(1)));
         assertEquals(5, AnswerDataUtil.answerDataToInt(new IntegerData(5)));
-
-        assertEquals(7, AnswerDataUtil.answerDataToInt(new DecimalData(7.35)));
-
-        assertEquals(3, AnswerDataUtil.answerDataToInt(new LongData(3L)));
+        assertEquals(20, AnswerDataUtil.answerDataToInt(new IntegerData(20)));
     }
 
     @Test
-    public void NonNumericalDataReturnsZeroWhenConvertedToInt() {
-        assertEquals(0, AnswerDataUtil.answerDataToInt(new BooleanData(true)));
-        assertEquals(0, AnswerDataUtil.answerDataToInt(new SelectOneData(new Selection("Selection1"))));
-        assertEquals(0, AnswerDataUtil.answerDataToInt(new DateData(new Date())));
+    public void answerDataToInt_returnsZeroForIntegerDataIfThereIsNoValue() {
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new IntegerData()));
+    }
+
+    @Test
+    public void answerDataToInt_returnsCorrectValueForDecimalData() {
+        assertEquals(2, AnswerDataUtil.answerDataToInt(new DecimalData(2)));
+        assertEquals(7, AnswerDataUtil.answerDataToInt(new DecimalData(7.5)));
+        assertEquals(41, AnswerDataUtil.answerDataToInt(new DecimalData(41)));
+    }
+
+    @Test
+    public void answerDataToInt_returnsZeroForDecimalDataIfThereIsNoValue() {
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new DecimalData()));
+    }
+
+    @Test
+    public void answerDataToInt_returnsCorrectValueForLongData() {
+        assertEquals(4, AnswerDataUtil.answerDataToInt(new LongData(4L)));
+        assertEquals(15, AnswerDataUtil.answerDataToInt(new LongData(15L)));
+        assertEquals(120, AnswerDataUtil.answerDataToInt(new LongData(120L)));
+    }
+
+    @Test
+    public void answerDataToInt_returnsZeroForLongDataIfThereIsNoValue() {
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new LongData()));
+    }
+
+    @Test
+    public void answerDataToInt_returnsCorrectValueForStringData() {
+        assertEquals(6, AnswerDataUtil.answerDataToInt(new StringData("6")));
+        assertEquals(9, AnswerDataUtil.answerDataToInt(new StringData("9.0")));
+        assertEquals(17, AnswerDataUtil.answerDataToInt(new StringData("17")));
+        assertEquals(21, AnswerDataUtil.answerDataToInt(new StringData("21.5")));
+        assertEquals(53, AnswerDataUtil.answerDataToInt(new StringData("53")));
+    }
+
+    @Test
+    public void answerDataToInt_returnsZeroForStringDataIfThereIsNoValue() {
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new StringData()));
+    }
+
+    @Test
+    public void answerDataToInt_returnsZeroForStringDataIfTheValueCanNotBeConvertedToInteger() {
         assertEquals(0, AnswerDataUtil.answerDataToInt(new StringData("blah")));
     }
 
     @Test
-    public void IfDataTypeHasNoAnswerReturnsZeroWhenConvertedToInt() {
-        assertEquals(0, AnswerDataUtil.answerDataToInt(new IntegerData()));
-        assertEquals(0, AnswerDataUtil.answerDataToInt(new DecimalData()));
-        assertEquals(0, AnswerDataUtil.answerDataToInt(new LongData()));
-        assertEquals(0, AnswerDataUtil.answerDataToInt(new BooleanData()));
+    public void answerDataToInt_returnsZeroForNotSupportedDataTypes() {
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new BooleanData(true)));
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new SelectOneData(new Selection("Selection1"))));
+        assertEquals(0, AnswerDataUtil.answerDataToInt(new DateData(new Date())));
     }
 }


### PR DESCRIPTION
Closes #783 

#### What has been done to verify that this works as intended?
I've improved automated tests and performed manual ones using the form attached below.

#### Why is this the best possible solution? Were any other approaches considered?
This improved `AnswerDataUtil#answerDataToInt` so that it supports parsing `StringData` to integers. It was a missing piece and that's why it was not possible to use numbers from an external CSV in `repeat_count`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just add support for using numbers from an external CSV in `repeat_count`, nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
I've used this: 
[families.csv](https://github.com/user-attachments/files/16461053/families.csv)
[families_form.xlsx](https://github.com/user-attachments/files/16461054/families_form.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.
