### PR TITLE
Fix handling date types

### DIFF
--- a/src/main/java/org/javarosa/core/model/data/IAnswerData.java
+++ b/src/main/java/org/javarosa/core/model/data/IAnswerData.java
@@ -23,7 +23,17 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Date;
 
-import static org.javarosa.core.model.DataType.*;
+import static org.javarosa.core.model.DataType.BOOLEAN;
+import static org.javarosa.core.model.DataType.CHOICE;
+import static org.javarosa.core.model.DataType.DATE;
+import static org.javarosa.core.model.DataType.DATE_TIME;
+import static org.javarosa.core.model.DataType.GEOPOINT;
+import static org.javarosa.core.model.DataType.GEOSHAPE;
+import static org.javarosa.core.model.DataType.GEOTRACE;
+import static org.javarosa.core.model.DataType.INTEGER;
+import static org.javarosa.core.model.DataType.LONG;
+import static org.javarosa.core.model.DataType.MULTIPLE_ITEMS;
+import static org.javarosa.core.model.DataType.TIME;
 
 /**
  * An IAnswerData object represents an answer to a question

--- a/src/main/java/org/javarosa/core/model/data/IAnswerData.java
+++ b/src/main/java/org/javarosa/core/model/data/IAnswerData.java
@@ -17,21 +17,13 @@
 package org.javarosa.core.model.data;
 
 import org.javarosa.core.model.DataType;
+import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Date;
 
-import static org.javarosa.core.model.DataType.BOOLEAN;
-import static org.javarosa.core.model.DataType.CHOICE;
-import static org.javarosa.core.model.DataType.DATE;
-import static org.javarosa.core.model.DataType.GEOPOINT;
-import static org.javarosa.core.model.DataType.GEOSHAPE;
-import static org.javarosa.core.model.DataType.GEOTRACE;
-import static org.javarosa.core.model.DataType.INTEGER;
-import static org.javarosa.core.model.DataType.LONG;
-import static org.javarosa.core.model.DataType.MULTIPLE_ITEMS;
-import static org.javarosa.core.model.DataType.TIME;
+import static org.javarosa.core.model.DataType.*;
 
 /**
  * An IAnswerData object represents an answer to a question
@@ -107,14 +99,28 @@ public interface IAnswerData extends Externalizable {
             return new SelectOneData().cast(new UncastData(String.valueOf(val)));
         } else if (dataType == MULTIPLE_ITEMS) {
             return new MultipleItemsData().cast(new UncastData(String.valueOf(val)));
+        } else if (dataType == TIME) {
+            if (val instanceof String) {
+                return new TimeData().cast(new UncastData(String.valueOf(val)));
+            } else {
+                return new TimeData((Date) val);
+            }
+        } else if (dataType == DATE) {
+            if (val instanceof String) {
+                return new DateData(DateUtils.parseDate(String.valueOf(val)));
+            } else {
+                return new DateData((Date) val);
+            }
+        } else if (dataType == DATE_TIME) {
+            if (val instanceof String) {
+                return new DateTimeData(DateUtils.parseDateTime(String.valueOf(val)));
+            } else {
+                return new DateTimeData((Date) val);
+            }
+        } else if (val instanceof Date) {
+            return new DateTimeData((Date) val);
         } else if (val instanceof String) {
             return new StringData((String) val);
-        } else if (val instanceof Date) {
-            if (dataType == TIME)
-                return new TimeData((Date) val);
-            if (dataType == DATE)
-                return new DateData((Date) val);
-            return new DateTimeData((Date) val);
         } else {
             throw new RuntimeException("unrecognized data type in 'calculate' expression: " + val.getClass().getName());
         }

--- a/src/test/java/org/javarosa/core/model/DateTimeTest.java
+++ b/src/test/java/org/javarosa/core/model/DateTimeTest.java
@@ -13,8 +13,14 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.javarosa.test.BindBuilderXFormsElement.bind;
-import static org.javarosa.test.XFormsElement.*;
+import static org.javarosa.test.XFormsElement.body;
+import static org.javarosa.test.XFormsElement.head;
+import static org.javarosa.test.XFormsElement.html;
 import static org.javarosa.test.XFormsElement.input;
+import static org.javarosa.test.XFormsElement.mainInstance;
+import static org.javarosa.test.XFormsElement.model;
+import static org.javarosa.test.XFormsElement.t;
+import static org.javarosa.test.XFormsElement.title;
 
 public class DateTimeTest {
     @Test

--- a/src/test/java/org/javarosa/core/model/DateTimeTest.java
+++ b/src/test/java/org/javarosa/core/model/DateTimeTest.java
@@ -30,28 +30,28 @@ public class DateTimeTest {
                 title("Time form"),
                 model(
                     mainInstance(t("data id=\"time-form\"",
-                        t("time1"),
-                        t("time2", "23:14:00.000+02:00"),
-                        t("time3")
+                        t("calculateLiteral"),
+                        t("empty", "23:14:00.000+02:00"),
+                        t("calculateReference")
                     )),
-                    bind("/data/time1").type("time").calculate("&quot;23:14:00.000+02:00&quot;"),
-                    bind("/data/time2").type("time"),
-                    bind("/data/time3").type("time").calculate("/data/time2")
+                    bind("/data/calculateLiteral").type("time").calculate("&quot;23:14:00.000+02:00&quot;"),
+                    bind("/data/empty").type("time"),
+                    bind("/data/calculateReference").type("time").calculate("/data/empty")
                 )
             ),
             body(
-                input("/data/time1"),
-                input("/data/time2"),
-                input("/data/time3")
+                input("/data/calculateLiteral"),
+                input("/data/empty"),
+                input("/data/calculateReference")
             )
         ));
-        IAnswerData answer1 = scenario.answerOf("/data/time1");
+        IAnswerData answer1 = scenario.answerOf("/data/calculateLiteral");
         assertThat(answer1 instanceof TimeData, equalTo(true));
 
-        IAnswerData answer2 = scenario.answerOf("/data/time2");
+        IAnswerData answer2 = scenario.answerOf("/data/empty");
         assertThat(answer2 instanceof TimeData, equalTo(true));
 
-        IAnswerData answer3 = scenario.answerOf("/data/time3");
+        IAnswerData answer3 = scenario.answerOf("/data/calculateReference");
         assertThat(answer3 instanceof TimeData, equalTo(true));
     }
 
@@ -62,28 +62,28 @@ public class DateTimeTest {
                 title("Date form"),
                 model(
                     mainInstance(t("data id=\"date-form\"",
-                        t("date1"),
-                        t("date2", "2025-09-25"),
-                        t("date3")
+                        t("calculateLiteral"),
+                        t("empty", "2025-09-25"),
+                        t("calculateReference")
                     )),
-                    bind("/data/date1").type("date").calculate("&quot;2025-09-25&quot;"),
-                    bind("/data/date2").type("date"),
-                    bind("/data/date3").type("date").calculate("/data/date2")
+                    bind("/data/calculateLiteral").type("date").calculate("&quot;2025-09-25&quot;"),
+                    bind("/data/empty").type("date"),
+                    bind("/data/calculateReference").type("date").calculate("/data/empty")
                 )
             ),
             body(
-                input("/data/date1"),
-                input("/data/date2"),
-                input("/data/date3")
+                input("/data/calculateLiteral"),
+                input("/data/empty"),
+                input("/data/calculateReference")
             )
         ));
-        IAnswerData answer1 = scenario.answerOf("/data/date1");
+        IAnswerData answer1 = scenario.answerOf("/data/calculateLiteral");
         assertThat(answer1 instanceof DateData, equalTo(true));
 
-        IAnswerData answer2 = scenario.answerOf("/data/date2");
+        IAnswerData answer2 = scenario.answerOf("/data/empty");
         assertThat(answer2 instanceof DateData, equalTo(true));
 
-        IAnswerData answer3 = scenario.answerOf("/data/date3");
+        IAnswerData answer3 = scenario.answerOf("/data/calculateReference");
         assertThat(answer3 instanceof DateData, equalTo(true));
     }
 
@@ -94,28 +94,28 @@ public class DateTimeTest {
                 title("DateTime form"),
                 model(
                     mainInstance(t("data id=\"datetime-form\"",
-                        t("dateTime1"),
-                        t("dateTime2", "2025-09-25T23:15:00.000+02:00"),
-                        t("dateTime3")
+                        t("calculateLiteral"),
+                        t("empty", "2025-09-25T23:15:00.000+02:00"),
+                        t("calculateReference")
                     )),
-                    bind("/data/dateTime1").type("dateTime").calculate("&quot;2025-09-25T23:15:00.000+02:00&quot;"),
-                    bind("/data/dateTime2").type("dateTime"),
-                    bind("/data/dateTime3").type("dateTime").calculate("/data/dateTime2")
+                    bind("/data/calculateLiteral").type("dateTime").calculate("&quot;2025-09-25T23:15:00.000+02:00&quot;"),
+                    bind("/data/empty").type("dateTime"),
+                    bind("/data/calculateReference").type("dateTime").calculate("/data/empty")
                 )
             ),
             body(
-                input("/data/dateTime1"),
-                input("/data/dateTime2"),
-                input("/data/dateTime3")
+                input("/data/calculateLiteral"),
+                input("/data/empty"),
+                input("/data/calculateReference")
             )
         ));
-        IAnswerData answer1 = scenario.answerOf("/data/dateTime1");
+        IAnswerData answer1 = scenario.answerOf("/data/calculateLiteral");
         assertThat(answer1 instanceof DateTimeData, equalTo(true));
 
-        IAnswerData answer2 = scenario.answerOf("/data/dateTime2");
+        IAnswerData answer2 = scenario.answerOf("/data/empty");
         assertThat(answer2 instanceof DateTimeData, equalTo(true));
 
-        IAnswerData answer3 = scenario.answerOf("/data/dateTime3");
+        IAnswerData answer3 = scenario.answerOf("/data/calculateReference");
         assertThat(answer3 instanceof DateTimeData, equalTo(true));
     }
 }

--- a/src/test/java/org/javarosa/core/model/DateTimeTest.java
+++ b/src/test/java/org/javarosa/core/model/DateTimeTest.java
@@ -1,0 +1,115 @@
+package org.javarosa.core.model;
+
+import org.javarosa.core.model.data.DateData;
+import org.javarosa.core.model.data.DateTimeData;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.TimeData;
+import org.javarosa.test.Scenario;
+import org.javarosa.xform.parse.XFormParser;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.javarosa.test.BindBuilderXFormsElement.bind;
+import static org.javarosa.test.XFormsElement.*;
+import static org.javarosa.test.XFormsElement.input;
+
+public class DateTimeTest {
+    @Test
+    public void timeQuestionReturnsTimeDataAnswer() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("DateTime form", html(
+            head(
+                title("Time form"),
+                model(
+                    mainInstance(t("data id=\"time-form\"",
+                        t("time1"),
+                        t("time2", "23:14:00.000+02:00"),
+                        t("time3")
+                    )),
+                    bind("/data/time1").type("time").calculate("&quot;23:14:00.000+02:00&quot;"),
+                    bind("/data/time2").type("time"),
+                    bind("/data/time3").type("time").calculate("/data/time2")
+                )
+            ),
+            body(
+                input("/data/time1"),
+                input("/data/time2"),
+                input("/data/time3")
+            )
+        ));
+        IAnswerData answer1 = scenario.answerOf("/data/time1");
+        assertThat(answer1 instanceof TimeData, equalTo(true));
+
+        IAnswerData answer2 = scenario.answerOf("/data/time2");
+        assertThat(answer2 instanceof TimeData, equalTo(true));
+
+        IAnswerData answer3 = scenario.answerOf("/data/time3");
+        assertThat(answer3 instanceof TimeData, equalTo(true));
+    }
+
+    @Test
+    public void dateQuestionReturnsDateDataAnswer() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("DateTime form", html(
+            head(
+                title("Date form"),
+                model(
+                    mainInstance(t("data id=\"date-form\"",
+                        t("date1"),
+                        t("date2", "2025-09-25"),
+                        t("date3")
+                    )),
+                    bind("/data/date1").type("date").calculate("&quot;2025-09-25&quot;"),
+                    bind("/data/date2").type("date"),
+                    bind("/data/date3").type("date").calculate("/data/date2")
+                )
+            ),
+            body(
+                input("/data/date1"),
+                input("/data/date2"),
+                input("/data/date3")
+            )
+        ));
+        IAnswerData answer1 = scenario.answerOf("/data/date1");
+        assertThat(answer1 instanceof DateData, equalTo(true));
+
+        IAnswerData answer2 = scenario.answerOf("/data/date2");
+        assertThat(answer2 instanceof DateData, equalTo(true));
+
+        IAnswerData answer3 = scenario.answerOf("/data/date3");
+        assertThat(answer3 instanceof DateData, equalTo(true));
+    }
+
+    @Test
+    public void dateTimeQuestionReturnsDateTimeDataAnswer() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init("DateTime form", html(
+            head(
+                title("DateTime form"),
+                model(
+                    mainInstance(t("data id=\"datetime-form\"",
+                        t("dateTime1"),
+                        t("dateTime2", "2025-09-25T23:15:00.000+02:00"),
+                        t("dateTime3")
+                    )),
+                    bind("/data/dateTime1").type("dateTime").calculate("&quot;2025-09-25T23:15:00.000+02:00&quot;"),
+                    bind("/data/dateTime2").type("dateTime"),
+                    bind("/data/dateTime3").type("dateTime").calculate("/data/dateTime2")
+                )
+            ),
+            body(
+                input("/data/dateTime1"),
+                input("/data/dateTime2"),
+                input("/data/dateTime3")
+            )
+        ));
+        IAnswerData answer1 = scenario.answerOf("/data/dateTime1");
+        assertThat(answer1 instanceof DateTimeData, equalTo(true));
+
+        IAnswerData answer2 = scenario.answerOf("/data/dateTime2");
+        assertThat(answer2 instanceof DateTimeData, equalTo(true));
+
+        IAnswerData answer3 = scenario.answerOf("/data/dateTime3");
+        assertThat(answer3 instanceof DateTimeData, equalTo(true));
+    }
+}


### PR DESCRIPTION
Closes #831 

#### What has been done to verify that this works as intended?
I've added automated tests and tested the fix manually with Collect.

#### Why is this the best possible solution? Were any other approaches considered?
As briefly described in one of the comments on the issue, the problem was that sometimes the wrong data type was returned for a given question, for example, `StringData` instead of `TimeData`. I couldn’t think of any other approach. We needed to handle the data types returned by `time`, `date`, and `dateTime` questions correctly, and that’s what I did.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just fix the issue, but it would be good to test the three related question types for regressions (`time`, `date` and `dateTime`).

#### Do we need any specific form for testing your changes? If so, please attach one.
[dateTimes.xlsx](https://github.com/user-attachments/files/22548597/dateTimes.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.