### PR TITLE
Do not remove answers that are not in choices list for RangeQuestion

### DIFF
--- a/src/main/java/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/main/java/org/javarosa/core/model/ItemsetBinding.java
@@ -2,9 +2,7 @@ package org.javarosa.core.model;
 
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IConditionExpr;
-import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
-import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.model.data.MultipleItemsData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
@@ -257,12 +255,8 @@ public class ItemsetBinding implements Externalizable, Localizable {
      */
     private void updateQuestionAnswerInModel(FormDef formDef, TreeReference curQRef, Map<String, SelectChoice> selectChoicesForAnswer) {
         IAnswerData originalValue = formDef.getMainInstance().resolveReference(curQRef).getValue();
-        if (originalValue instanceof IntegerData || originalValue instanceof DecimalData) {
-            // Do not perform any updates for RangeQuestion with choices
-            return;
-        }
-        
-        if (selectChoicesForAnswer != null) {
+
+        if (originalValue instanceof MultipleItemsData || originalValue instanceof SelectOneData) {
             IAnswerData boundAndFilteredValue;
             if (originalValue instanceof MultipleItemsData) {
                 boundAndFilteredValue = getFilteredAndBoundSelections((MultipleItemsData) originalValue, selectChoicesForAnswer);

--- a/src/main/java/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/main/java/org/javarosa/core/model/ItemsetBinding.java
@@ -2,7 +2,9 @@ package org.javarosa.core.model;
 
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IConditionExpr;
+import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.model.data.MultipleItemsData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
@@ -255,7 +257,11 @@ public class ItemsetBinding implements Externalizable, Localizable {
      */
     private void updateQuestionAnswerInModel(FormDef formDef, TreeReference curQRef, Map<String, SelectChoice> selectChoicesForAnswer) {
         IAnswerData originalValue = formDef.getMainInstance().resolveReference(curQRef).getValue();
-
+        if (originalValue instanceof IntegerData || originalValue instanceof DecimalData) {
+            // Do not perform any updates for RangeQuestion with choices
+            return;
+        }
+        
         if (selectChoicesForAnswer != null) {
             IAnswerData boundAndFilteredValue;
             if (originalValue instanceof MultipleItemsData) {

--- a/src/main/java/org/javarosa/test/Scenario.java
+++ b/src/main/java/org/javarosa/test/Scenario.java
@@ -601,6 +601,13 @@ public class Scenario {
         return answer(new SelectOneData(choice.selection()));
     }
 
+    public AnswerResult answer(String xPath, SelectChoice choice) {
+        createMissingRepeats(xPath);
+        TreeReference ref = getRef(xPath);
+        silentJump(getIndexOf(ref));
+        return answer(new SelectOneData(choice.selection()));
+    }
+
     /**
      * Answers the question at the form index
      */

--- a/src/test/java/org/javarosa/core/model/RangeQuestionTest.java
+++ b/src/test/java/org/javarosa/core/model/RangeQuestionTest.java
@@ -20,11 +20,11 @@ import static org.javarosa.test.XFormsElement.title;
 public class RangeQuestionTest {
     @Test
     public void answerIsPreservedWhenRangeQuestionHasIncompleteChoices() throws Exception {
-        Scenario scenario = Scenario.init("indefinite repeat", html(
+        Scenario scenario = Scenario.init("range question with incomplete choices", html(
             head(
-                title("Indefinite repeat"),
+                title("Range question with incomplete choices"),
                 model(
-                    mainInstance(t("data id=\"indefinite-repeat\"",
+                    mainInstance(t("data id=\"range-question-with-incomplete-choices\"",
                         t("range")
                     )),
 

--- a/src/test/java/org/javarosa/core/model/RangeQuestionTest.java
+++ b/src/test/java/org/javarosa/core/model/RangeQuestionTest.java
@@ -1,0 +1,45 @@
+package org.javarosa.core.model;
+
+import org.javarosa.test.Scenario;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.javarosa.core.test.AnswerDataMatchers.intAnswer;
+import static org.javarosa.test.BindBuilderXFormsElement.bind;
+import static org.javarosa.test.XFormsElement.*;
+import static org.javarosa.test.XFormsElement.t;
+
+public class RangeQuestionTest {
+    @Test
+    public void answerIsPreservedWhenRangeQuestionHasIncompleteChoices() throws Exception {
+        Scenario scenario = Scenario.init("indefinite repeat", html(
+            head(
+                title("Indefinite repeat"),
+                model(
+                    mainInstance(t("data id=\"indefinite-repeat\"",
+                        t("range")
+                    )),
+
+                    instance("ticks",
+                        item(-2, "A"),
+                        item(0, "B"),
+                        item(2, "C")),
+
+                    bind("/data/range").type("int")
+                )),
+            body(
+                t("range ref=\"/data/range\" start=\"-2\" end=\"2\" step=\"1\"",
+                    t("itemset nodeset=\"instance('ticks')/root/item\"",
+                        t("label ref=\"label\""),
+                        t("value ref=\"value\"")
+                    )
+                )
+            )
+        ));
+
+        scenario.answer("/data/range", 1);
+        scenario.choicesOf("/data/range");
+        assertThat(scenario.answerOf("/data/range"), is(intAnswer(1)));
+    }
+}

--- a/src/test/java/org/javarosa/core/model/RangeQuestionTest.java
+++ b/src/test/java/org/javarosa/core/model/RangeQuestionTest.java
@@ -7,8 +7,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.AnswerDataMatchers.intAnswer;
 import static org.javarosa.test.BindBuilderXFormsElement.bind;
-import static org.javarosa.test.XFormsElement.*;
+import static org.javarosa.test.XFormsElement.body;
+import static org.javarosa.test.XFormsElement.head;
+import static org.javarosa.test.XFormsElement.html;
+import static org.javarosa.test.XFormsElement.instance;
+import static org.javarosa.test.XFormsElement.item;
+import static org.javarosa.test.XFormsElement.mainInstance;
+import static org.javarosa.test.XFormsElement.model;
 import static org.javarosa.test.XFormsElement.t;
+import static org.javarosa.test.XFormsElement.title;
 
 public class RangeQuestionTest {
     @Test

--- a/src/test/java/org/javarosa/core/model/SelectOneChoiceFilterTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectOneChoiceFilterTest.java
@@ -99,8 +99,8 @@ public class SelectOneChoiceFilterTest {
         assertThat(scenario.choicesOf("/data/level2"), empty());
         assertThat(scenario.choicesOf("/data/level3"), empty());
 
-        scenario.answer("/data/level1", "a");
-        scenario.answer("/data/level2", "aa");
+        scenario.answer("/data/level1", scenario.choicesOf("/data/level1").get(0));
+        scenario.answer("/data/level2", scenario.choicesOf("/data/level2").get(0));
         assertThat(scenario.choicesOf("/data/level3"), containsInAnyOrder(
             choice("aaa"),
             choice("aab")));
@@ -119,9 +119,9 @@ public class SelectOneChoiceFilterTest {
         assertThat(scenario.answerOf("/data/level2"), nullValue());
         assertThat(scenario.answerOf("/data/level3"), nullValue());
 
-        scenario.answer("/data/level1", "a");
-        scenario.answer("/data/level2", "aa");
-        scenario.answer("/data/level3", "aab");
+        scenario.answer("/data/level1", scenario.choicesOf("/data/level1").get(0));
+        scenario.answer("/data/level2", scenario.choicesOf("/data/level2").get(0));
+        scenario.answer("/data/level3", scenario.choicesOf("/data/level3").get(0));
 
         scenario.answer("/data/level1", "");
 
@@ -144,14 +144,14 @@ public class SelectOneChoiceFilterTest {
     public void changingValueAtLevel2_ShouldClearLevel3_IfChoiceNoLongerAvailable() {
         scenario.newInstance();
 
-        scenario.answer("/data/level1_contains", "a");
-        scenario.answer("/data/level2_contains", "aa");
+        scenario.answer("/data/level1_contains", scenario.choicesOf("/data/level1_contains").get(0));
+        scenario.answer("/data/level2_contains", scenario.choicesOf("/data/level2_contains").get(0));
         assertThat(scenario.choicesOf("/data/level3_contains"), containsInAnyOrder(
             choice("aaa"),
             choice("aab"),
             choice("baa")));
-        scenario.answer("/data/level3_contains", "aaa");
-        scenario.answer("/data/level2_contains", "ab");
+        scenario.answer("/data/level3_contains", scenario.choicesOf("/data/level3_contains").get(0));
+        scenario.answer("/data/level2_contains", scenario.choicesOf("/data/level2_contains").get(1));
         assertThat(scenario.choicesOf("/data/level3_contains"), containsInAnyOrder(
             choice("aab"),
             choice("bab")));


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've added automated tests and also tested the fix with Collect.

#### Why is this the best possible solution? Were any other approaches considered?
Comments below.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It shouldn’t cause any regression in the features we currently support. Once range questions with labels become available in Collect, this should prevent removing answers that don’t have corresponding choices.

#### Do we need any specific form for testing your changes? If so, please attach one.
The one from https://github.com/getodk/javarosa/pull/841 (from tests), for example.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.