### PR TITLE
Support non-numeric seeds when using randomize in itemset nodeset expression

### DIFF
--- a/src/main/java/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/main/java/org/javarosa/core/model/ItemsetBinding.java
@@ -100,7 +100,7 @@ public class ItemsetBinding implements Externalizable, Localizable {
         Map<TreeReference, IAnswerData> currentTriggerValues = getCurrentTriggerValues(formDef, curQRef);
         boolean allTriggerRefsBound = currentTriggerValues != null;
 
-        Long currentRandomizeSeed = resolveRandomSeed(formDef.getMainInstance(), formDef.getEvaluationContext());
+        Long currentRandomizeSeed = resolveRandomSeed(formDef.getMainInstance(), new EvaluationContext(formDef.getEvaluationContext(), contextRef.contextualize(curQRef)));
 
         // Return cached list if possible
         if (cachedFilteredChoiceList != null && allTriggerRefsBound && Objects.equals(currentTriggerValues, cachedTriggerValues)

--- a/src/main/java/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/main/java/org/javarosa/core/model/ItemsetBinding.java
@@ -38,8 +38,7 @@ import java.util.Set;
 
 import static org.javarosa.core.model.FormDef.getAbsRef;
 import static org.javarosa.xform.parse.RandomizeHelper.shuffle;
-import static org.javarosa.xpath.expr.XPathFuncExpr.toLongHash;
-import static org.javarosa.xpath.expr.XPathFuncExpr.toNumeric;
+import static org.javarosa.xform.parse.RandomizeHelper.toNumericWithLongHash;
 
 public class ItemsetBinding implements Externalizable, Localizable {
     // Temporarily cached filtered list (not serialized)
@@ -311,16 +310,7 @@ public class ItemsetBinding implements Externalizable, Localizable {
 
     private Long resolveRandomSeed(DataInstance model, EvaluationContext ec) {
         if (randomSeedExpr != null) {
-            Object seed = randomSeedExpr.eval(model, ec);
-            Double asDouble = toNumeric(seed);
-            if (Double.isNaN(asDouble)) {
-                // Reasonable attempts at reading the node's value as a number failed.
-                // Fall back to deriving the seed from it using hashing.
-                // See https://github.com/getodk/javarosa/issues/800
-                return toLongHash(seed);
-            } else {
-                return asDouble.longValue();
-            }
+            return toNumericWithLongHash(randomSeedExpr.eval(model, ec));
         } else {
             return null;
         }

--- a/src/main/java/org/javarosa/xform/parse/RandomizeHelper.java
+++ b/src/main/java/org/javarosa/xform/parse/RandomizeHelper.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.javarosa.xpath.expr.XPathFuncExpr.toLongHash;
+import static org.javarosa.xpath.expr.XPathFuncExpr.toNumeric;
+
 /**
  * This class contains all the code needed to implement the xform randomize()
  * function.
@@ -38,6 +41,18 @@ public final class RandomizeHelper {
      */
     static String cleanNodesetDefinition(String nodesetStr) {
         return getArgs(nodesetStr)[0].trim();
+    }
+
+    public static Long toNumericWithLongHash(Object value) {
+        Double asDouble = toNumeric(value);
+        if (Double.isNaN(asDouble)) {
+            // Reasonable attempts at reading the node's value as a number failed.
+            // Fall back to deriving the seed from it using hashing.
+            // See https://github.com/getodk/javarosa/issues/800
+            return toLongHash(value);
+        } else {
+            return asDouble.longValue();
+        }
     }
 
     /**

--- a/src/main/java/org/javarosa/xform/parse/RandomizeHelper.java
+++ b/src/main/java/org/javarosa/xform/parse/RandomizeHelper.java
@@ -41,22 +41,6 @@ public final class RandomizeHelper {
     }
 
     /**
-     * Cleans an xform randomize() expression to leave only its second argument, if it exists, which
-     * should be a number or an xpath expression, or null if there's no second argument present
-     * <p>
-     * Can throw an {@link IllegalArgumentException} if the expression doesn't conform
-     * to an xform randomize() call.
-     *
-     * @param nodesetStr an xform randomize() expression
-     * @return a {@link String} with the second argument of the xform randomize() expression, or
-     *         null, if there's no second argument present
-     */
-    static String cleanSeedDefinition(String nodesetStr) {
-        String[] args = getArgs(nodesetStr);
-        return args.length > 1 ? args[1].trim() : null;
-    }
-
-    /**
      * This method will return a new list with the same elements, randomly reordered.
      * Every call to this method will produce a different random seed, which will
      * potentially produce a different ordering each time.

--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -16,20 +16,7 @@
 
 package org.javarosa.xpath.expr;
 
-import static java.lang.Double.NaN;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.regex.Pattern;
+import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IFallbackFunctionHandler;
 import org.javarosa.core.model.condition.IFunctionHandler;
@@ -58,7 +45,22 @@ import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.XPathUnhandledException;
 import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
-import org.bouncycastle.crypto.digests.SHA256Digest;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static java.lang.Double.NaN;
+import static org.javarosa.xform.parse.RandomizeHelper.toNumericWithLongHash;
 
 /**
  * Representation of an xpath function expression.
@@ -514,7 +516,7 @@ public class XPathFuncExpr extends XPathExpression {
                 return XPathNodeset.shuffle((XPathNodeset) argVals[0]);
 
             if (args.length == 2)
-                return XPathNodeset.shuffle((XPathNodeset) argVals[0], toNumeric(argVals[1]).longValue());
+                return XPathNodeset.shuffle((XPathNodeset) argVals[0], toNumericWithLongHash(argVals[1]));
 
             throw new XPathUnhandledException("function 'randomize' requires 1 or 2 arguments. " + args.length + " provided.");
         } else if (name.equals("base64-decode")) {

--- a/src/test/java/org/javarosa/xform/parse/RandomizeHelperTest.java
+++ b/src/test/java/org/javarosa/xform/parse/RandomizeHelperTest.java
@@ -15,20 +15,19 @@
  */
 package org.javarosa.xform.parse;
 
-import static java.util.stream.Collectors.toList;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertNotSame;
-import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
-import static org.javarosa.xform.parse.RandomizeHelper.cleanSeedDefinition;
-import static org.javarosa.xform.parse.RandomizeHelper.shuffle;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.Test;
+
+import static java.util.stream.Collectors.toList;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotSame;
+import static org.javarosa.xform.parse.RandomizeHelper.cleanNodesetDefinition;
+import static org.javarosa.xform.parse.RandomizeHelper.shuffle;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RandomizeHelperTest {
     @Test
@@ -50,20 +49,6 @@ public class RandomizeHelperTest {
         assertEquals("/some/path[someFilter]",                  cleanNodesetDefinition("randomize(/some/path[someFilter], 33)"));
         assertEquals("/some/path[someFilter(with, commas)]",    cleanNodesetDefinition("randomize(/some/path[someFilter(with, commas)])"));
         assertEquals("/some/path[someFilter(with, commas)]",    cleanNodesetDefinition("randomize(/some/path[someFilter(with, commas)], 33)"));
-    }
-
-    @Test
-    public void cleans_the_seed_definition() {
-        // We will try different combinations of whitespace and seed presence around the path
-        assertNull(cleanSeedDefinition("randomize(/some/path)"));
-        assertEquals("33",               cleanSeedDefinition("randomize(/some/path,33)"));
-        assertEquals("33",               cleanSeedDefinition("randomize(/some/path,33 )"));
-        assertEquals("33",               cleanSeedDefinition("randomize(/some/path, 33)"));
-        assertEquals("33",               cleanSeedDefinition("randomize(/some/path, 33 )"));
-        assertEquals("/some/other/path", cleanSeedDefinition("randomize(/some/path,/some/other/path)"));
-        assertEquals("/some/other/path", cleanSeedDefinition("randomize(/some/path,/some/other/path) "));
-        assertEquals("/some/other/path", cleanSeedDefinition("randomize(/some/path, /some/other/path)"));
-        assertEquals("/some/other/path", cleanSeedDefinition("randomize(/some/path, /some/other/path) "));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/org/javarosa/xpath/expr/RandomizeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/RandomizeTest.java
@@ -27,7 +27,6 @@ import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.model.xform.XFormsModule;
 import org.javarosa.test.FormParseInit;
-import org.javarosa.test.Scenario;
 import org.javarosa.xform.parse.XFormParser;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,24 +42,10 @@ import static java.nio.file.Files.createTempFile;
 import static java.nio.file.Files.delete;
 import static java.nio.file.Files.newInputStream;
 import static java.nio.file.Files.newOutputStream;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.model.instance.TreeReference.CONTEXT_ABSOLUTE;
 import static org.javarosa.core.model.instance.TreeReference.INDEX_UNBOUND;
 import static org.javarosa.core.model.instance.TreeReference.REF_ABSOLUTE;
-import static org.javarosa.test.BindBuilderXFormsElement.bind;
 import static org.javarosa.test.ResourcePathHelper.r;
-import static org.javarosa.test.XFormsElement.body;
-import static org.javarosa.test.XFormsElement.head;
-import static org.javarosa.test.XFormsElement.html;
-import static org.javarosa.test.XFormsElement.input;
-import static org.javarosa.test.XFormsElement.instance;
-import static org.javarosa.test.XFormsElement.item;
-import static org.javarosa.test.XFormsElement.mainInstance;
-import static org.javarosa.test.XFormsElement.model;
-import static org.javarosa.test.XFormsElement.select1Dynamic;
-import static org.javarosa.test.XFormsElement.t;
-import static org.javarosa.test.XFormsElement.title;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -174,56 +159,6 @@ public class RandomizeTest {
         assertTrue(nodesEqualInOrder(choices2a, choices2b));
         assertTrue(nodesEqualInOrder(choices2a, choices2c));
     }
-
-    //region Type coercion
-    @Test
-    public void stringNumberSeedConvertsToIntWhenUsedInNodesetExpression() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
-            head(
-                title("Randomize non-numeric seed"),
-                model(
-                    mainInstance(t("data id=\"rand-non-numeric\"",
-                        t("choice")
-                    )),
-                    instance("choices",
-                        item("a", "A"),
-                        item("b", "B")
-                    ),
-                    bind("/data/choice").type("string")
-                )
-            ),
-            body(
-                select1Dynamic("/data/choice", "randomize(instance('choices')/root/item, '1')")
-            )
-        ));
-
-        assertThat(scenario.choicesOf("/data/choice").get(0).getValue(), is("b"));
-    }
-
-    @Test
-    public void stringNumberSeedConvertsToIntWhenUsedInExpression() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
-            head(
-                title("Randomize non-numeric seed"),
-                model(
-                    mainInstance(t("data id=\"rand-non-numeric\"",
-                        t("choice")
-                    )),
-                    instance("choices",
-                        item("a", "A"),
-                        item("b", "B")
-                    ),
-                    bind("/data/choice").type("string").calculate("selected-at(join(' ', randomize(instance('choices')/root/item/label, '1')), 0)")
-                )
-            ),
-            body(
-                input("/data/choice")
-            )
-        ));
-
-        assertThat(scenario.answerOf("/data/choice").getDisplayText(), is("B"));
-    }
-    // endregion
 
     private FormDef serializeAndDeserializeForm(FormDef formDef) throws IOException, DeserializationException {
         // Initialize serialization

--- a/src/test/java/org/javarosa/xpath/expr/RandomizeTypesTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/RandomizeTypesTest.java
@@ -1,0 +1,120 @@
+package org.javarosa.xpath.expr;
+
+import org.javarosa.test.Scenario;
+import org.javarosa.xform.parse.XFormParser;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.test.BindBuilderXFormsElement.bind;
+import static org.javarosa.test.XFormsElement.body;
+import static org.javarosa.test.XFormsElement.head;
+import static org.javarosa.test.XFormsElement.html;
+import static org.javarosa.test.XFormsElement.input;
+import static org.javarosa.test.XFormsElement.instance;
+import static org.javarosa.test.XFormsElement.item;
+import static org.javarosa.test.XFormsElement.mainInstance;
+import static org.javarosa.test.XFormsElement.model;
+import static org.javarosa.test.XFormsElement.select1Dynamic;
+import static org.javarosa.test.XFormsElement.t;
+import static org.javarosa.test.XFormsElement.title;
+
+public class RandomizeTypesTest {
+    @Test
+    public void stringNumberSeedConvertsWhenUsedInNodesetExpression() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+            head(
+                title("Randomize non-numeric seed"),
+                model(
+                    mainInstance(t("data id=\"rand-non-numeric\"",
+                        t("choice")
+                    )),
+                    instance("choices",
+                        item("a", "A"),
+                        item("b", "B")
+                    ),
+                    bind("/data/choice").type("string")
+                )
+            ),
+            body(
+                select1Dynamic("/data/choice", "randomize(instance('choices')/root/item, '1')")
+            )
+        ));
+
+        assertThat(scenario.choicesOf("/data/choice").get(0).getValue(), is("b"));
+    }
+
+    @Test
+    public void stringNumberSeedConvertsWhenUsedInCalculate() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+            head(
+                title("Randomize non-numeric seed"),
+                model(
+                    mainInstance(t("data id=\"rand-non-numeric\"",
+                        t("choice")
+                    )),
+                    instance("choices",
+                        item("a", "A"),
+                        item("b", "B")
+                    ),
+                    bind("/data/choice").type("string").calculate("selected-at(join(' ', randomize(instance('choices')/root/item/label, '1')), 0)")
+                )
+            ),
+            body(
+                input("/data/choice")
+            )
+        ));
+
+        assertThat(scenario.answerOf("/data/choice").getDisplayText(), is("B"));
+    }
+
+    @Test
+    public void stringTextSeedConvertsWhenUsedInNodesetExpression() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+            head(
+                title("Randomize non-numeric seed"),
+                model(
+                    mainInstance(t("data id=\"rand-non-numeric\"",
+                        t("choice")
+                    )),
+                    instance("choices",
+                        item("a", "A"),
+                        item("b", "B")
+                    ),
+                    bind("/data/choice").type("string")
+                )
+            ),
+            body(
+                select1Dynamic("/data/choice", "randomize(instance('choices')/root/item, 'foo')")
+            )
+        ));
+
+        assertThat(scenario.choicesOf("/data/choice").get(0).getValue(), is("b"));
+    }
+
+    @Test
+    public void stringTextSeedConvertsWhenUsedInCalculate() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+            head(
+                title("Randomize non-numeric seed"),
+                model(
+                    mainInstance(t("data id=\"rand-non-numeric\"",
+                        t("choice")
+                    )),
+                    instance("choices",
+                        item("a", "A"),
+                        item("b", "B")
+                    ),
+                    bind("/data/choice").type("string").calculate("selected-at(join(' ', randomize(instance('choices')/root/item/label, 'foo')), 0)")
+                )
+            ),
+            body(
+                input("/data/choice")
+            )
+        ));
+
+        assertThat(scenario.answerOf("/data/choice").getDisplayText(), is("B"));
+    }
+}


