### PR TITLE
Fix string representation of geotrace and geoshape data

### DIFF
--- a/src/main/java/org/javarosa/core/model/data/GeoShapeData.java
+++ b/src/main/java/org/javarosa/core/model/data/GeoShapeData.java
@@ -96,7 +96,7 @@ public class GeoShapeData implements IAnswerData, IExprDataType {
         boolean first = true;
         for ( GeoPointData p : points ) {
             if ( !first ) {
-                b.append("; ");
+                b.append(";");
             }
             first = false;
             b.append(p.getDisplayText());

--- a/src/main/java/org/javarosa/core/model/data/GeoTraceData.java
+++ b/src/main/java/org/javarosa/core/model/data/GeoTraceData.java
@@ -101,7 +101,7 @@ public class GeoTraceData implements IAnswerData, IExprDataType {
         boolean first = true;
         for ( GeoPointData p : points ) {
             if ( !first ) {
-                b.append("; ");
+                b.append(";");
             }
             first = false;
             b.append(p.getDisplayText());

--- a/src/test/java/org/javarosa/core/model/data/GeoShapeDataTest.java
+++ b/src/test/java/org/javarosa/core/model/data/GeoShapeDataTest.java
@@ -55,4 +55,14 @@ public class GeoShapeDataTest {
             )))).hashCode())
         );
     }
+
+    @Test
+    public void getDisplayText_returnsSemicolonSeparatedPoints() {
+        GeoShapeData data = new GeoShapeData(new GeoShapeData.GeoShape(Arrays.asList(
+            new double[]{1.0, 1.0, 0.0, 0.0},
+            new double[]{2.0, 2.0, 0.0, 0.0}
+        )));
+
+        assertThat(data.getDisplayText(), equalTo("1.0 1.0 0.0 0.0;2.0 2.0 0.0 0.0"));
+    }
 }

--- a/src/test/java/org/javarosa/core/model/data/GeoTraceDataTest.java
+++ b/src/test/java/org/javarosa/core/model/data/GeoTraceDataTest.java
@@ -56,4 +56,14 @@ public class GeoTraceDataTest {
             )))).hashCode())
         );
     }
+
+    @Test
+    public void getDisplayText_returnsSemicolonSeparatedPoints() {
+        GeoTraceData data = new GeoTraceData(new GeoTraceData.GeoTrace(Arrays.asList(
+            new double[]{1.0, 1.0, 0.0, 0.0},
+            new double[]{2.0, 2.0, 0.0, 0.0}
+        )));
+
+        assertThat(data.getDisplayText(), equalTo("1.0 1.0 0.0 0.0;2.0 2.0 0.0 0.0"));
+    }
 }


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've tested the changes with Collect.

#### Why is this the best possible solution? Were any other approaches considered?
Points should be separated by semicolons, without any whitespace between them.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should simply fix the string representation of getotrace/geoshape data.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any for with geotrace/geoshape questions.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.