### PR TITLE
Fixed deserialization of forms containing triggers with no value

### DIFF
--- a/src/main/java/org/javarosa/core/model/actions/SetValueAction.java
+++ b/src/main/java/org/javarosa/core/model/actions/SetValueAction.java
@@ -37,8 +37,6 @@ public class SetValueAction extends Action {
     /** the value to be assigned to the target when this action is triggered **/
     private XPathExpression value;
 
-    private String explicitValue;
-
     public static final String ELEMENT_NAME = "setvalue";
 
     public SetValueAction() {
@@ -49,12 +47,6 @@ public class SetValueAction extends Action {
         super(ELEMENT_NAME);
         this.target = target;
         this.value = value;
-    }
-
-    public SetValueAction(TreeReference target, String explicitValue) {
-        super(ELEMENT_NAME);
-        this.target = target;
-        this.explicitValue = explicitValue;
     }
 
     public static IElementHandler getHandler() {
@@ -101,12 +93,7 @@ public class SetValueAction extends Action {
             }
         }
 
-        Object result;
-        if (explicitValue != null) {
-            result = explicitValue;
-        } else {
-            result = XPathFuncExpr.unpack(value.eval(model.getMainInstance(), context));
-        }
+        Object result = XPathFuncExpr.unpack(value.eval(model.getMainInstance(), context));
 
         int dataType = node.getDataType();
         IAnswerData val = IAnswerData.wrapData(result, dataType);
@@ -123,19 +110,11 @@ public class SetValueAction extends Action {
 
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         target = (TreeReference)ExtUtil.read(in, TreeReference.class, pf);
-        explicitValue = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        if(explicitValue == null) {
-            value = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
-        }
-
+        value = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
     }
 
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, target);
-
-        ExtUtil.write(out, ExtUtil.emptyIfNull(explicitValue));
-        if(explicitValue == null) {
-            ExtUtil.write(out, new ExtWrapTagged(value));
-        }
+        ExtUtil.write(out, new ExtWrapTagged(value));
     }
 }

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -889,7 +889,7 @@ public class XFormParser implements IXFormParserFunctions {
                 value = e.getText(0);
             }
 
-            action = new SetValueAction(treeref, value);
+            action = new SetValueAction(treeref, new XPathStringLiteral(value));
         } else {
             try {
                 action = new SetValueAction(treeref, valueExpression.equals("") ? new XPathStringLiteral("")

--- a/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
@@ -137,6 +137,34 @@ public class SetValueActionTest {
         assertThat(scenario.answerOf("/data/destination"), is(intAnswer(16)));
     }
 
+    @Test
+    public void setvalueWithNoValue_isSerializedAndDeserialized() throws IOException, DeserializationException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("Setvalue action", html(
+            head(
+                title("Setvalue action"),
+                model(
+                    mainInstance(t("data id=\"setvalue\"",
+                        t("source"),
+                        t("destination", "10")
+                    )),
+                    bind("/data/destination").type("int")
+                )
+            ),
+            body(
+                input("/data/source",
+                    setvalue("xforms-value-changed", "/data/destination"))
+            )));
+
+        scenario.serializeAndDeserializeForm();
+
+        assertThat(scenario.answerOf("/data/destination"), is(intAnswer(10)));
+
+        scenario.next();
+        scenario.answer(5);
+
+        assertThat(scenario.answerOf("/data/destination"), is(nullValue()));
+    }
+
     //region groups
     @Test
     public void setvalueInGroup_setsValueOutsideOfGroup() throws IOException, XFormParser.ParseException {


### PR DESCRIPTION
Closes #https://github.com/getodk/collect/issues/6583

#### What has been done to verify that this works as intended?
I've added an automated test and also performed manual tests.

#### Why is this the best possible solution? Were any other approaches considered?
The difference between using an empty string in a trigger versus a null value was as follows:  

- With an empty string, `SetValueAction#value` was set to `XPathStringLiteral("")`, while `SetValueAction#explicitValue` was `null`. When serialized, `explicitValue` was saved as an empty string, and `value` remained `XPathStringLiteral("")` (see [this code](https://github.com/getodk/javarosa/compare/master...grzesiek2010:javarosa:setvalue_serialize?expand=1#diff-95152bc467c506aae66b25edf2944f8b9b202c0eb2a5594e415e32bfa8ebb7c9L136)).  
- With a null trigger value, `SetValueAction#value` was `null`, and `SetValueAction#explicitValue` was an empty string. During serialization (see the link below), only `explicitValue` was saved, while `value` was skipped.  

During deserialization in the second case, an exception occurred because `value` was missing entirely.  

I found the code unnecessarily complex - having both `value` and `explicitValue` was redundant. To simplify, I removed `explicitValue` from `SetValueAction` and now always use `SetValueAction#value` with `XPathStringLiteral("")`, regardless of whether the trigger contained an empty string or null.  

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached at https://github.com/getodk/collect/issues/6583

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.
