### PR TITLE
Add support for tick itemset for range

### DIFF
--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -1170,13 +1170,6 @@ public class XFormParser implements IXFormParserFunctions {
             }
         }
 
-        final boolean hasItems =
-            controlType == CONTROL_SELECT_MULTI
-                || controlType == CONTROL_RANK
-                || controlType == CONTROL_SELECT_ONE;
-
-        final boolean hasOptionalItemset = controlType == CONTROL_RANGE;
-
         question.setControlType(controlType);
         question.setAppearanceAttr(e.getAttributeValue(null, APPEARANCE_ATTR));
 
@@ -1189,15 +1182,16 @@ public class XFormParser implements IXFormParserFunctions {
                 parseQuestionLabel(question, child);
             } else if ("hint".equals(childName)) {
                 parseHint(question, child);
-            } else if (hasItems && "item".equals(childName)) {
+            } else if ((hasRequiredItems(controlType) || hasOptionalItems(controlType)) && "item".equals(childName)) {
                 parseItem(question, child);
-            } else if ((hasItems || hasOptionalItemset) && "itemset".equals(childName)) {
+            } else if ((hasRequiredItems(controlType) || hasOptionalItems(controlType)) && "itemset".equals(childName)) {
                 parseItemset(question, child, parent);
             } else if (actionHandlers.containsKey(childName)) {
                 actionHandlers.get(childName).handle(this, child, question);
             }
         }
