### PR TITLE
Fixed initialization of the form definition for edits that are already modifications of finalized forms

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1116,8 +1116,11 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             if (metaSection != null) {
                 TreeElement instanceId = metaSection.getFirstChild("instanceID");
                 if (instanceId != null) {
-                    TreeElement deprecatedId = new TreeElement("deprecatedID");
-                    metaSection.addChild(deprecatedId);
+                    TreeElement deprecatedId = metaSection.getFirstChild("deprecatedID");
+                    if (deprecatedId == null) {
+                        deprecatedId = new TreeElement("deprecatedID");
+                        metaSection.addChild(deprecatedId);
+                    }
                     deprecatedId.setAnswer(instanceId.getValue());
                     instanceId.setAnswer(new StringData("uuid:" + PropertyUtils.genUUID()));
                 }

--- a/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -51,6 +51,7 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IFunctionHandler;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.test.Scenario;
 import org.javarosa.test.XFormsElement;
@@ -530,6 +531,9 @@ public class FormDefTest {
         formDef = Scenario.createFormDef("Simplest", formXml);
 
         formDef.getMainInstance().getRoot().getFirstChild("meta").getFirstChild("instanceID").setAnswer(originalInstanceID);
+        TreeElement deprecatedID = new TreeElement("deprecatedID");
+        deprecatedID.setAnswer(originalDeprecatedID);
+        formDef.getMainInstance().getRoot().getFirstChild("meta").addChild(deprecatedID);
         formDef.initialize(FormInitializationMode.FINALIZED_FORM_EDIT);
 
         IAnswerData newInstanceID = formDef.getMainInstance().getRoot().getFirstChild("meta").getFirstChild("instanceID").getValue();


### PR DESCRIPTION
Closes #

#### What has been done to verify that this works as intended?
I've improved the tests and tested the fix with ODK Collect.

#### Why is this the best possible solution? Were any other approaches considered?
When we edit a form that is already an edit of a finalized form (it already contains `deprecatedID`) we need to set that id but we don't need to add it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.