### PR TITLE
Deploy/install flattened pom instead of one with variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     working_directory: ~/work
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:17.0.11
     steps:
       - checkout
       - restore_cache:
@@ -53,7 +53,7 @@ jobs:
   package:
     working_directory: ~/work
     docker:
-      - image: circleci/openjdk:latest
+      - image: cimg/openjdk:17.0.11
     steps:
       - checkout
       - restore_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ logback-test.xml
 
 # Android api level checker
 android-api-level-checker/app/src/main/java/*
+
+# flatten-maven-plugin
+.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,31 @@
                 </execution>
             </executions>
         </plugin>
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <version>1.6.0</version>
+            <configuration>
+                <updatePomFile>true</updatePomFile>
+                <flattenMode>resolveCiFriendliesOnly</flattenMode>
+            </configuration>
+            <executions>
+                <execution>
+                    <id>flatten</id>
+                    <phase>process-resources</phase>
+                    <goals>
+                        <goal>flatten</goal>
+                    </goals>
+                </execution>
+                <execution>
+                    <id>flatten.clean</id>
+                    <phase>clean</phase>
+                    <goals>
+                        <goal>clean</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This should fix the problem with OSSRH versions ending up with `5.0.0-SNAPSHOT-${revision}` as the version in the POM.