### PR TITLE
Improved parsing attributes in tests

### DIFF
--- a/src/main/java/org/javarosa/test/XFormsElement.java
+++ b/src/main/java/org/javarosa/test/XFormsElement.java
@@ -135,16 +135,7 @@ public interface XFormsElement {
     }
 
     static XFormsElement select1Dynamic(String ref, String nodesetRef) {
-        XFormsElement value = t("value ref=\"value\"");
-        XFormsElement label = t("label ref=\"label\"");
-
-        HashMap<String, String> itemsetAttributes = new HashMap<>();
-        itemsetAttributes.put("nodeset", nodesetRef);
-        TagXFormsElement itemset = new TagXFormsElement("itemset", itemsetAttributes, asList(value, label));
-
-        HashMap<String, String> select1Attributes = new HashMap<>();
-        select1Attributes.put("ref", ref);
-        return new TagXFormsElement("select1", select1Attributes, asList(itemset));
+        return select1Dynamic(ref, nodesetRef, "value", "label");
     }
 
     static XFormsElement select1Dynamic(String ref, String nodesetRef, String valueRef, String labelRef) {

--- a/src/main/java/org/javarosa/test/XFormsElement.java
+++ b/src/main/java/org/javarosa/test/XFormsElement.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
@@ -42,7 +43,12 @@ public interface XFormsElement {
         if (!name.contains(" "))
             return emptyMap();
         Map<String, String> attributes = new HashMap<>();
-        String[] words = name.split(" ");
+
+        // Regex to split on spaces, ignoring spaces inside quoted text
+        final String SPACE_OUTSIDE_QUOTES_REGEX = " (?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)";
+        Pattern spaceOutsideQuotesPattern = Pattern.compile(SPACE_OUTSIDE_QUOTES_REGEX);
+        String[] words = spaceOutsideQuotesPattern.split(name);
+
         for (String word : asList(words).subList(1, words.length)) {
             String[] parts = word.split("(?<!\\))=(\"|')", 2);
             attributes.put(parts[0], parts[1].substring(0, parts[1].length() - 1));

--- a/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -381,7 +381,7 @@ public class FormDefTest {
                 title("output with relative ref in translation"),
                 model(
                     t("itext", t("translation lang=\"Français\"",
-                        t("text id=\"/data/repeat/position_in_label:label",
+                        t("text id=\"/data/repeat/position_in_label:label\"",
                             t("value", "Position: <output value=\"../position\"/>"))
                     )),
                     mainInstance(t("data id=\"relative-output\"",


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've run automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
Currently, in `XFormsElement`, we have two different implementations of `select1Dynamic`: https://github.com/getodk/javarosa/blob/3d3efac4dded7f0bee706d4b740b052a0732c4f1/src/main/java/org/javarosa/test/XFormsElement.java#L150C26-L150C40.
In the past, one implementation relied on the other, but this has recently changed in:
https://github.com/grzesiek2010/javarosa/commit/3e9c22510964ff8c0c0493024457dca1998254b9

I experimented with some tests and tried using the second implementation, which allows me to provide `valueRef` and `labelRef`, but I couldn't make it work due to the same issue that led to changes in the first method (it was buggy). I could have reworked it and called the new code in both cases (the new one), but it seems to me that the changes weren't necessary here. We can still rely on the old (more consistent) approach, as long as the parsing of attributes is fixed. That's what I did.
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This does not require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.