-        if (hasItems) {
+
+        if (hasRequiredItems(controlType)) {
             if (question.getNumChoices() > 0 && question.getDynamicChoices() != null) {
                 throw new XFormParseException("Select question contains both literal choices and <itemset>");
             } else if (question.getNumChoices() == 0 && question.getDynamicChoices() == null) {
@@ -1215,6 +1209,16 @@ public class XFormParser implements IXFormParserFunctions {
 
         questionProcessors.stream().forEach(questionProcessor -> questionProcessor.processQuestion(question));
         return question;
+    }
+
+    private static boolean hasRequiredItems(int controlType) {
+        return controlType == CONTROL_SELECT_MULTI
+                || controlType == CONTROL_RANK
+                || controlType == CONTROL_SELECT_ONE;
+    }
+
+    private static boolean hasOptionalItems(int controlType) {
+        return controlType == CONTROL_RANGE;
     }
 
     private QuestionDef questionForControlType(int controlType) {

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -1170,10 +1170,12 @@ public class XFormParser implements IXFormParserFunctions {
             }
         }
 
-        boolean isItem =
+        final boolean hasItems =
             controlType == CONTROL_SELECT_MULTI
                 || controlType == CONTROL_RANK
                 || controlType == CONTROL_SELECT_ONE;
+
+        final boolean hasOptionalItemset = controlType == CONTROL_RANGE;
 
         question.setControlType(controlType);
         question.setAppearanceAttr(e.getAttributeValue(null, APPEARANCE_ATTR));
@@ -1187,15 +1189,15 @@ public class XFormParser implements IXFormParserFunctions {
                 parseQuestionLabel(question, child);
             } else if ("hint".equals(childName)) {
                 parseHint(question, child);
-            } else if (isItem && "item".equals(childName)) {
+            } else if (hasItems && "item".equals(childName)) {
                 parseItem(question, child);
-            } else if (isItem && "itemset".equals(childName)) {
+            } else if ((hasItems || hasOptionalItemset) && "itemset".equals(childName)) {
                 parseItemset(question, child, parent);
             } else if (actionHandlers.containsKey(childName)) {
                 actionHandlers.get(childName).handle(this, child, question);
             }
         }
-        if (isItem) {
+        if (hasItems) {
             if (question.getNumChoices() > 0 && question.getDynamicChoices() != null) {
                 throw new XFormParseException("Select question contains both literal choices and <itemset>");
             } else if (question.getNumChoices() == 0 && question.getDynamicChoices() == null) {

--- a/src/test/java/org/javarosa/xform/parse/XFormParserTest.java
+++ b/src/test/java/org/javarosa/xform/parse/XFormParserTest.java
@@ -1,37 +1,7 @@
 package org.javarosa.xform.parse;
 
-import static java.nio.file.Files.copy;
-import static java.nio.file.Files.readAllBytes;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.javarosa.core.model.Constants.CONTROL_RANGE;
-import static org.javarosa.core.model.Constants.CONTROL_RANK;
-import static org.javarosa.core.test.AnswerDataMatchers.intAnswer;
-import static org.javarosa.test.BindBuilderXFormsElement.bind;
-import static org.javarosa.test.XFormsElement.body;
-import static org.javarosa.test.XFormsElement.head;
-import static org.javarosa.test.XFormsElement.html;
-import static org.javarosa.test.XFormsElement.input;
-import static org.javarosa.test.XFormsElement.mainInstance;
-import static org.javarosa.test.XFormsElement.model;
-import static org.javarosa.test.XFormsElement.t;
-import static org.javarosa.test.ResourcePathHelper.r;
-import static org.javarosa.xform.parse.FormParserHelper.deserializeAndCleanUpSerializedForm;
-import static org.javarosa.xform.parse.FormParserHelper.getSerializedFormPath;
-import static org.javarosa.xform.parse.FormParserHelper.parse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
 import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
 import org.javarosa.core.model.IDataReference;
 import org.javarosa.core.model.IFormElement;
@@ -48,10 +18,13 @@ import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.reference.ReferenceManagerTestUtils;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
-import org.javarosa.test.Scenario;
 import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
+import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.model.xform.XFormSerializingVisitor;
 import org.javarosa.model.xform.XPathReference;
+import org.javarosa.test.Scenario;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.After;
 import org.junit.Before;
@@ -61,6 +34,40 @@ import org.junit.rules.ExpectedException;
 import org.kxml2.kdom.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static java.nio.file.Files.copy;
+import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.javarosa.core.model.Constants.CONTROL_RANGE;
+import static org.javarosa.core.model.Constants.CONTROL_RANK;
+import static org.javarosa.core.test.AnswerDataMatchers.intAnswer;
+import static org.javarosa.test.BindBuilderXFormsElement.bind;
+import static org.javarosa.test.ResourcePathHelper.r;
+import static org.javarosa.test.XFormsElement.body;
+import static org.javarosa.test.XFormsElement.head;
+import static org.javarosa.test.XFormsElement.html;
+import static org.javarosa.test.XFormsElement.input;
+import static org.javarosa.test.XFormsElement.mainInstance;
+import static org.javarosa.test.XFormsElement.model;
+import static org.javarosa.test.XFormsElement.t;
+import static org.javarosa.xform.parse.FormParserHelper.deserializeAndCleanUpSerializedForm;
+import static org.javarosa.xform.parse.FormParserHelper.getSerializedFormPath;
+import static org.javarosa.xform.parse.FormParserHelper.parse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class XFormParserTest {
     private static final Logger logger = LoggerFactory.getLogger(XFormParserTest.class);
@@ -201,6 +208,22 @@ public class XFormParserTest {
         FormDef deserializedFormDef = deserializeAndCleanUpSerializedForm(serializedForm);
 
         assertThat(originalFormDef.getTitle(), is(deserializedFormDef.getTitle()));
+
+        RangeQuestion question = (RangeQuestion) deserializedFormDef.getChild(0);
+        assertThat(question.getDynamicChoices(), is(nullValue()));
+    }
+
+    @Test
+    public void itemsetRangeFormSavesAndRestores() throws IOException, XFormParser.ParseException, DeserializationException {
+        FormDef originalFormDef = parse(r("range-form-itemset.xml"));
+
+        Path serializedForm = getSerializedFormPath(originalFormDef);
+        FormDef deserializedFormDef = deserializeAndCleanUpSerializedForm(serializedForm);
+
+        assertThat(originalFormDef.getTitle(), is(deserializedFormDef.getTitle()));
+
+        RangeQuestion question = (RangeQuestion) deserializedFormDef.getChild(0);
+        assertThat(question.getDynamicChoices(), is(notNullValue()));
     }
 
     @Test
@@ -220,6 +243,23 @@ public class XFormParserTest {
         assertEquals(-2.0d, question.getRangeStart().doubleValue(), 0);
         assertEquals(2.0d, question.getRangeEnd().doubleValue(), 0);
         assertEquals(0.5d, question.getRangeStep().doubleValue(), 0);
+    }
+
+    @Test
+    public void parsesRangeFormWithItemset() throws IOException, XFormParser.ParseException {
+        FormDef formDef = parse(r("range-form-itemset.xml"));
+        RangeQuestion question = (RangeQuestion) formDef.getChild(0);
+        assertEquals(CONTROL_RANGE, question.getControlType());
+        assertEquals(-2.0d, question.getRangeStart().doubleValue(), 0);
+        assertEquals(2.0d, question.getRangeEnd().doubleValue(), 0);
+        assertEquals(0.5d, question.getRangeStep().doubleValue(), 0);
+
+        FormEntryModel formEntryModel = new FormEntryModel(formDef);
+        FormEntryController formEntryController = new FormEntryController(formEntryModel);
+        formEntryController.stepToNextEvent();
+        FormIndex questionIndex = formEntryController.getModel().getFormIndex();
+        FormEntryPrompt formEntryPrompt = formEntryModel.getQuestionPrompt(questionIndex);
+        assertThat(formEntryPrompt.getSelectChoices().size(), is(2));
     }
 
     @Test(expected = XFormParseException.class)

--- a/src/test/resources/range-form-itemset.xml
+++ b/src/test/resources/range-form-itemset.xml
@@ -1,0 +1,40 @@
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:h="http://www.w3.org/1999/xhtml">
+
+    <h:head>
+        <h:title>Form with a Range</h:title>
+        <model>
+            <instance>
+                <stats id="a">
+                    <balance/>
+                </stats>
+            </instance>
+
+            <instance id="ticks">
+                <root>
+                    <item>
+                        <name>-2.0</name>
+                        <label>Great</label>
+                    </item>
+                    <item>
+                        <name>2.0</name>
+                        <label>Bad</label>
+                    </item>
+                </root>
+            </instance>
+
+            <bind nodeset="/stats/balance" type="xsd:decimal" />
+        </model>
+    </h:head>
+
+    <h:body>
+        <range ref="/stats/balance" start="-2.0" end="2.0" step="0.5">
+            <label>Balance</label>
+            <itemset nodeset="instance('ticks')/root/item">
+                <label ref="label" />
+                <value ref="name" />
+            </itemset>
+        </range>
+    </h:body>
+
+</h:html>


### PR DESCRIPTION
In support of https://github.com/getodk/collect/issues/7013

#### What has been done to verify that this works as intended?
Added and ran tests.

#### Why is this the best possible solution? Were any other approaches considered?
We considered having a special `tick-labelset` attribute to specify the nodeset with label items but @garethbowen nudged us to consider reusing the `itemset` child pattern already used for selects and rank.

The names of methods in JavaRosa don't feel quite right for this because they're focused on `itemset`s defining select choices but I think it's understandable enough. I considered adding a `getChildItems` method to `FormEntryPrompt` that just delegates to `getSelectChoices` but felt that didn't add enough to justify further expanding the API. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It's a focused, additive change so risk is low. There should be no change to existing behavior. Collect should now be able to use `getSelectChoices` on a `range` to get its tick labels.

#### Do we need any specific form for testing your changes? If so, please attach one.
See test. This will be hard to validate outside of a test before Collect has support.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Not yet.