### PR TITLE
Extend randomize seed tests

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -705,12 +705,18 @@ public class XPathFuncExpr extends XPathExpression {
     }
 
     /**
-     * convert a string value to an integer by:
+     * Convert a non-zero-length string value to an integer by:
      * - encoding it as utf-8
      * - hashing it with sha256 (available cross-platform, including via browser crypto API)
      * - interpreting the first 8 bytes of the hash as a long
+     *
+     * A zero-length string results in a 0L — this is the classic behaviour that we want
+     * to conserve for backward compatibility with a case that is expected to be common.
+     * In practical terms, we don't want the sort order of choice lists using an empty string as
+     * a seed to change with the introduction of this seed derivation mechanism.
      */
     public static long toLongHash(String sourceString) {
+        if (sourceString.length() == 0) return 0L;
         byte[] hasheeBuf = sourceString.getBytes(Charset.forName("UTF-8"));
         SHA256Digest hasher = new SHA256Digest();
         hasher.update(hasheeBuf, 0, hasheeBuf.length);

--- a/src/test/java/org/javarosa/xpath/expr/RandomizeTypesTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/RandomizeTypesTest.java
@@ -192,4 +192,41 @@ public class RandomizeTypesTest {
         assertThat(scenario.choicesOf("/data/repeat[2]/choice").get(0).getValue(), is("b"));
         assertThat(scenario.choicesOf("/data/repeat[1]/choice").get(0).getValue(), is("a"));
     }
+
+    @Test
+    public void seedFromArbitraryInputCanBeUsed() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+            head(
+                title("Randomize non-numeric seed"),
+                model(
+                    mainInstance(t("data id=\"rand-non-numeric\"",
+                        t("input"),
+                        t("choice")
+                    )),
+                    instance("choices",
+                        item("a", "A"),
+                        item("b", "B"),
+                        item("c", "C"),
+                        item("d", "D"),
+                        item("e", "E"),
+                        item("f", "F"),
+                        item("g", "G"),
+                        item("h", "H")
+                    ),
+                    bind("/data/input").type("geopoint"),
+                    bind("/data/choice").type("string")
+                )
+            ),
+            body(
+                input("/data/input"),
+                select1Dynamic("/data/choice", "randomize(instance('choices')/root/item, /data/input)")
+            )
+        ));
+
+        scenario.answer("/data/input", "-6.8137120026589315 39.29392995851879");
+        String[] shuffled = {"h", "b", "d", "f", "a", "g", "c", "e"};
+        for (int i = 0; i < shuffled.length; i++) {
+            assertThat(scenario.choicesOf("/data/choice").get(i).getValue(), is(shuffled[i]));
+        }
+    }
 }

--- a/src/test/java/org/javarosa/xpath/expr/RandomizeTypesTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/RandomizeTypesTest.java
@@ -30,21 +30,35 @@ public class RandomizeTypesTest {
                 title("Randomize non-numeric seed"),
                 model(
                     mainInstance(t("data id=\"rand-non-numeric\"",
-                        t("choice")
+                        t("choices_numeric_seed"),
+                        t("choices_stringified_numeric_seed")
                     )),
                     instance("choices",
                         item("a", "A"),
-                        item("b", "B")
+                        item("b", "B"),
+                        item("c", "C"),
+                        item("d", "D"),
+                        item("e", "E"),
+                        item("f", "F"),
+                        item("g", "G"),
+                        item("h", "H")
                     ),
-                    bind("/data/choice").type("string")
+                    bind("/data/choices_numeric_seed").type("string"),
+                    bind("/data/choices_stringified_numeric_seed").type("string")
                 )
             ),
             body(
-                select1Dynamic("/data/choice", "randomize(instance('choices')/root/item, '1')")
+                select1Dynamic("/data/choices_numeric_seed", "randomize(instance('choices')/root/item, 1234)"),
+                select1Dynamic("/data/choices_stringified_numeric_seed", "randomize(instance('choices')/root/item, '1234')")
             )
         ));
-
-        assertThat(scenario.choicesOf("/data/choice").get(0).getValue(), is("b"));
+        String[] shuffled = {"g", "f", "e", "d", "a", "h", "b", "c"};
+        String[] nodes = {"/data/choices_numeric_seed", "/data/choices_stringified_numeric_seed"};
+        for (int i = 0; i < shuffled.length; i++) {
+            for (String node : nodes) {
+                assertThat(scenario.choicesOf(node).get(i).getValue(), is(shuffled[i]));
+            }
+        }
     }
 
     @Test
