### PR TITLE
Remove usage of integer type which in JR is alias for int

### DIFF
--- a/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
@@ -177,7 +177,7 @@ public class OdkNewRepeatEventTest {
                         t("repeat",
                             t("q"))
                     )),
-                    bind("/data/repeat/q").type("integer")
+                    bind("/data/repeat/q").type("int")
                 )
             ),
             body(

--- a/src/test/resources/org/javarosa/core/model/actions/event-odk-new-repeat.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/event-odk-new-repeat.xml
@@ -33,14 +33,14 @@
             </instance>
 
             <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
-            <bind nodeset="/data/my-toplevel-value" type="integer"/>
+            <bind nodeset="/data/my-toplevel-value" type="int"/>
             <bind nodeset="/data/my-repeat/defaults-to-position" type="string"/>
-            <bind nodeset="/data/my-repeat/defaults-to-toplevel" type="integer"/>
+            <bind nodeset="/data/my-repeat/defaults-to-toplevel" type="int"/>
 
-            <bind nodeset="/data/repeat-count" type="integer"/>
+            <bind nodeset="/data/repeat-count" type="int"/>
             <bind nodeset="/data/my-jr-count-repeat/defaults-to-position-again" type="string"/>
 
-            <bind nodeset="/data/my-repeat-without-template/my-value" type="integer"/>
+            <bind nodeset="/data/my-repeat-without-template/my-value" type="int"/>
         </model>
     </h:head>
 

--- a/src/test/resources/org/javarosa/core/model/actions/multiple-events.xml
+++ b/src/test/resources/org/javarosa/core/model/actions/multiple-events.xml
@@ -17,8 +17,8 @@
 
             <bind nodeset="/data/nested-first-load" type="string" />
             <bind nodeset="/data/my-group/nested-first-load-in-group" type="string" />
-            <bind nodeset="/data/my-value" type="integer" />
-            <bind nodeset="/data/my-calculated-value" type="integer" />
+            <bind nodeset="/data/my-value" type="int" />
+            <bind nodeset="/data/my-calculated-value" type="int" />
         </model>
     </h:head>
     <h:body>


### PR DESCRIPTION
I accidentally introduced test forms with the `integer` bind type. This is technically supported (in the xsd namespace) in the W3C XForms spec. JavaRosa defines the alias. Most other tools in the ecosystem would not recognize it so I think we should aim not to use it in tests.