### PR TITLE
Allow manually running publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
Currently, we need to manually publish releases off non-master branches. This will allow us to manually trigger the publish workflow.