@@ -54,21 +68,30 @@ public class RandomizeTypesTest {
                 title("Randomize non-numeric seed"),
                 model(
                     mainInstance(t("data id=\"rand-non-numeric\"",
-                        t("choice")
+                        t("choices_numeric_seed"),
+                        t("choices_stringified_numeric_seed")
                     )),
                     instance("choices",
                         item("a", "A"),
-                        item("b", "B")
+                        item("b", "B"),
+                        item("c", "C"),
+                        item("d", "D"),
+                        item("e", "E"),
+                        item("f", "F"),
+                        item("g", "G"),
+                        item("h", "H")
                     ),
-                    bind("/data/choice").type("string").calculate("selected-at(join(' ', randomize(instance('choices')/root/item/label, '1')), 0)")
+                    bind("/data/choices_numeric_seed").type("string").calculate("join('', randomize(instance('choices')/root/item/label, 1234))"),
+                    bind("/data/choices_stringified_numeric_seed").type("string").calculate("join('', randomize(instance('choices')/root/item/label, '1234'))")
                 )
             ),
             body(
-                input("/data/choice")
+                input("/data/choices_numeric_seed"),
+                input("/data/choices_stringified_numeric_seed")
             )
         ));
-
-        assertThat(scenario.answerOf("/data/choice").getDisplayText(), is("B"));
+        assertThat(scenario.answerOf("/data/choices_numeric_seed").getDisplayText(), is(scenario.answerOf("/data/choices_stringified_numeric_seed").getDisplayText()));
+        assertThat(scenario.answerOf("/data/choices_numeric_seed").getDisplayText(), is("GFEDAHBC"));
     }
 
     @Test
@@ -82,7 +105,13 @@ public class RandomizeTypesTest {
                     )),
                     instance("choices",
                         item("a", "A"),
-                        item("b", "B")
+                        item("b", "B"),
+                        item("c", "C"),
+                        item("d", "D"),
+                        item("e", "E"),
+                        item("f", "F"),
+                        item("g", "G"),
+                        item("h", "H")
                     ),
                     bind("/data/choice").type("string")
                 )
@@ -91,8 +120,10 @@ public class RandomizeTypesTest {
                 select1Dynamic("/data/choice", "randomize(instance('choices')/root/item, 'foo')")
             )
         ));
-
-        assertThat(scenario.choicesOf("/data/choice").get(0).getValue(), is("b"));
+        String[] shuffled = {"e", "a", "d", "b", "h", "g", "c", "f"};
+        for (int i = 0; i < shuffled.length; i++) {
+            assertThat(scenario.choicesOf("/data/choice").get(i).getValue(), is(shuffled[i]));
+        }
     }
 
     @Test
@@ -106,9 +137,15 @@ public class RandomizeTypesTest {
                     )),
                     instance("choices",
                         item("a", "A"),
-                        item("b", "B")
+                        item("b", "B"),
+                        item("c", "C"),
+                        item("d", "D"),
+                        item("e", "E"),
+                        item("f", "F"),
+                        item("g", "G"),
+                        item("h", "H")
                     ),
-                    bind("/data/choice").type("string").calculate("selected-at(join(' ', randomize(instance('choices')/root/item/label, 'foo')), 0)")
+                    bind("/data/choice").type("string").calculate("join('', randomize(instance('choices')/root/item/label, 'foo'))")
                 )
             ),
             body(
@@ -116,7 +153,7 @@ public class RandomizeTypesTest {
             )
         ));
 
-        assertThat(scenario.answerOf("/data/choice").getDisplayText(), is("B"));
+        assertThat(scenario.answerOf("/data/choice").getDisplayText(), is("EADBHGCF"));
     }
 
     @Test

--- a/src/test/java/org/javarosa/xpath/expr/XPathFuncAsSomethingTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/XPathFuncAsSomethingTest.java
@@ -15,7 +15,7 @@ public class XPathFuncAsSomethingTest {
     @Test
     public void toLongHashHashesWell() {
         assertThat(toLongHash("Hello"), equalTo(1756278180214341157L));
-        assertThat(toLongHash(""), equalTo(-2039914840885289964L));
+        assertThat(toLongHash(""), equalTo(0L)); // the empty string would actually hash to -2039914840885289964L; but we've added this quirk for backward compatibility.
     }
 
     @Test


### PR DESCRIPTION
Tests in #804 could serendipitously ~fail~ succeed while they shouldn't since randomization took place over only 2 items (thus randomize(x, y) would result in the same shuffled order with probability 0.5 when varying y).

This expands tests to use a larger collection so that entropy is `8!` rather than 2 when the  total ordering rather than just the identity of the first element of the shuffled list is tested (reducing the "lucky factor" to 1/40320 if I'm not mistaken).


Update: Preserved classic behaviour for the special case of zero-length strings as seed input, and added/modified tests for that behaviour.