### PR TITLE
Expose secondary instance CSV parsing

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
@@ -25,24 +25,25 @@ public class CsvExternalInstance implements ExternalInstanceParser.FileInstanceP
             .withDelimiter(getDelimiter(path))
             .withFirstRecordAsHeader();
         Reader reader = new InputStreamReader(new BOMInputStream(new FileInputStream(path)));
-        final CSVParser csvParser = new CSVParser(reader, csvFormat);
-        final String[] fieldNames = csvParser.getHeaderMap().keySet().toArray(new String[0]);
-        int multiplicity = 0;
+        try (final CSVParser csvParser = new CSVParser(reader, csvFormat)) {
+            final String[] fieldNames = csvParser.getHeaderMap().keySet().toArray(new String[0]);
+            int multiplicity = 0;
 
-        for (CSVRecord csvRecord : csvParser.getRecords()) {
-            TreeElement item = new TreeElement("item", multiplicity);
+            for (CSVRecord csvRecord : csvParser) {
+                TreeElement item = new TreeElement("item", multiplicity);
 
-            for (int i = 0; i < fieldNames.length; ++i) {
-                TreeElement field = new TreeElement(fieldNames[i], 0);
-                field.setValue(new UncastData(i < csvRecord.size() ? csvRecord.get(i) : ""));
-                item.addChild(field);
+                for (int i = 0; i < fieldNames.length; ++i) {
+                    TreeElement field = new TreeElement(fieldNames[i], 0);
+                    field.setValue(new UncastData(i < csvRecord.size() ? csvRecord.get(i) : ""));
+                    item.addChild(field);
+                }
+
+                root.addChild(item);
+                multiplicity++;
             }
 
-            root.addChild(item);
-            multiplicity++;
+            return root;
         }
-
-        return root;
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/CsvExternalInstance.java
@@ -1,19 +1,14 @@
 package org.javarosa.core.model.instance;
 
-import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.apache.commons.io.input.BOMInputStream;
 import org.javarosa.core.model.data.UncastData;
 import org.javarosa.xform.parse.ExternalInstanceParser;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 
 public class CsvExternalInstance implements ExternalInstanceParser.FileInstanceParser {
 
@@ -21,11 +16,11 @@ public class CsvExternalInstance implements ExternalInstanceParser.FileInstanceP
         final TreeElement root = new TreeElement("root", 0);
         root.setInstanceName(instanceId);
 
-        final CSVFormat csvFormat = CSVFormat.DEFAULT
-            .withDelimiter(getDelimiter(path))
-            .withFirstRecordAsHeader();
-        Reader reader = new InputStreamReader(new BOMInputStream(new FileInputStream(path)));
-        try (final CSVParser csvParser = new CSVParser(reader, csvFormat)) {
+        try (
+            final CSVParser csvParser = new SecondaryInstanceCSVParserBuilder()
+                .path(path)
+                .build()
+        ) {
             final String[] fieldNames = csvParser.getHeaderMap().keySet().toArray(new String[0]);
             int multiplicity = 0;
 

--- a/src/main/java/org/javarosa/core/model/instance/SecondaryInstanceCSVParserBuilder.java
+++ b/src/main/java/org/javarosa/core/model/instance/SecondaryInstanceCSVParserBuilder.java
@@ -1,0 +1,42 @@
+package org.javarosa.core.model.instance;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.io.input.BOMInputStream;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+public class SecondaryInstanceCSVParserBuilder {
+
+    private String path;
+
+    public SecondaryInstanceCSVParserBuilder path(String path) {
+        this.path = path;
+        return this;
+    }
+
+    public CSVParser build() throws IOException {
+        final CSVFormat csvFormat = CSVFormat.DEFAULT
+            .withDelimiter(getDelimiter(path))
+            .withFirstRecordAsHeader();
+        Reader reader = new InputStreamReader(new BOMInputStream(new FileInputStream(path)));
+        return new CSVParser(reader, csvFormat);
+    }
+
+    private static char getDelimiter(String path) throws IOException {
+        char delimiter = ',';
+        try (BufferedReader reader = new BufferedReader(new FileReader(path))) {
+            String header = reader.readLine();
+
+            if (header.contains(";")) {
+                delimiter = ';';
+            }
+        }
+        return delimiter;
+    }
+}


### PR DESCRIPTION
Work towards https://github.com/getodk/collect/issues/6350

This exposes the secondary instance CSV parsing code as `SecondaryInstanceCSVParserBuilder` so that clients can parse secondary instances directly. It also brings in changes from v4.4.1 that makes the standard CSV parsing code in `CsvExternalInstance` more memory efficient by streaming the CSV into memory rather than load it in one go.

#### What has been done to verify that this works as intended?

This just exposes existing code, so running existing tests was enough.

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here! I think a builder feels like a pretty standard approach to sharing code like this with clients.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Very little risk here as, again, it's all existing code.
