### PR TITLE
Fixed deserialization of forms containing selects with default answers

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -93,10 +93,8 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
      */
     public void setRoot(TreeElement topLevel) {
         root = new TreeElement();
-        if(this.getName() != null) {
-            root.setInstanceName(this.getName());
-        }
         if (topLevel != null) {
+            root.setInstanceName(topLevel.getInstanceName());
             root.addChild(topLevel);
         }
     }

--- a/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 
-
 /**
  * This class represents the xform model instance
  */

--- a/src/test/java/org/javarosa/core/model/FormDefSerializationTest.java
+++ b/src/test/java/org/javarosa/core/model/FormDefSerializationTest.java
@@ -24,12 +24,15 @@ import static org.javarosa.test.XFormsElement.body;
 import static org.javarosa.test.XFormsElement.head;
 import static org.javarosa.test.XFormsElement.html;
 import static org.javarosa.test.XFormsElement.input;
+import static org.javarosa.test.XFormsElement.instance;
 import static org.javarosa.test.XFormsElement.mainInstance;
 import static org.javarosa.test.XFormsElement.model;
+import static org.javarosa.test.XFormsElement.select1Dynamic;
 import static org.javarosa.test.XFormsElement.t;
 import static org.javarosa.test.XFormsElement.title;
 
 import java.io.IOException;
+
 import org.javarosa.test.Scenario;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.xform.parse.XFormParser;
@@ -75,6 +78,32 @@ public class FormDefSerializationTest {
 
         deserialized.next();
         assertThat(deserialized.getFormDef().getMainInstance().getBase().getInstanceName(), is(nullValue()));
+    }
+
+    @Test public void serializeAndDeserializeFormWithDefaultAnswerInSelectQuestion_worksCorrectly() throws IOException, DeserializationException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Internal choices", html(
+            head(
+                title("Internal choices"),
+                model(
+                    mainInstance(
+                        t("data id='main-instance'",
+                            t("select-from-secondary-instance", "a")
+                        )
+                    ),
+                    instance("secondary-instance",
+                        t("item",
+                            t("label", "A"),
+                            t("value", "a")
+                        )
+                    )
+                )
+            ),
+            body(
+                select1Dynamic("/data/select-from-secondary-instance", "instance('secondary-instance')/root/item")
+            ))
+        );
+
+        scenario.serializeAndDeserializeForm();
     }
 
     private static Scenario getSimplestFormScenario() throws IOException, XFormParser.ParseException {


### PR DESCRIPTION
Closes #https://github.com/getodk/collect/issues/6571

#### What has been done to verify that this works as intended?
I've added an automated test and performed manual tests based on the steps described in the issue.

#### Why is this the best possible solution? Were any other approaches considered?
According to my findings, the issue stems from setting the instance name for tree elements in the form instance after deserialization. When reading the form from XML, everything works correctly.  

According to the provided reference:  
![image](https://github.com/user-attachments/assets/d9149006-892f-4013-9c83-f892c7444909)  

For elements in the primary instance, the instance name should be `null`. However, during deserialization, when attempting to read the reference (`ref`) of a select-one question located in the primary instance, the reference appears as:  

```
instance(Internal choices)/data/select-from-secondary-instance
```  

In this case, the instance name is mistakenly set to the ID of a child in the primary instance. According to the comment in the reference, the instance name should be `null`, and the reference should instead be (exactly as it appears when we read form from XML):  

```
/data/select-from-secondary-instance
```  

This difference in TreeReferences triggers an exception because the expected question cannot be found. I believe it worked correctly for a long time only because the `equals` method used for comparing references was faulty. Once that method was fixed in [[this pull request](https://github.com/getodk/javarosa/pull/578)](https://github.com/getodk/javarosa/pull/578), the issue began to occur.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It shouldn't affect users at all. It should only fix the problem with the deserialization of forms containing selects with default answers.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.