### PR TITLE
Spaces after CSV delimiters are not stripped

### DIFF
--- a/src/test/java/org/javarosa/core/model/instance/CsvExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/CsvExternalInstanceTest.java
@@ -29,6 +29,12 @@ public class CsvExternalInstanceTest {
     }
 
     @Test
+    public void heading_spaces_are_not_stripped() {
+        assertEquals(" extra", commaSeparated.getChildAt(0).getChildAt(3).getName());
+        assertEquals(" extra", semiColonSeparated.getChildAt(0).getChildAt(3).getName());
+    }
+
+    @Test
     public void value_has_no_extra_quotes() {
         assertEquals("A", commaSeparated.getChildAt(0).getChildAt(0).getValue().getValue());
         assertEquals("A", semiColonSeparated.getChildAt(0).getChildAt(0).getValue().getValue());
@@ -52,6 +58,12 @@ public class CsvExternalInstanceTest {
             assertEquals("", commaSeparated.getChildAt(5).getChildAt(fieldIndex).getValue().getValue());
             assertEquals("", semiColonSeparated.getChildAt(5).getChildAt(fieldIndex).getValue().getValue());
         }
+    }
+
+    @Test
+    public void value_spaces_are_not_stripped() {
+        assertEquals(" b", commaSeparated.getChildAt(8).getChildAt(1).getValue().getValue());
+        assertEquals(" b", semiColonSeparated.getChildAt(8).getChildAt(1).getValue().getValue());
     }
 
     @Test

--- a/src/test/resources/org/javarosa/core/model/instance/external-secondary-comma-complex.csv
+++ b/src/test/resources/org/javarosa/core/model/instance/external-secondary-comma-complex.csv
@@ -1,4 +1,4 @@
-"label","name","first"
+"label","name","first", extra
 "A","a",
 B,b,
 C,c
@@ -7,3 +7,4 @@ AB,ab,a
 AC
 "121 Main St, NE",main,m
 "text; more text",foo,bar
+a, b

--- a/src/test/resources/org/javarosa/core/model/instance/external-secondary-semicolon-complex.csv
+++ b/src/test/resources/org/javarosa/core/model/instance/external-secondary-semicolon-complex.csv
@@ -1,4 +1,4 @@
-"label";"name";"first"
+"label";"name";"first"; extra
 "A";"a";
 B;b;
 C;c
@@ -7,3 +7,4 @@ AB;ab;a
 AC
 "121 Main St, NE";main;m
 "text; more text";foo;bar
+a; b


### PR DESCRIPTION
Tests illustrating that spaces after CSV delimiters are not stripped. This is something users sometimes run into when they build CSVs by hand. To make matters more confusing, Enketo does strip whitespace so issues are only caught when testing with Collect.

For now I want to make sure we have tests so that the behavior is documented and can't change without being noticed.

I followed the test style in that suite.
