### PR TITLE
hash un-numeric input when used as PRNG seed, fixes #800

### DIFF
--- a/src/test/java/org/javarosa/xpath/expr/XPathFuncAsSomethingTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathFuncAsSomethingTest.java
@@ -1,0 +1,42 @@
+package org.javarosa.xpath.expr;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.javarosa.xpath.expr.XPathFuncExpr.toLongHash;
+import static org.javarosa.xpath.expr.XPathFuncExpr.toNumeric;
+
+import java.util.Date;
+
+public class XPathFuncAsSomethingTest {
+
+    @Test
+    public void toLongHashHashesWell() {
+        assertThat(toLongHash("Hello"), equalTo(1756278180214341157L));
+        assertThat(toLongHash(""), equalTo(-2039914840885289964L));
+    }
+
+    @Test
+    public void toNumericHandlesBooleans() {
+        assertThat(toNumeric(true), equalTo(1.0));
+        assertThat(toNumeric(false), equalTo(0.0));
+    }
+
+    @Test
+    public void toNumericHandlesStrings() {
+        assertThat(toNumeric("  123  "), equalTo(123.0));
+        assertThat(toNumeric("  123.0  "), equalTo(123.0));
+        assertThat(toNumeric("  123.4  "), equalTo(123.4));
+        assertThat(toNumeric("  123,4  "), equalTo(123.4));
+
+        assertThat(toNumeric("0x12"), not(18.0));
+        assertThat(toNumeric("0x12"), equalTo(Double.NaN));
+    }
+
+    @Test
+    public void toNumericHandlesDates() {
+        assertThat(toNumeric(new Date(86400 * 1000L)), equalTo(1.0));
+    }
+}


### PR DESCRIPTION
Closes #800

As discussed on Slack, but there may be more to discuss!

#### What has been done to verify that this works as intended?
Ran the tests, added some tests too. Ideally I'd put this JR version in an ODKCollect to witness some choice randomization change when altering the seed value in [this test form](https://staging.getodk.cloud/#/projects/112/forms/seeded_rando), but I didn't manage that today ;-)

#### Why is this the best possible solution? Were any other approaches considered?
The nice thing is that it doesn't change existing randomizations that were working well (eg, strings interpretable as numerics). It only changes randomizations for which the seed wasn't working (eg, strings not interpretable as numerics).


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

In very specific use cases this can cause an unwelcome change.

For instance: In some survey the randomization of the order of choice fields is part of the survey. Also, it wasn't actually working due to issue #800, but anyway. Now if ODKCollect is updated with this new OpenRosa version halfway through the survey, some users will have seen randomization X for seed Z while others will have seen randomization Y for that same seed Z. If the research draws conclusions based on either X or Y, then the researchers need to know which version of ODKCollect was used so they know (or can deduce) which choice randomization went with seed Z.


#### Do we need any specific form for testing your changes? If so, please attach one.
as mentioned above, running ODKCollect on [this form](https://staging.getodk.cloud/#/projects/112/forms/seeded_rando) and witnessing the choice list reshuffle based on string input variations in the seed field, would be extra convincing.


#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

Maybe. We could say something like:

> "As of ODKCollect version X, the choice randomization based on using an RNG seed from some other field actually works for more inputs (notably, any text). If you have ongoing research that depends on this type of randomization, and where the analysis is dependent on the specific choice list ordering that used to go with certain seeds, you may want to test with this new version of ODKCollect to see if your choice list randomization will change, and decide to not upgrade ODKCollect while this research is ongoing".