### PR DESCRIPTION
Closes #800

#801 did not have any effect because an exception was thrown when a non-numeric input was provided to `randomize` in an itemset nodeset expression (see tests in f31435ca08dad564302f96ca4189b25d6a7d69fc).

This brings the intended behavior from #801 to both the itemset nodeset context and any other expression in which `randomize` is called. It also switches to using the XPath parser rather than regex for identifying `randomize` calls and their seeds in itemset nodeset expressions.

#### What has been done to verify that this works as intended?
Added tests.

#### Why is this the best possible solution? Were any other approaches considered?
I went further than I initially expected so there's some risk here. I think it's the right balance of risk and getting the work to a consistent, clear state.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think the changes to `XFormParser` are the riskiest. This PR changes the regex-based identification of `randomize` calls and seeds to using the XPath parser. It also allows any type of expression to be passed in as a seed whereas previously only numeric literal or path expressions were allowed. Any mistakes here could lead to changes in how existing seeds randomize choices.

Another area of risk is that the cached/serialized form definition has changed because now `ItemsetBinding` stores a single, more general representation of the seed. Now is a good time for this kind of change because we're working on a major release. Collect will now delete the form cache file and rebuild it on every app upgrade.

#### Do we need any specific form for testing your changes? If so, please attach one.
See issue

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
https://github.com/getodk/xforms-spec/pull/318
