### PR TITLE
Fix ambiguous constructors

### DIFF
--- a/src/main/java/org/javarosa/core/model/data/DecimalData.java
+++ b/src/main/java/org/javarosa/core/model/data/DecimalData.java
@@ -45,9 +45,6 @@ public class DecimalData implements IAnswerData {
     public DecimalData(double d) {
         this.d = d;
     }
-    public DecimalData(@NotNull Double d) {
-        setValue(d);
-    }
 
     @Override
     public IAnswerData clone () {

--- a/src/main/java/org/javarosa/core/model/data/IntegerData.java
+++ b/src/main/java/org/javarosa/core/model/data/IntegerData.java
@@ -45,9 +45,6 @@ public class IntegerData implements IAnswerData {
     public IntegerData(int n) {
         this.n = n;
     }
-    public IntegerData(@NotNull Integer n) {
-        setValue(n);
-    }
 
     @Override
     public IAnswerData clone () {

--- a/src/main/java/org/javarosa/core/model/data/LongData.java
+++ b/src/main/java/org/javarosa/core/model/data/LongData.java
@@ -44,9 +44,6 @@ public class LongData implements IAnswerData {
     public LongData(long n) {
         this.n = n;
     }
-    public LongData(@NotNull Long n) {
-        setValue(n);
-    }
 
     @Override
     public IAnswerData clone () {


### PR DESCRIPTION
This fixes a problem introduced by https://github.com/getodk/javarosa/pull/794 when using JavaRosa with Kotlin: Java's `int` and `@NotNull Integer` both map to Kotlin's `Int` which makes overloaded constructors using those types ambiguous (this goes for any primitive type and its corresponding "boxed" type).