### PR TITLE
Allow any question to optionally have choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Snapshots are published for each commit to `master` and are available [here](htt
 
 ## Requirements
 
-JavaRosa works on Android API level 21+ (with desugaring enabled) and Java 8+.
+JavaRosa works on Android API level 26+ (with desugaring enabled) and Java 8+.
 
 ## Extending
 

--- a/build.gradle
+++ b/build.gradle
@@ -122,8 +122,8 @@ if (!project.hasProperty("android")) {
         compileSdk = 36
 
         defaultConfig {
-            minSdk = 21
-            targetSdk = 33
+            minSdk = 26
+            targetSdk = 36
             versionCode = 1
             versionName = "1.0"
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -131,8 +131,8 @@ if (!project.hasProperty("android")) {
 
         compileOptions {
             coreLibraryDesugaringEnabled = true // For APIs requiring > API 21
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
 
         buildTypes {

--- a/src/jmh/java/org/javarosa/benchmarks/core/model/CreateRepeatDagBenchmark.java
+++ b/src/jmh/java/org/javarosa/benchmarks/core/model/CreateRepeatDagBenchmark.java
@@ -97,7 +97,7 @@ public class CreateRepeatDagBenchmark {
     }
 
     static Scenario getExpressionInsideScenario() throws IOException, XFormParser.ParseException {
-        return Scenario.init("Repeat with expression inside", html(
+        return Scenario.init(html(
             head(
                 title("Repeat with expression inside"),
                 model(
@@ -119,7 +119,7 @@ public class CreateRepeatDagBenchmark {
     }
 
     static Scenario getExpressionInsideWithRefOutsideScenario() throws IOException, XFormParser.ParseException {
-        return Scenario.init("Repeat with expression inside referencing outside", html(
+        return Scenario.init(html(
             head(
                 title("Repeat with expression inside referencing outside"),
                 model(
@@ -141,7 +141,7 @@ public class CreateRepeatDagBenchmark {
     }
 
     static Scenario getSumExpressionOutsideScenario() throws IOException, XFormParser.ParseException {
-        return Scenario.init("Repeat with sum expression outside", html(
+        return Scenario.init(html(
             head(
                 title("Repeat with sum expression outside"),
                 model(
@@ -163,7 +163,7 @@ public class CreateRepeatDagBenchmark {
     }
 
     static Scenario getExpressionInsideWithPositionCallScenario() throws IOException, XFormParser.ParseException {
-        return Scenario.init("Repeat with expression inside referencing outside", html(
+        return Scenario.init(html(
             head(
                 title("Repeat with expression inside referencing outside"),
                 model(

--- a/src/main/java/org/javarosa/test/Scenario.java
+++ b/src/main/java/org/javarosa/test/Scenario.java
@@ -273,7 +273,7 @@ public class Scenario {
         new XFormsModule().registerModule();
 
         // Serialize form in a temp file
-        File tempFile = TempFileUtils.createTempFile("javarosa", "test");
+        File tempFile = TempFileUtils.createTempFile("test");
         formDef.writeExternal(new DataOutputStream(new FileOutputStream(tempFile)));
 
         // Create an empty FormDef and deserialize the form into it
@@ -434,28 +434,27 @@ public class Scenario {
     /**
      * Initializes the Scenario using a form defined using the DSL in XFormsElement
      */
-    // TODO Extract the form's name from the provided XFormsElement object to simplify args
-    public static Scenario init(String formName, XFormsElement form) throws IOException, XFormParser.ParseException {
-        File tempDir = TempFileUtils.createTempDir("javarosa");
-        File formFile = TempFileUtils.createTempFile(tempDir, formName, "xml");
+    public static Scenario init(XFormsElement form) throws IOException, XFormParser.ParseException {
+        File tempDir = TempFileUtils.createTempDir();
+        File formFile = TempFileUtils.createTempFile(tempDir, "xml");
         String xml = form.asXml();
         System.out.println(xml);
         FileUtils.write(formFile, xml, UTF_8);
         return Scenario.init(formFile);
     }
 
-    public static Scenario init(String formName, XFormsElement form, Function<FormDef, FormEntryController> controllerSupplier) throws IOException, XFormParser.ParseException {
-        File tempDir = TempFileUtils.createTempDir("javarosa");
-        File formFile = TempFileUtils.createTempFile(tempDir, formName, "xml");
+    public static Scenario init(XFormsElement form, Function<FormDef, FormEntryController> controllerSupplier) throws IOException, XFormParser.ParseException {
+        File tempDir = TempFileUtils.createTempDir();
+        File formFile = TempFileUtils.createTempFile(tempDir, "xml");
         String xml = form.asXml();
         System.out.println(xml);
         FileUtils.write(formFile, xml, UTF_8);
         return Scenario.init(formFile, controllerSupplier);
     }
 
-    public static FormDef createFormDef(String formName, XFormsElement form) throws IOException, XFormParser.ParseException {
-        File tempDir = TempFileUtils.createTempDir("javarosa");
-        File formFile = TempFileUtils.createTempFile(tempDir, formName, "xml");
+    public static FormDef createFormDef(XFormsElement form) throws IOException, XFormParser.ParseException {
+        File tempDir = TempFileUtils.createTempDir();
+        File formFile = TempFileUtils.createTempFile(tempDir, "xml");
         String xml = form.asXml();
         System.out.println(xml);
         FileUtils.write(formFile, xml, UTF_8);

--- a/src/main/java/org/javarosa/test/TempFileUtils.java
+++ b/src/main/java/org/javarosa/test/TempFileUtils.java
@@ -2,24 +2,25 @@ package org.javarosa.test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.UUID;
+import java.nio.file.Files;
 
 public class TempFileUtils {
 
-    static File createTempDir(String name) {
-        File tempDir = new File(System.getProperty("java.io.tmpdir"));
-        File subDir = new File(tempDir, name + UUID.randomUUID().toString());
-        subDir.mkdir();
-        return subDir;
-    }
-
-    public static File createTempFile(String prefix, String suffix) {
-        return createTempFile(null, prefix, suffix);
-    }
-
-    public static File createTempFile(File parent, String prefix, String suffix) {
+    static File createTempDir() {
         try {
-            File tempFile = File.createTempFile(prefix, suffix, parent);
+            return Files.createTempDirectory("temp").toFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static File createTempFile(String suffix) {
+        return createTempFile(null, suffix);
+    }
+
+    public static File createTempFile(File parent, String suffix) {
+        try {
+            File tempFile = File.createTempFile("file", suffix, parent);
             tempFile.deleteOnExit();
             return tempFile;
         } catch (IOException e) {

--- a/src/main/java/org/javarosa/test/XFormsElement.java
+++ b/src/main/java/org/javarosa/test/XFormsElement.java
@@ -21,6 +21,7 @@ import kotlin.Pair;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.regex.Pattern;
 
@@ -111,6 +112,10 @@ public interface XFormsElement {
         return t("h:title", innerHTML);
     }
 
+    static XFormsElement title() {
+        return t("h:title", UUID.randomUUID().toString());
+    }
+
     static XFormsElement model(XFormsElement... children) {
         return t("model", children);
     }
@@ -126,6 +131,10 @@ public interface XFormsElement {
 
     static XFormsElement mainInstance(XFormsElement... children) {
         return t("instance", children);
+    }
+
+    static XFormsElement data(XFormsElement... children) {
+        return t("data id=\"" + UUID.randomUUID() + "\"", children);
     }
 
     static XFormsElement instance(String name, XFormsElement... children) {

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -1182,9 +1182,9 @@ public class XFormParser implements IXFormParserFunctions {
                 parseQuestionLabel(question, child);
             } else if ("hint".equals(childName)) {
                 parseHint(question, child);
-            } else if ((hasRequiredItems(controlType) || hasOptionalItems(controlType)) && "item".equals(childName)) {
+            } else if ("item".equals(childName)) {
                 parseItem(question, child);
-            } else if ((hasRequiredItems(controlType) || hasOptionalItems(controlType)) && "itemset".equals(childName)) {
+            } else if ("itemset".equals(childName)) {
                 parseItemset(question, child, parent);
             } else if (actionHandlers.containsKey(childName)) {
                 actionHandlers.get(childName).handle(this, child, question);
@@ -1215,10 +1215,6 @@ public class XFormParser implements IXFormParserFunctions {
         return controlType == CONTROL_SELECT_MULTI
                 || controlType == CONTROL_RANK
                 || controlType == CONTROL_SELECT_ONE;
-    }
-
-    private static boolean hasOptionalItems(int controlType) {
-        return controlType == CONTROL_RANGE;
     }
 
     private QuestionDef questionForControlType(int controlType) {

--- a/src/test/java/org/javarosa/core/model/ChoiceNameTest.java
+++ b/src/test/java/org/javarosa/core/model/ChoiceNameTest.java
@@ -76,7 +76,7 @@ public class ChoiceNameTest {
     // set yet, the choice list is empty. Setting the country does not automatically trigger re-computation of the choice list for the
     // city question. Instead, clients trigger a recomputation of the list when the list is displayed.
     @Test public void choiceNameCallWithDynamicChoicesAndPredicate_requiresExplicitDynamicChoicesRecomputation() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Dynamic Choices and Predicates", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Dynamic Choices and Predicates"),
                 model(
@@ -121,7 +121,7 @@ public class ChoiceNameTest {
     }
 
     @Test public void choiceNameCallWithIndexedRepeatAndStaticChoices_worksWithMultipleRepeats() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Static choices in repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Static choices in repeat"),
                 model(
@@ -155,7 +155,7 @@ public class ChoiceNameTest {
     }
 
     @Test public void choiceNameCallWithIndexedRepeatAndDynamicChoices_worksWithMultipleRepeats() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Dynamic choices in repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Dynamic choices in repeat"),
                 model(

--- a/src/test/java/org/javarosa/core/model/DateTimeTest.java
+++ b/src/test/java/org/javarosa/core/model/DateTimeTest.java
@@ -25,7 +25,7 @@ import static org.javarosa.test.XFormsElement.title;
 public class DateTimeTest {
     @Test
     public void timeQuestionReturnsTimeDataAnswer() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("DateTime form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Time form"),
                 model(
@@ -57,7 +57,7 @@ public class DateTimeTest {
 
     @Test
     public void dateQuestionReturnsDateDataAnswer() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("DateTime form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Date form"),
                 model(
@@ -89,7 +89,7 @@ public class DateTimeTest {
 
     @Test
     public void dateTimeQuestionReturnsDateTimeDataAnswer() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("DateTime form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("DateTime form"),
                 model(

--- a/src/test/java/org/javarosa/core/model/DynamicSelectUpdateTest.java
+++ b/src/test/java/org/javarosa/core/model/DynamicSelectUpdateTest.java
@@ -56,7 +56,7 @@ public class DynamicSelectUpdateTest {
     // contents of those instances (item values, labels) can also change.
     @Test
     public void selectFromRepeat_whenRepeatAdded_updatesChoices() throws Exception {
-        Scenario scenario = Scenario.init("Select from repeat", getSelectFromRepeatForm());
+        Scenario scenario = Scenario.init(getSelectFromRepeatForm());
 
         scenario.answer("/data/repeat[1]/value","a");
         scenario.answer("/data/repeat[1]/label","A");
@@ -72,7 +72,7 @@ public class DynamicSelectUpdateTest {
 
     @Test
     public void selectFromRepeat_whenRepeatChanged_updatesChoices() throws Exception {
-        Scenario scenario = Scenario.init("Select from repeat", getSelectFromRepeatForm());
+        Scenario scenario = Scenario.init(getSelectFromRepeatForm());
 
         scenario.answer("/data/repeat[1]/value","a");
         scenario.answer("/data/repeat[1]/label","A");
@@ -88,7 +88,7 @@ public class DynamicSelectUpdateTest {
 
     @Test
     public void selectFromRepeat_whenRepeatRemoved_updatesChoices() throws Exception {
-        Scenario scenario = Scenario.init("Select from repeat", getSelectFromRepeatForm());
+        Scenario scenario = Scenario.init(getSelectFromRepeatForm());
 
         scenario.answer("/data/repeat[1]/value", "a");
         scenario.answer("/data/repeat[1]/label", "A");
@@ -101,7 +101,7 @@ public class DynamicSelectUpdateTest {
 
     @Test
     public void selectFromRepeat_withPredicate_whenPredicateTriggerChanges_updatesChoices() throws Exception {
-        Scenario scenario = Scenario.init("Select from repeat", getSelectFromRepeatForm("starts-with(value,current()/../filter)"));
+        Scenario scenario = Scenario.init(getSelectFromRepeatForm("starts-with(value,current()/../filter)"));
 
         scenario.answer("/data/repeat[1]/value", "a");
         scenario.answer("/data/repeat[1]/label", "A");
@@ -142,7 +142,7 @@ public class DynamicSelectUpdateTest {
     //region Multi-language
     @Test
     public void multilanguage() throws Exception {
-        Scenario scenario = Scenario.init("Multilingual dynamic select", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Multilingual dynamic select"),
                 model(
@@ -186,7 +186,7 @@ public class DynamicSelectUpdateTest {
 
     @Test
     public void selectWithChangedTriggers_recomputesChoiceList() throws Exception {
-        Scenario scenario = Scenario.init("Select", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Select"),
                 model(
@@ -221,7 +221,7 @@ public class DynamicSelectUpdateTest {
 
     @Test
     public void selectWithRepeatAsTrigger_recomputesChoiceListAtEveryRequest() throws Exception {
-        Scenario scenario = Scenario.init("Select with repeat trigger", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Repeat trigger"),
                 model(
@@ -257,7 +257,7 @@ public class DynamicSelectUpdateTest {
     // When a dynamic select is in a repeat, the itemsets for all repeat instances are represented by the same ItemsetBinding.
     @Test
     public void selectInRepeat_withRefToRepeatChildInPredicate_evaluatesChoiceListForEachRepeatInstance() throws Exception {
-        Scenario scenario = Scenario.init("Select in repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Select in repeat"),
                 model(

--- a/src/test/java/org/javarosa/core/model/FormDefSerializationTest.java
+++ b/src/test/java/org/javarosa/core/model/FormDefSerializationTest.java
@@ -81,7 +81,7 @@ public class FormDefSerializationTest {
     }
 
     @Test public void serializeAndDeserializeFormWithDefaultAnswerInSelectQuestion_worksCorrectly() throws IOException, DeserializationException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Internal choices", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Internal choices"),
                 model(
@@ -107,7 +107,7 @@ public class FormDefSerializationTest {
     }
 
     private static Scenario getSimplestFormScenario() throws IOException, XFormParser.ParseException {
-        return Scenario.init("Simplest", html(
+        return Scenario.init(html(
             head(
                 title("Simplest"),
                 model(

--- a/src/test/java/org/javarosa/core/model/OptionalChoicesQuestionTest.java
+++ b/src/test/java/org/javarosa/core/model/OptionalChoicesQuestionTest.java
@@ -17,9 +17,9 @@ import static org.javarosa.test.XFormsElement.model;
 import static org.javarosa.test.XFormsElement.t;
 import static org.javarosa.test.XFormsElement.title;
 
-public class RangeQuestionTest {
+public class OptionalChoicesQuestionTest {
     @Test
-    public void answerIsPreservedWhenRangeQuestionHasIncompleteItemsetChoices() throws Exception {
+    public void answerIsPreservedWhenQuestionHasIncompleteItemsetChoices() throws Exception {
         Scenario scenario = Scenario.init("range question with incomplete choices", html(
             head(
                 title("Range question with incomplete choices"),
@@ -51,7 +51,7 @@ public class RangeQuestionTest {
     }
 
     @Test
-    public void answerIsPreservedWhenRangeQuestionHasIncompleteItemChoices() throws Exception {
+    public void answerIsPreservedWhenQuestionHasIncompleteItemChoices() throws Exception {
         Scenario scenario = Scenario.init("range question with incomplete choices", html(
             head(
                 title("Range question with incomplete choices"),

--- a/src/test/java/org/javarosa/core/model/OptionalChoicesQuestionTest.java
+++ b/src/test/java/org/javarosa/core/model/OptionalChoicesQuestionTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.is;
 import static org.javarosa.core.test.AnswerDataMatchers.intAnswer;
 import static org.javarosa.test.BindBuilderXFormsElement.bind;
 import static org.javarosa.test.XFormsElement.body;
+import static org.javarosa.test.XFormsElement.data;
 import static org.javarosa.test.XFormsElement.head;
 import static org.javarosa.test.XFormsElement.html;
 import static org.javarosa.test.XFormsElement.instance;
@@ -20,13 +21,15 @@ import static org.javarosa.test.XFormsElement.title;
 public class OptionalChoicesQuestionTest {
     @Test
     public void answerIsPreservedWhenQuestionHasIncompleteItemsetChoices() throws Exception {
-        Scenario scenario = Scenario.init("range question with incomplete choices", html(
+        Scenario scenario = Scenario.init(html(
             head(
-                title("Range question with incomplete choices"),
+                title(),
                 model(
-                    mainInstance(t("data id=\"range-question-with-incomplete-choices\"",
-                        t("range")
-                    )),
+                    mainInstance(
+                        data(
+                            t("range")
+                        )
+                    ),
 
                     instance("ticks",
                         item(-2, "A"),
@@ -52,13 +55,15 @@ public class OptionalChoicesQuestionTest {
 
     @Test
     public void answerIsPreservedWhenQuestionHasIncompleteItemChoices() throws Exception {
-        Scenario scenario = Scenario.init("range question with incomplete choices", html(
+        Scenario scenario = Scenario.init(html(
             head(
-                title("Range question with incomplete choices"),
+                title(),
                 model(
-                    mainInstance(t("data id=\"range-question-with-incomplete-choices\"",
-                        t("range")
-                    )),
+                    mainInstance(
+                        data(
+                            t("range")
+                        )
+                    ),
                     bind("/data/range").type("int")
                 )),
             body(

--- a/src/test/java/org/javarosa/core/model/PredicateCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/PredicateCachingTest.java
@@ -28,7 +28,7 @@ public class PredicateCachingTest {
 
     @Test
     public void repeatedEqPredicatesAreOnlyEvaluatedOnceWhileAnswering() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -63,7 +63,7 @@ public class PredicateCachingTest {
 
     @Test
     public void repeatedCompPredicatesAreOnlyEvaluatedOnceWhileAnswering() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -98,7 +98,7 @@ public class PredicateCachingTest {
 
     @Test
     public void repeatedIdempotentFuncPredicatesAreOnlyEvaluatedOnceWhileAnswering() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -133,7 +133,7 @@ public class PredicateCachingTest {
 
     @Test
     public void repeatedEqPredicatesAreOnlyEvaluatedOnce() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -169,7 +169,7 @@ public class PredicateCachingTest {
 
     @Test
     public void firstPredicateInMultipleEqPredicatesAreOnlyEvaluatedOnce() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -221,7 +221,7 @@ public class PredicateCachingTest {
 
     @Test
     public void repeatedCompPredicatesWithSameAbsoluteValueAreOnlyEvaluatedOnce() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -257,7 +257,7 @@ public class PredicateCachingTest {
 
     @Test
     public void repeatedIdempotentFuncPredicatesWithSameAbsoluteValueAreOnlyEvaluatedOnce() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -323,7 +323,7 @@ public class PredicateCachingTest {
 
     @Test
     public void predicatesOnDifferentChildNamesDoNotGetConfused() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -360,7 +360,7 @@ public class PredicateCachingTest {
 
     @Test
     public void eqExpressionsWorkIfEitherSideIsRelative() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -398,7 +398,7 @@ public class PredicateCachingTest {
 
     @Test
     public void eqExpressionsWorkIfBothSidesAreRelative() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -424,7 +424,7 @@ public class PredicateCachingTest {
 
     @Test
     public void nestedPredicatesDoNotGetConfused() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -474,7 +474,7 @@ public class PredicateCachingTest {
 
     @Test
     public void similarCmpAndEqExpressionsDoNotGetConfused() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -506,7 +506,7 @@ public class PredicateCachingTest {
 
     @Test
     public void differentEqExpressionsAreNotConfused() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -542,7 +542,7 @@ public class PredicateCachingTest {
 
     @Test
     public void differentKindsOfEqExpressionsAreNotConfused() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -573,7 +573,7 @@ public class PredicateCachingTest {
 
     @Test
     public void repeatsUsedInCalculatesStayUpToDate() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -611,7 +611,7 @@ public class PredicateCachingTest {
     public void eqPredicatesDoNotIncreaseLoadTime() {
         int evaluations = Measure.withMeasure(asList("PredicateEvaluation", "IndexEvaluation"), () -> {
                 try {
-                    Scenario.init("Some form", html(
+                    Scenario.init(html(
                         head(
                             title("Some form"),
                             model(

--- a/src/test/java/org/javarosa/core/model/RangeQuestionTest.java
+++ b/src/test/java/org/javarosa/core/model/RangeQuestionTest.java
@@ -19,7 +19,7 @@ import static org.javarosa.test.XFormsElement.title;
 
 public class RangeQuestionTest {
     @Test
-    public void answerIsPreservedWhenRangeQuestionHasIncompleteChoices() throws Exception {
+    public void answerIsPreservedWhenRangeQuestionHasIncompleteItemsetChoices() throws Exception {
         Scenario scenario = Scenario.init("range question with incomplete choices", html(
             head(
                 title("Range question with incomplete choices"),
@@ -41,6 +41,31 @@ public class RangeQuestionTest {
                         t("label ref=\"label\""),
                         t("value ref=\"value\"")
                     )
+                )
+            )
+        ));
+
+        scenario.answer("/data/range", 1);
+        scenario.choicesOf("/data/range");
+        assertThat(scenario.answerOf("/data/range"), is(intAnswer(1)));
+    }
+
+    @Test
+    public void answerIsPreservedWhenRangeQuestionHasIncompleteItemChoices() throws Exception {
+        Scenario scenario = Scenario.init("range question with incomplete choices", html(
+            head(
+                title("Range question with incomplete choices"),
+                model(
+                    mainInstance(t("data id=\"range-question-with-incomplete-choices\"",
+                        t("range")
+                    )),
+                    bind("/data/range").type("int")
+                )),
+            body(
+                t("range ref=\"/data/range\" start=\"-2\" end=\"2\" step=\"1\"",
+                    item(-2, "A"),
+                    item(0, "B"),
+                    item(2, "C")
                 )
             )
         ));

--- a/src/test/java/org/javarosa/core/model/RepeatTest.java
+++ b/src/test/java/org/javarosa/core/model/RepeatTest.java
@@ -26,7 +26,7 @@ public class RepeatTest {
 
     @Test
     public void whenRepeatIsNotRelevant_repeatPromptIsSkipped() throws Exception {
-        Scenario scenario = Scenario.init("Non relevant repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Non relevant repeat"),
                 model(
@@ -50,7 +50,7 @@ public class RepeatTest {
 
     @Test
     public void whenRepeatRelevanceIsDynamic_andNotRelevant_repeatPromptIsSkipped() throws Exception {
-        Scenario scenario = Scenario.init("Repeat relevance - dynamic expression", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Repeat relevance - dynamic expression"),
                 model(
@@ -79,7 +79,7 @@ public class RepeatTest {
 
     @Test
     public void whenRepeatAndTopLevelNodeHaveSameRelevanceExpression_andExpressionEvaluatesToFalse_repeatPromptIsSkipped() throws Exception {
-        Scenario scenario = Scenario.init("Repeat relevance same as other", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Repeat relevance same as other"),
                 model(
@@ -115,7 +115,7 @@ public class RepeatTest {
      */
     @Test
     public void absoluteSingleNodePaths_areQualified_forLegacyPurposes() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Absolute relative ref", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Absolute relative ref"),
                 model(

--- a/src/test/java/org/javarosa/core/model/SelectCachingTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectCachingTest.java
@@ -26,7 +26,7 @@ public class SelectCachingTest {
 
     @Test
     public void eqChoiceFiltersAreOnlyEvaluatedOnceForRepeatedChoiceListEvaluations() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -61,7 +61,7 @@ public class SelectCachingTest {
 
     @Test
     public void andOfTwoEqChoiceFiltersAreOnlyEvaluatedOnceForRepeatedChoiceListEvaluations() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -96,7 +96,7 @@ public class SelectCachingTest {
 
     @Test
     public void andOfTwoEqChoiceFiltersIsNotConfusedWithOr() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -128,7 +128,7 @@ public class SelectCachingTest {
 
     @Test
     public void repeatedEqChoiceFiltersAreOnlyEvaluatedOnce_whileLiteralExpressionIsTheSame() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -166,7 +166,7 @@ public class SelectCachingTest {
 
     @Test
     public void repeatedCompChoiceFiltersAreOnlyEvaluatedOnce_whileLiteralExpressionIsTheSame() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -204,7 +204,7 @@ public class SelectCachingTest {
 
     @Test
     public void repeatedEqChoiceFiltersAreOnlyEvaluatedOnce() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -243,7 +243,7 @@ public class SelectCachingTest {
 
     @Test
     public void nestedPredicatesAreOnlyEvaluatedOnceForAQuestionWhileTheFormStateIsStable() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -284,7 +284,7 @@ public class SelectCachingTest {
 
     @Test
     public void nestedPredicatesAreCorrectAfterFormStateChanges() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -320,7 +320,7 @@ public class SelectCachingTest {
     //region repeats
     @Test
     public void eqChoiceFilter_inRepeat_onlyEvaluatedOnce() throws Exception {
-        Scenario scenario = Scenario.init("Select in repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Select in repeat"),
                 model(
@@ -356,7 +356,7 @@ public class SelectCachingTest {
 
     @Test
     public void eqChoiceFiltersInRepeatsWithCurrentPathExpressionsAreOnlyEvaluatedOnce() throws Exception {
-        Scenario scenario = Scenario.init("Select in repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Select in repeat"),
                 model(
@@ -395,7 +395,7 @@ public class SelectCachingTest {
 
     @Test
     public void eqChoiceFiltersForIntsWork() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(

--- a/src/test/java/org/javarosa/core/model/SelectChoiceTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectChoiceTest.java
@@ -56,7 +56,7 @@ import static org.junit.Assert.fail;
 public class SelectChoiceTest {
     @Test
     public void value_should_continue_being_an_empty_string_after_deserialization() throws IOException, DeserializationException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("SelectChoice.getValue() regression test form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("SelectChoice.getValue() regression test form"),
                 model(
@@ -107,7 +107,7 @@ public class SelectChoiceTest {
 
     @Test
     public void getChild_returnsEmptyString_whenChoicesAreFromSecondaryInstance_andRequestedChildHasNoValue() throws XFormParser.ParseException, IOException {
-        Scenario scenario = Scenario.init("Select with empty value", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Select with empty value"),
                 model(
@@ -126,7 +126,7 @@ public class SelectChoiceTest {
 
     @Test
     public void getChild_updates_whenChoicesAreFromRepeat() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Select from repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Select from repeat"),
                 model(
@@ -159,7 +159,7 @@ public class SelectChoiceTest {
 
     @Test
     public void getChild_returnsNull_whenCalledOnAChoiceFromInlineSelect() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Static select", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Static select"),
                 model(
@@ -195,7 +195,7 @@ public class SelectChoiceTest {
 
     @Test
     public void getChildren_updates_whenChoicesAreFromRepeat() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Select from repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Select from repeat"),
                 model(
@@ -232,7 +232,7 @@ public class SelectChoiceTest {
 
     @Test
     public void selectFromRepeat_usesSpecifiedValueAndLabelRefs() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Select from repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Select from repeat"),
                 model(
@@ -254,7 +254,7 @@ public class SelectChoiceTest {
 
     @Test
     public void getAdditionalChildren_returnsEmpty_whenCalledOnAChoiceFromInlineSelect() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Static select", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Static select"),
                 model(
@@ -270,7 +270,7 @@ public class SelectChoiceTest {
 
     @Test
     public void getAdditionalChildren_returnsEmptyStringValue_forEmptyChildren() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Internal instance select", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Internal instance select"),
                 model(
@@ -301,7 +301,7 @@ public class SelectChoiceTest {
 
     @Test
     public void itemsetBindingVerification_doesNotVerifySecondItem() throws IOException, XFormParser.ParseException {
-        Scenario.init("Some form", html(
+        Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -331,7 +331,7 @@ public class SelectChoiceTest {
     @Test
     public void itemsetBindingVerification_verifiesFirstItem() throws IOException {
         try {
-            Scenario.init("Some form", html(
+            Scenario.init(html(
                 head(
                     title("Some form"),
                     model(

--- a/src/test/java/org/javarosa/core/model/SelectOneQuestionTest.java
+++ b/src/test/java/org/javarosa/core/model/SelectOneQuestionTest.java
@@ -29,7 +29,7 @@ public class SelectOneQuestionTest {
 
     @Test
     public void choiceIsSelectedWhenLiteralStringValueMatchesChoiceValue() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("String calculate", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("String calculate"),
                 model(
@@ -55,7 +55,7 @@ public class SelectOneQuestionTest {
 
     @Test
     public void choiceIsSelectedWhenLiteralIntegerValueMatchesChoiceValue() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Integer calculate", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Integer calculate"),
                 model(
@@ -81,7 +81,7 @@ public class SelectOneQuestionTest {
 
     @Test
     public void choiceIsSelectedWhenLiteralIntegerValueMatchesChoiceValue_afterDeserialization() throws IOException, XFormParser.ParseException, DeserializationException {
-        Scenario scenario = Scenario.init("Integer calculate", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Integer calculate"),
                 model(
@@ -107,7 +107,7 @@ public class SelectOneQuestionTest {
 
     @Test
     public void selectQuestionValueBlankWhenValueNotInChoices() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("String calculate", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("String calculate"),
                 model(

--- a/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
+++ b/src/test/java/org/javarosa/core/model/TriggerableDagTest.java
@@ -73,7 +73,7 @@ public class TriggerableDagTest {
 
     @Test
     public void order_of_the_DAG_is_ensured() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -108,7 +108,7 @@ public class TriggerableDagTest {
         exceptionRule.expect(XFormParseException.class);
         exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
-        Scenario.init("Some form", buildFormForDagCyclesCheck(
+        Scenario.init(buildFormForDagCyclesCheck(
             bind("/data/count").type("int").calculate(". + 1")
         ));
     }
@@ -118,7 +118,7 @@ public class TriggerableDagTest {
         exceptionRule.expect(XFormParseException.class);
         exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
-        Scenario.init("Some form", buildFormForDagCyclesCheck(
+        Scenario.init(buildFormForDagCyclesCheck(
             bind("/data/a").type("int").calculate("/data/b + 1"),
             bind("/data/b").type("int").calculate("/data/c + 1"),
             bind("/data/c").type("int").calculate("/data/a + 1")
@@ -130,7 +130,7 @@ public class TriggerableDagTest {
         exceptionRule.expect(XFormParseException.class);
         exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
-        Scenario.init("Some form", buildFormForDagCyclesCheck(
+        Scenario.init(buildFormForDagCyclesCheck(
             bind("/data/count").type("int").relevant(". > 0")
         ));
     }
@@ -140,7 +140,7 @@ public class TriggerableDagTest {
         exceptionRule.expect(XFormParseException.class);
         exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
-        Scenario.init("Some form", buildFormForDagCyclesCheck(
+        Scenario.init(buildFormForDagCyclesCheck(
             bind("/data/count").type("int").readonly(". > 10")
         ));
     }
@@ -150,14 +150,14 @@ public class TriggerableDagTest {
         exceptionRule.expect(XFormParseException.class);
         exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
-        Scenario.init("Some form", buildFormForDagCyclesCheck(
+        Scenario.init(buildFormForDagCyclesCheck(
             bind("/data/count").type("int").required(". > 10")
         ));
     }
 
     @Test
     public void supports_self_references_in_constraints() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", buildFormForDagCyclesCheck(
+        Scenario scenario = Scenario.init(buildFormForDagCyclesCheck(
             bind("/data/count").type("int").constraint(". > 10")
         ));
         scenario.next();
@@ -194,7 +194,7 @@ public class TriggerableDagTest {
     @Test
     @Ignore
     public void supports_codependant_relevant_expressions() throws IOException, XFormParser.ParseException {
-        Scenario.init("Some form", buildFormForDagCyclesCheck(
+        Scenario.init(buildFormForDagCyclesCheck(
             bind("/data/a").type("int").relevant("/data/b > 0"),
             bind("/data/b").type("int").relevant("/data/a > 0")));
         // TODO Complete the test adding some assertions that verify that the form works as we would expect
@@ -225,7 +225,7 @@ public class TriggerableDagTest {
     @Test
     @Ignore
     public void supports_codependant_required_conditions() throws IOException, XFormParser.ParseException {
-        Scenario.init("Some form", buildFormForDagCyclesCheck(
+        Scenario.init(buildFormForDagCyclesCheck(
             bind("/data/a").type("int").required("/data/b > 0"),
             bind("/data/b").type("int").required("/data/a > 0")));
         // TODO Complete the test adding some assertions that verify that the form works as we would expect
@@ -256,7 +256,7 @@ public class TriggerableDagTest {
     @Test
     @Ignore
     public void supports_codependant_readonly_conditions() throws IOException, XFormParser.ParseException {
-        Scenario.init("Some form", buildFormForDagCyclesCheck(
+        Scenario.init(buildFormForDagCyclesCheck(
             bind("/data/a").type("int").readonly("/data/b > 0"),
             bind("/data/b").type("int").readonly("/data/a > 0")));
         // TODO Complete the test adding some assertions that verify that the form works as we would expect
@@ -267,7 +267,7 @@ public class TriggerableDagTest {
         exceptionRule.expect(XFormParseException.class);
         exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
-        Scenario.init("Some form", html(
+        Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -295,7 +295,7 @@ public class TriggerableDagTest {
         exceptionRule.expect(XFormParseException.class);
         exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
-        Scenario.init("Some form", html(
+        Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -324,7 +324,7 @@ public class TriggerableDagTest {
     @Test
     @Ignore
     public void supports_self_reference_dependency_when_targeting_different_repeat_instance_siblings() throws IOException, XFormParser.ParseException {
-        Scenario.init("Some form", html(
+        Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -348,7 +348,7 @@ public class TriggerableDagTest {
         exceptionRule.expect(XFormParseException.class);
         exceptionRule.expectMessage("Cycle detected in form's relevant and calculation logic!");
 
-        Scenario.init("Some form", html(
+        Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -378,7 +378,7 @@ public class TriggerableDagTest {
      */
     @Test
     public void non_relevance_is_inherited_from_ancestors() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -424,7 +424,7 @@ public class TriggerableDagTest {
      */
     @Test
     public void relevanceIsDeterminedByModelNesting() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -449,7 +449,7 @@ public class TriggerableDagTest {
 
     @Test
     public void non_relevant_nodes_are_excluded_from_nodeset_evaluation() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -498,7 +498,7 @@ public class TriggerableDagTest {
 
     @Test
     public void non_relevant_node_values_are_always_null_regardless_of_their_actual_value() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -539,7 +539,7 @@ public class TriggerableDagTest {
      */
     @Test
     public void verify_relation_between_calculate_expressions_and_relevancy_conditions() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -589,7 +589,7 @@ public class TriggerableDagTest {
      */
     @Test
     public void whenRepeatAndTopLevelNodeHaveSameRelevanceExpression_andExpressionEvaluatesToFalse_repeatPromptIsSkipped() throws Exception {
-        Scenario scenario = Scenario.init("Repeat relevance same as other", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Repeat relevance same as other"),
                 model(
@@ -626,7 +626,7 @@ public class TriggerableDagTest {
      */
     @Test
     public void readonly_is_inherited_from_ancestors() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -683,7 +683,7 @@ public class TriggerableDagTest {
     //region Required and constraint
     @Test
     public void constraints_of_fields_that_are_empty_are_always_satisfied() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -710,7 +710,7 @@ public class TriggerableDagTest {
 
     @Test
     public void empty_required_fields_make_form_validation_fail() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -735,7 +735,7 @@ public class TriggerableDagTest {
 
     @Test
     public void constraint_violations_and_form_finalization() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -784,7 +784,7 @@ public class TriggerableDagTest {
     //region Adding or deleting repeats
     @Test
     public void addingRepeatInstance_updatesCalculationCascade() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Add repeat instance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Add repeat instance"),
                 model(
@@ -821,7 +821,7 @@ public class TriggerableDagTest {
 
     @Test
     public void addingRepeat_updatesInnerCalculations_withMultipleDependencies() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Repeat cascading calc", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Repeat cascading calc"),
                 model(
@@ -857,7 +857,7 @@ public class TriggerableDagTest {
     // Illustrates the second case in TriggerableDAG.getTriggerablesAffectingAllInstances
     @Test
     public void addingOrRemovingRepeatInstance_withCalculatedCountOutsideRepeat_updatesReferenceToCountInside() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Count outside repeat used inside"),
                 model(
@@ -898,7 +898,7 @@ public class TriggerableDagTest {
     // every repeat instance.
     @Test
     public void addingOrRemovingRepeatInstance_updatesRepeatCount_insideAndOutsideRepeat() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Count outside repeat used inside"),
                 model(
@@ -937,7 +937,7 @@ public class TriggerableDagTest {
     @Ignore("Highlights issue with de-duplicating refs and different contexts")
     @Test
     public void addingOrRemovingRepeatInstance_updatesRepeatCount_insideRepeat() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Count outside repeat used inside"),
                 model(
@@ -970,7 +970,7 @@ public class TriggerableDagTest {
 
     @Test
     public void addingOrRemovingRepeatInstance_updatesRelativeRepeatCount_insideRepeat() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Count outside repeat used inside"),
                 model(
@@ -1003,7 +1003,7 @@ public class TriggerableDagTest {
 
     @Test
     public void addingOrRemovingRepeatInstance_withReferenceToRepeatInRepeat_andOuterSum_updates() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Count outside repeat used inside"),
                 model(
@@ -1042,7 +1042,7 @@ public class TriggerableDagTest {
 
     @Test
     public void addingOrRemovingRepeatInstance_withReferenceToPreviousInstance_updatesThatReference() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1096,7 +1096,7 @@ public class TriggerableDagTest {
 
     @Test
     public void addingOrDeletingRepeatInstance_withRelevanceInsideRepeatDependingOnCount_updatesRelevanceForAllInstances() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1140,7 +1140,7 @@ public class TriggerableDagTest {
     //region Deleting repeats
     @Test
     public void deleteSecondRepeatGroup_evaluatesTriggerables_dependentOnPrecedingRepeatGroupSiblings() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1181,7 +1181,7 @@ public class TriggerableDagTest {
 
     @Test
     public void deleteSecondRepeatGroup_evaluatesTriggerables_dependentOnTheParentPosition() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1232,7 +1232,7 @@ public class TriggerableDagTest {
 
     @Test
     public void deleteSecondRepeatGroup_doesNotEvaluateTriggerables_notDependentOnTheParentPosition() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1283,7 +1283,7 @@ public class TriggerableDagTest {
 
     @Test
     public void deleteThirdRepeatGroup_evaluatesTriggerables_dependentOnTheRepeatGroupsNumber() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1313,7 +1313,7 @@ public class TriggerableDagTest {
     // calculations outside the repeat should only be re-computed once.
     @Test
     public void repeatInstanceDeletion_triggersCalculationsOutsideTheRepeat_exactlyOnce() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1348,7 +1348,7 @@ public class TriggerableDagTest {
 
     @Test
     public void repeatInstanceDeletion_withoutReferencesToRepeat_evaluatesNoTriggersInInstances() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1396,7 +1396,7 @@ public class TriggerableDagTest {
      */
     @Test
     public void deleteThirdRepeatGroup_evaluatesTriggerables_indirectlyDependentOnTheRepeatGroupsNumber() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1432,7 +1432,7 @@ public class TriggerableDagTest {
 
     @Test
     public void deleteLastRepeat_evaluatesTriggerables() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Delete last repeat instance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Delete last repeat instance"),
                 model(
@@ -1461,7 +1461,7 @@ public class TriggerableDagTest {
 
     @Test
     public void deleteLastRepeat_evaluatesTriggerables_indirectlyDependentOnTheDeletedRepeat() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Delete last repeat instance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Delete last repeat instance"),
                 model(
@@ -1495,7 +1495,7 @@ public class TriggerableDagTest {
      */
     @Test
     public void adding_repeat_instance_triggers_triggerables_outside_repeat_that_reference_repeat_nodeset() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Form"),
                 model(
@@ -1527,7 +1527,7 @@ public class TriggerableDagTest {
      */
     @Test
     public void adding_repeat_instance_triggers_descendant_node_triggerables() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Form"),
                 model(
@@ -1576,7 +1576,7 @@ public class TriggerableDagTest {
     // getTriggerablesAffectingAllInstances but for initializeTriggerables.
     @Test
     public void addingRepeatInstance_withInnerSumOfQuestionInRepeat_updatesInnerSumForAllInstances() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Count outside repeat used inside"),
                 model(
@@ -1615,7 +1615,7 @@ public class TriggerableDagTest {
     // getTriggerablesAffectingAllInstances but for initializeTriggerables.
     @Test
     public void addingRepeatInstance_withInnerCalculateDependentOnOuterSum_updatesInnerSumForAllInstances() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Count outside repeat used inside", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Count outside repeat used inside"),
                 model(
@@ -1655,7 +1655,7 @@ public class TriggerableDagTest {
     // is added, it will trigger recomputation for previous instances.
     @Test
     public void changingValueInRepeat_withReferenceToNextInstance_updatesPreviousInstance() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1710,7 +1710,7 @@ public class TriggerableDagTest {
         // This is a translation of the XML form in the issue to our DSL with some adaptations:
         // - Explicit binds for all fields
         // - Migrated the condition field to boolean, which should be easier to understand
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1768,7 +1768,7 @@ public class TriggerableDagTest {
     //region Repeat misc
     @Test
     public void issue_135_verify_that_counts_in_inner_repeats_work_as_expected() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1829,7 +1829,7 @@ public class TriggerableDagTest {
 
     @Test
     public void addingNestedRepeatInstance_updatesExpressionTriggeredByGenericRef_forAllRepeatInstances() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -1870,7 +1870,7 @@ public class TriggerableDagTest {
 
     @Test
     public void addingRepeatInstance_updatesReferenceToLastInstance_usingPositionPredicate() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(

--- a/src/test/java/org/javarosa/core/model/actions/InstanceLoadEventsTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/InstanceLoadEventsTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class InstanceLoadEventsTest {
     @Test
     public void instanceLoadEvent_firesOnFirstLoad() throws Exception {
-        Scenario scenario = Scenario.init("Instance load form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Instance load form"),
                 model(
@@ -46,7 +46,7 @@ public class InstanceLoadEventsTest {
 
     @Test
     public void instanceLoadEvent_firesOnSecondLoad() throws Exception {
-        Scenario scenario = Scenario.init("Instance load form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Instance load form"),
                 model(
@@ -70,7 +70,7 @@ public class InstanceLoadEventsTest {
 
     @Test
     public void instanceFirstLoadEvent_doesNotfireOnSecondLoad() throws Exception {
-        Scenario scenario = Scenario.init("Instance load form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Instance load form"),
                 model(
@@ -94,7 +94,7 @@ public class InstanceLoadEventsTest {
 
     @Test
     public void instanceLoadEvent_triggersNestedActions() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested instance load", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested instance load"),
                 model(
@@ -119,7 +119,7 @@ public class InstanceLoadEventsTest {
 
     @Test
     public void instanceLoadEvent_triggeredForAllPreExistingRepeatInstances() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested instance load", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested instance load"),
                 model(

--- a/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/OdkNewRepeatEventTest.java
@@ -131,7 +131,7 @@ public class OdkNewRepeatEventTest {
 
     @Test
     public void newRepeatInstance_doesNotTriggerActionOnUnrelatedRepeat() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Parallel repeats", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Parallel repeats"),
                 model(
@@ -170,7 +170,7 @@ public class OdkNewRepeatEventTest {
 
     @Test
     public void newRepeatInstance_canUsePreviousInstanceAsDefault() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Default from prior instance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Default from prior instance"),
                 model(

--- a/src/test/java/org/javarosa/core/model/actions/RecordAudioActionTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/RecordAudioActionTest.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class RecordAudioActionTest {
     @Test
     public void recordAudioAction_isProcessedOnFormParse() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Record audio form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Record audio form"),
                 model(
@@ -62,7 +62,7 @@ public class RecordAudioActionTest {
         CapturingRecordAudioActionListener listener = new CapturingRecordAudioActionListener();
         RecordAudioActions.setRecordAudioListener(listener);
 
-        Scenario.init("Record audio form", html(
+        Scenario.init(html(
             head(
                 title("Record audio form"),
                 model(
@@ -86,7 +86,7 @@ public class RecordAudioActionTest {
         CapturingRecordAudioActionListener listener = new CapturingRecordAudioActionListener();
         RecordAudioActions.setRecordAudioListener(listener);
 
-        Scenario.init("Record audio form", html(
+        Scenario.init(html(
             head(
                 title("Record audio form"),
                 model(
@@ -108,7 +108,7 @@ public class RecordAudioActionTest {
 
     @Test
     public void serializationAndDeserialization_maintainsFields() throws IOException, DeserializationException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Record audio form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Record audio form"),
                 model(

--- a/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
+++ b/src/test/java/org/javarosa/core/model/actions/SetValueActionTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.fail;
 public class SetValueActionTest {
     @Test
     public void when_triggerNodeIsUpdated_targetNodeCalculation_isEvaluated() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested setvalue action", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested setvalue action"),
                 model(
@@ -76,7 +76,7 @@ public class SetValueActionTest {
 
     @Test
     public void expressionAsLiteralValue_isNotEvaluated() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Literal setvalue", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Literal setvalue"),
                 model(
@@ -103,7 +103,7 @@ public class SetValueActionTest {
 
     @Test
     public void when_triggerNodeIsUpdatedWithTheSameValue_targetNodeCalculation_isNotEvaluated() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested setvalue action", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested setvalue action"),
                 model(
@@ -139,7 +139,7 @@ public class SetValueActionTest {
 
     @Test
     public void setvalue_isSerializedAndDeserialized() throws IOException, DeserializationException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested setvalue action", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested setvalue action"),
                 model(
@@ -167,7 +167,7 @@ public class SetValueActionTest {
 
     @Test
     public void setvalueWithNoValue_isSerializedAndDeserialized() throws IOException, DeserializationException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Setvalue action", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue action"),
                 model(
@@ -196,7 +196,7 @@ public class SetValueActionTest {
     //region groups
     @Test
     public void setvalueInGroup_setsValueOutsideOfGroup() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Setvalue", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue"),
                 model(
@@ -222,7 +222,7 @@ public class SetValueActionTest {
 
     @Test
     public void setvalueOutsideGroup_setsValueInGroup() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Setvalue", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue"),
                 model(
@@ -249,7 +249,7 @@ public class SetValueActionTest {
     //region repeats
     @Test
     public void sourceInRepeat_updatesDestInSameRepeatInstance() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested setvalue action with repeats", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested setvalue action with repeats"),
                 model(
@@ -287,7 +287,7 @@ public class SetValueActionTest {
 
     @Test
     public void setvalueAtRoot_setsValueOfNodeInFirstRepeatInstance() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Setvalue into repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue into repeat"),
                 model(
@@ -317,7 +317,7 @@ public class SetValueActionTest {
     @Ignore("TODO: verifyActions seems like it may be overzealous")
     @Test
     public void setvalueAtRoot_setsValueOfNodeInRepeatInstanceAddedAfterFormLoad() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Setvalue into repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue into repeat"),
                 model(
@@ -346,7 +346,7 @@ public class SetValueActionTest {
 
     @Test
     public void setValueAtRoot_throwsExpression_whenTargetIsUnboundReference() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Setvalue into repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue into repeat"),
                 model(
@@ -379,7 +379,7 @@ public class SetValueActionTest {
 
     @Test
     public void setValueInRepeat_setsValueOutsideOfRepeat() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested setvalue action with repeats", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested setvalue action with repeats"),
                 model(
@@ -414,7 +414,7 @@ public class SetValueActionTest {
 
     @Test
     public void setvalueInOuterRepeat_setsInnerRepeatValue() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested repeats", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested repeats"),
                 model(
@@ -446,7 +446,7 @@ public class SetValueActionTest {
      */
     @Test
     public void setvalue_setsValueOfReadOnlyField() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Setvalue readonly", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue readonly"),
                 model(
@@ -466,7 +466,7 @@ public class SetValueActionTest {
 
     @Test
     public void setvalue_withInnerEmptyString_clearsTarget() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Setvalue empty string", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue empty string"),
                 model(
@@ -486,7 +486,7 @@ public class SetValueActionTest {
 
     @Test
     public void setvalue_withEmptyStringValue_clearsTarget() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Setvalue empty string", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue empty string"),
                 model(
@@ -506,7 +506,7 @@ public class SetValueActionTest {
 
     @Test
     public void setvalue_setsValueOfMultipleFields() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Setvalue multiple destinations", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue multiple destinations"),
                 model(
@@ -532,7 +532,7 @@ public class SetValueActionTest {
 
     @Test
     public void xformsValueChanged_triggeredAfterRecomputation() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("xforms-value-changed-event", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Value changed event"),
                 model(
@@ -556,7 +556,7 @@ public class SetValueActionTest {
 
     @Test
     public void setvalue_setsValueOfAttribute() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Setvalue attribute", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue attribute"),
                 model(
@@ -575,7 +575,7 @@ public class SetValueActionTest {
 
     @Test
     public void setvalue_setsValueOfAttribute_afterDeserialization() throws IOException, XFormParser.ParseException, DeserializationException {
-        Scenario scenario = Scenario.init("Setvalue attribute", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Setvalue attribute"),
                 model(

--- a/src/test/java/org/javarosa/core/model/condition/EvaluationContextExpandReferenceTest.java
+++ b/src/test/java/org/javarosa/core/model/condition/EvaluationContextExpandReferenceTest.java
@@ -48,7 +48,7 @@ public class EvaluationContextExpandReferenceTest {
 
     @BeforeClass
     public static void setUp() throws IOException, XFormParser.ParseException {
-        scenario = Scenario.init("Some form", html(
+        scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(

--- a/src/test/java/org/javarosa/core/model/condition/ReadOnlyCalculateTest.java
+++ b/src/test/java/org/javarosa/core/model/condition/ReadOnlyCalculateTest.java
@@ -40,7 +40,7 @@ public class ReadOnlyCalculateTest {
      */
     @Test
     public void calculate_evaluatedOnReadonlyFieldWithUi() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Calculate readonly", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Calculate readonly"),
                 model(

--- a/src/test/java/org/javarosa/core/model/data/test/GeoPointDataTests.java
+++ b/src/test/java/org/javarosa/core/model/data/test/GeoPointDataTests.java
@@ -45,7 +45,7 @@ public class GeoPointDataTests {
 
     @Test
     public void missingAccuracy_isNotTreatedAs0() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Missing accuracy", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Missing accuracy"),
                 model(

--- a/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -84,7 +84,7 @@ public class FormDefTest {
             body(input("/data/a"))
         );
 
-        Scenario scenario = Scenario.init("Some form", formDef);
+        Scenario scenario = Scenario.init(formDef);
 
         scenario.next();
         Scenario.AnswerResult result = scenario.answer("00000");
@@ -104,7 +104,7 @@ public class FormDefTest {
     //region Repeat relevance
     @Test
     public void repeatRelevanceChanges_whenDependentValuesOfRelevanceExpressionChange() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Repeat relevance - dynamic expression", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Repeat relevance - dynamic expression"),
                 model(
@@ -133,7 +133,7 @@ public class FormDefTest {
 
     @Test
     public void repeatIsIrrelevant_whenRelevanceSetToFalse() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Repeat relevance - false()", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Repeat relevance - false()"),
                 model(
@@ -155,7 +155,7 @@ public class FormDefTest {
 
     @Test
     public void repeatRelevanceChanges_whenDependentValuesOfGrandparentRelevanceExpressionChange() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Repeat relevance - dynamic expression", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Repeat relevance - dynamic expression"),
                 model(
@@ -188,7 +188,7 @@ public class FormDefTest {
 
     @Test
     public void repeatIsIrrelevant_whenGrandparentRelevanceSetToFalse() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Repeat relevance - false()", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Repeat relevance - false()"),
                 model(
@@ -215,7 +215,7 @@ public class FormDefTest {
 
     @Test
     public void nestedRepeatRelevance_updatesBasedOnParentPosition() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested repeat relevance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested repeat relevance"),
                 model(
@@ -275,7 +275,7 @@ public class FormDefTest {
 
     @Test
     public void innerRepeatGroupIsIrrelevant_whenItsParentRepeatGroupDoesNotExist() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested repeat relevance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested repeat relevance"),
                 model(
@@ -304,7 +304,7 @@ public class FormDefTest {
 
     @Test
     public void canCreateRepeat_returnsFalse_when_repeatCountSetButTheGroupItBelongsToDoesNotExist() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested repeat relevance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested repeat relevance"),
                 model(
@@ -341,7 +341,7 @@ public class FormDefTest {
 
     @Test
     public void fillTemplateString_resolvesRelativeReferences() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("<output> with relative ref", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("output with relative ref"),
                 model(
@@ -377,7 +377,7 @@ public class FormDefTest {
 
     @Test
     public void fillTemplateString_resolvesRelativeReferences_inItext() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("<output> with relative ref in translation", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("output with relative ref in translation"),
                 model(
@@ -417,7 +417,7 @@ public class FormDefTest {
 
     @Test
     public void canAddFunctionHandlersBeforeInitialize() throws Exception {
-        FormDef formDef = Scenario.createFormDef("custom-func-form", html(
+        FormDef formDef = Scenario.createFormDef(html(
             head(
                 title("custom-func-form"),
                 model(

--- a/src/test/java/org/javarosa/core/model/utils/test/QuestionPreloaderTest.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/QuestionPreloaderTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 public class QuestionPreloaderTest {
     @Test
     public void preloader_preloadsElements() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Preload attribute", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Preload element"),
                 model(
@@ -41,7 +41,7 @@ public class QuestionPreloaderTest {
     @Test
     // Unintentional limitation
     public void preloader_doesNotpreloadAttributes() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Preload attribute", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Preload attribute"),
                 model(

--- a/src/test/java/org/javarosa/core/util/GeoAreaTest.java
+++ b/src/test/java/org/javarosa/core/util/GeoAreaTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 public class GeoAreaTest {
     @Test
     public void area_isComputedForGeoshape() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("geoshape area", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Geoshape area"),
                 model(
@@ -62,7 +62,7 @@ public class GeoAreaTest {
 
     @Test
     public void area_isComputedForGeopointNodeset() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("geopoint nodeset area", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Geopoint nodeset area"),
                 model(
@@ -102,7 +102,7 @@ public class GeoAreaTest {
 
     @Test
     public void area_isComputedForString() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("string area", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("String area"),
                 model(
@@ -136,7 +136,7 @@ public class GeoAreaTest {
 
     @Test
     public void area_whenShapeHasFewerThanThreePoints_isZero() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("geoshape area", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Geoshape area"),
                 model(

--- a/src/test/java/org/javarosa/core/util/GeoDistanceTest.java
+++ b/src/test/java/org/javarosa/core/util/GeoDistanceTest.java
@@ -46,7 +46,7 @@ public class GeoDistanceTest {
 
     @Test
     public void distance_isComputedForGeopointNodeset() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("geopoint nodeset distance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Geopoint nodeset distance"),
                 model(
@@ -76,7 +76,7 @@ public class GeoDistanceTest {
 
     @Test
     public void distance_isComputedForGeotrace() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("geotrace distance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Geotrace distance"),
                 model(
@@ -99,7 +99,7 @@ public class GeoDistanceTest {
 
     @Test
     public void distance_isComputedForGeoshape() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("geoshape distance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Geoshape distance"),
                 model(
@@ -122,7 +122,7 @@ public class GeoDistanceTest {
 
     @Test
     public void distance_isComputedForString() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("string distance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("String distance"),
                 model(
@@ -155,7 +155,7 @@ public class GeoDistanceTest {
 
     @Test
     public void distance_isComputedForInlineString() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("string distance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("String distance"),
                 model(
@@ -187,7 +187,7 @@ public class GeoDistanceTest {
     @Test
     public void distance_throwsForNonPoint() throws IOException, XFormParser.ParseException {
         try {
-            Scenario.init("string distance", html(
+            Scenario.init(html(
                 head(
                     title("String distance"),
                     model(
@@ -210,7 +210,7 @@ public class GeoDistanceTest {
 
     @Test
     public void distance_isComputedForMultiplePathArguments() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("string distance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Multi parameter distance"),
                 model(
@@ -241,7 +241,7 @@ public class GeoDistanceTest {
 
     @Test
     public void distance_isComputedForMixedPathAndStringArguments() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("string distance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Multi parameter distance"),
                 model(
@@ -268,7 +268,7 @@ public class GeoDistanceTest {
 
     @Test
     public void distance_whenTraceHasFewerThanTwoPoints_isZero() throws Exception {
-        Scenario scenario = Scenario.init("geotrace distance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Geotrace distance"),
                 model(

--- a/src/test/java/org/javarosa/form/api/FormEntryControllerTest.java
+++ b/src/test/java/org/javarosa/form/api/FormEntryControllerTest.java
@@ -25,7 +25,7 @@ public class FormEntryControllerTest {
 
     @Test
     public void jumpToNewRepeatPrompt_whenInRepeat_jumpsToRepeatPrompt() throws Exception {
-        Scenario scenario = Scenario.init("repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("form"),
                 model(
@@ -63,7 +63,7 @@ public class FormEntryControllerTest {
 
     @Test
     public void jumpToNewRepeatPrompt_whenInOuterOfNestedRepeat_jumpsToOuterRepeatPrompt() throws Exception {
-        Scenario scenario = Scenario.init("nestedRepeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("form"),
                 model(
@@ -110,7 +110,7 @@ public class FormEntryControllerTest {
 
     @Test
     public void jumpToNewRepeatPrompt_whenInInnerOfNestedRepeat_jumpsToInnerRepeatPrompt() throws Exception {
-        Scenario scenario = Scenario.init("nestedRepeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("form"),
                 model(
@@ -160,7 +160,7 @@ public class FormEntryControllerTest {
 
     @Test
     public void jumpToNewRepeatPrompt_whenInGroupInRepeat_jumpsToRepeatPrompt() throws Exception {
-        Scenario scenario = Scenario.init("groupInRepeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("form"),
                 model(
@@ -203,7 +203,7 @@ public class FormEntryControllerTest {
 
     @Test
     public void jumpToNewRepeatPrompt_whenNotInRepeat_doesNothing() throws Exception {
-        Scenario scenario = Scenario.init("questionsOnly", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("form"),
                 model(

--- a/src/test/java/org/javarosa/form/api/FormEntryModelTest.java
+++ b/src/test/java/org/javarosa/form/api/FormEntryModelTest.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class FormEntryModelTest {
     @Test
     public void isIndexRelevant_respectsRelevanceOfOutermostGroup() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Nested relevance", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Nested relevance"),
                 model(

--- a/src/test/java/org/javarosa/form/api/FormEntryPromptTest.java
+++ b/src/test/java/org/javarosa/form/api/FormEntryPromptTest.java
@@ -40,7 +40,7 @@ public class FormEntryPromptTest {
     //region Binding of select choice values to labels
     @Test
     public void getSelectItemText_onSelectionFromDynamicSelect_withoutTranslations_returnsLabelInnerText() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Select", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Select"),
                 model(
@@ -69,7 +69,7 @@ public class FormEntryPromptTest {
 
     @Test
     public void getSelectItemText_onSelectionFromDynamicSelect_withTranslations_returnsCorrectTranslation() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Multilingual dynamic select", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Multilingual dynamic select"),
                 model(
@@ -114,7 +114,7 @@ public class FormEntryPromptTest {
 
     @Test
     public void getSelectItemText_onSelectionsInRepeatInstances_returnsLabelInnerText() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Select", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Select"),
                 model(

--- a/src/test/java/org/javarosa/form/api/MultiplePredicateTest.java
+++ b/src/test/java/org/javarosa/form/api/MultiplePredicateTest.java
@@ -21,7 +21,7 @@ public class MultiplePredicateTest {
 
     @Test
     public void calculatesSupportMultiplePredicatesInOnePartOfPath() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -66,7 +66,7 @@ public class MultiplePredicateTest {
 
     @Test
     public void calculatesSupportMultiplePredicatesInMultiplePartsOfPath() throws Exception {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(

--- a/src/test/java/org/javarosa/model/xform/XFormSerializingVisitorTest.java
+++ b/src/test/java/org/javarosa/model/xform/XFormSerializingVisitorTest.java
@@ -36,7 +36,7 @@ public class XFormSerializingVisitorTest {
             body(input("/data/text"))
         );
 
-        Scenario scenario = Scenario.init("Some form", formDef);
+        Scenario scenario = Scenario.init(formDef);
         scenario.next();
         scenario.answer("\uD83E\uDDDB");
 

--- a/src/test/java/org/javarosa/plugins/InstancePluginTest.java
+++ b/src/test/java/org/javarosa/plugins/InstancePluginTest.java
@@ -56,10 +56,10 @@ public class InstancePluginTest {
             new Pair<>("1", "Item 1")
         ), true));
 
-        File tempFile = TempFileUtils.createTempFile("fake-instance", "fake");
+        File tempFile = TempFileUtils.createTempFile("fake");
         setUpSimpleReferenceManager(tempFile, "file-csv", "file");
 
-        Scenario scenario = Scenario.init("Fake instance form", html(
+        Scenario scenario = Scenario.init(html(
                 head(
                     title("Fake instance form"),
                     model(
@@ -125,10 +125,10 @@ public class InstancePluginTest {
             new Pair<>("1", "Item 1")
         ), true));
 
-        File tempFile = TempFileUtils.createTempFile("fake-instance", "fake");
+        File tempFile = TempFileUtils.createTempFile("fake");
         setUpSimpleReferenceManager(tempFile, "file-csv", "file");
 
-        Scenario scenario = Scenario.init("Fake instance form", html(
+        Scenario scenario = Scenario.init(html(
                 head(
                     title("Fake instance form"),
                     model(
@@ -194,10 +194,10 @@ public class InstancePluginTest {
             new Pair<>("1", "Item 1")
         ), true));
 
-        File tempFile = TempFileUtils.createTempFile("fake-instance", "fake");
+        File tempFile = TempFileUtils.createTempFile("fake");
         setUpSimpleReferenceManager(tempFile, "file-csv", "file");
 
-        Scenario scenario = Scenario.init("Fake instance form", html(
+        Scenario scenario = Scenario.init(html(
                 head(
                     title("Fake instance form"),
                     model(
@@ -247,10 +247,10 @@ public class InstancePluginTest {
             new Pair<>("0", "Item 0")
         ), false));
 
-        File tempFile = TempFileUtils.createTempFile("fake-instance", "fake");
+        File tempFile = TempFileUtils.createTempFile("fake");
         setUpSimpleReferenceManager(tempFile, "file-csv", "file");
 
-        Scenario scenario = Scenario.init("Fake instance form", html(
+        Scenario scenario = Scenario.init(html(
                 head(
                     title("Fake instance form"),
                     model(

--- a/src/test/java/org/javarosa/regression/IndexedRepeatRelativeRefsTest.java
+++ b/src/test/java/org/javarosa/regression/IndexedRepeatRelativeRefsTest.java
@@ -76,7 +76,7 @@ public class IndexedRepeatRelativeRefsTest {
 
     @Test
     public void indexed_repeat() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(

--- a/src/test/java/org/javarosa/regression/SameRefDifferentInstancesIssue449Test.java
+++ b/src/test/java/org/javarosa/regression/SameRefDifferentInstancesIssue449Test.java
@@ -61,7 +61,7 @@ public class SameRefDifferentInstancesIssue449Test {
 
     @Test
     public void constraintsAreCorrectlyApplied_afterDeserialization() throws IOException, DeserializationException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Tree reference deserialization", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Tree reference deserialization"),
                 model(

--- a/src/test/java/org/javarosa/regression/TriggersForRelativeRefsTest.java
+++ b/src/test/java/org/javarosa/regression/TriggersForRelativeRefsTest.java
@@ -25,7 +25,7 @@ import static org.javarosa.test.XFormsElement.title;
 public class TriggersForRelativeRefsTest {
     @Test
     public void indefiniteRepeatJrCountExpression_inSingleRepeat_addsRepeatsUntilConditionMet() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("indefinite repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Indefinite repeat"),
                 model(
@@ -62,7 +62,7 @@ public class TriggersForRelativeRefsTest {
 
     @Test
     public void indefiniteRepeatJrCountExpression_inNestedRepeat_addsRepeatsUntilConditionMet() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("nested indefinite repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Indefinite repeat in nested repeat"),
                 model(
@@ -113,7 +113,7 @@ public class TriggersForRelativeRefsTest {
 
     @Test
     public void indefiniteRepeatJrCountExpression_inNestedRepeat_withRelativePaths_addsRepeatsUntilConditionMet() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("nested indefinite repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Indefinite repeat in nested repeat"),
                 model(
@@ -164,7 +164,7 @@ public class TriggersForRelativeRefsTest {
 
     @Test
     public void predicateWithRelativePathExpression_reevaluated_whenTriggerChanges() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Predicate trigger", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Predicate trigger"),
                 model(
@@ -217,7 +217,7 @@ public class TriggersForRelativeRefsTest {
 
     @Test
     public void predicateWithCurrentPathExpression_reevaluated_whenTriggerChanges() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Predicate trigger", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Predicate trigger"),
                 model(

--- a/src/test/java/org/javarosa/xform/parse/ExternalSecondaryInstanceParseTest.java
+++ b/src/test/java/org/javarosa/xform/parse/ExternalSecondaryInstanceParseTest.java
@@ -109,7 +109,7 @@ public class ExternalSecondaryInstanceParseTest {
         configureReferenceManagerCorrectly();
 
         try {
-            Scenario.init("Some form", html(
+            Scenario.init(html(
                 head(
                     title("Some form"),
                     model(
@@ -138,7 +138,7 @@ public class ExternalSecondaryInstanceParseTest {
     public void csvSecondaryInstanceWithHeaderOnly_parsesWithoutError() throws IOException, XFormParser.ParseException {
         configureReferenceManagerCorrectly();
 
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(
@@ -265,7 +265,7 @@ public class ExternalSecondaryInstanceParseTest {
     public void exceptionFromChoiceSelection_whenFormIsDeserialized_afterPlaceholderInstanceUsed_andFileMissingColumns() throws IOException, DeserializationException, XFormParser.ParseException {
         configureReferenceManagerIncorrectly();
 
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Some form"),
                 model(

--- a/src/test/java/org/javarosa/xform/parse/XFormParserTest.java
+++ b/src/test/java/org/javarosa/xform/parse/XFormParserTest.java
@@ -120,7 +120,7 @@ public class XFormParserTest {
     
     @Test
     public void spacesBetweenOutputs_areRespected() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("spaces-outputs", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 model(
                     mainInstance(t("data id=\"spaces-outputs\"",

--- a/src/test/java/org/javarosa/xpath/expr/Base64DecodeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/Base64DecodeTest.java
@@ -55,7 +55,7 @@ public class Base64DecodeTest {
     }
 
     private static Scenario getBase64DecodeScenario(String testName, String source) throws IOException, XFormParser.ParseException {
-        return Scenario.init(testName, html(
+        return Scenario.init(html(
             head(
                 title(testName),
                 model(
@@ -76,7 +76,7 @@ public class Base64DecodeTest {
     @Test
     public void base64DecodeFunction_throwsWhenNotExactlyOneArg() throws IOException, XFormParser.ParseException {
         try {
-            Scenario scenario = Scenario.init("Invalid base64 string", html(
+            Scenario scenario = Scenario.init(html(
                 head(
                     title("Invalid base64 string"),
                     model(
@@ -101,7 +101,7 @@ public class Base64DecodeTest {
 
     @Test
     public void base64DecodeFunction_returnsEmptyStringWhenInputInvalid() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Invalid base64 string", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Invalid base64 string"),
                 model(

--- a/src/test/java/org/javarosa/xpath/expr/DigestTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/DigestTest.java
@@ -87,7 +87,7 @@ public class DigestTest {
 
     @Test
     public void digestFunction_acceptsDynamicParameters() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Some form", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Digest form"),
                 model(

--- a/src/test/java/org/javarosa/xpath/expr/ExtractSignedTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/ExtractSignedTest.java
@@ -67,7 +67,7 @@ public class ExtractSignedTest {
     @Test
     public void whenNoArgs_throwsException() throws Exception {
         try {
-            Scenario.init("extract signed form", html(
+            Scenario.init(html(
                 head(
                     title("extract signed form"),
                     model(
@@ -171,7 +171,7 @@ public class ExtractSignedTest {
 
     @NotNull
     private static Scenario createScenario(String encodedContents, String encodedPublicKey) throws IOException, XFormParser.ParseException {
-        return Scenario.init("extract signed form", html(
+        return Scenario.init(html(
             head(
                 title("extract signed form"),
                 model(

--- a/src/test/java/org/javarosa/xpath/expr/IndexedRepeatTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/IndexedRepeatTest.java
@@ -28,7 +28,7 @@ public class IndexedRepeatTest {
     @Test
     public void firstArgNotChildOfRepeat_throwsException() throws Exception {
         try {
-            Scenario.init("indexed-repeat", html(
+            Scenario.init(html(
                 head(
                     title("indexed-repeat"),
                     model(
@@ -56,7 +56,7 @@ public class IndexedRepeatTest {
 
     @Test
     public void getsIndexedValueInSingleRepeat() throws Exception {
-        Scenario scenario = Scenario.init("indexed-repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("indexed-repeat"),
                 model(
@@ -96,7 +96,7 @@ public class IndexedRepeatTest {
 
     @Test
     public void getsIndexedValueUsingParallelRepeatPosition() throws Exception {
-        Scenario scenario = Scenario.init("indexed-repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("indexed-repeat"),
                 model(
@@ -182,7 +182,7 @@ public class IndexedRepeatTest {
     }
 
     public static Scenario buildNestedRepeatForm() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("indexed-repeat", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("indexed-repeat"),
                 model(

--- a/src/test/java/org/javarosa/xpath/expr/RandomizeTypesTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/RandomizeTypesTest.java
@@ -26,7 +26,7 @@ import static org.javarosa.test.XFormsElement.title;
 public class RandomizeTypesTest {
     @Test
     public void stringNumberSeedConvertsWhenUsedInNodesetExpression() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Randomize non-numeric seed"),
                 model(
@@ -64,7 +64,7 @@ public class RandomizeTypesTest {
 
     @Test
     public void stringNumberSeedConvertsWhenUsedInCalculate() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Randomize non-numeric seed"),
                 model(
@@ -97,7 +97,7 @@ public class RandomizeTypesTest {
 
     @Test
     public void stringTextSeedConvertsWhenUsedInNodesetExpression() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Randomize non-numeric seed"),
                 model(
@@ -129,7 +129,7 @@ public class RandomizeTypesTest {
 
     @Test
     public void stringTextSeedConvertsWhenUsedInCalculate() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Randomize non-numeric seed"),
                 model(
@@ -159,7 +159,7 @@ public class RandomizeTypesTest {
 
     @Test
     public void seedInRepeatIsEvaluatedForEachInstance() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Randomize non-numeric seed"),
                 model(
@@ -196,7 +196,7 @@ public class RandomizeTypesTest {
 
     @Test
     public void seedFromArbitraryInputCanBeUsed() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+        Scenario scenario = Scenario.init(html(
             head(
                 title("Randomize non-numeric seed"),
                 model(
@@ -233,7 +233,7 @@ public class RandomizeTypesTest {
 
     @Test
     public void seed0FromNaNs() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Randomize non-numeric seed", html(
+        Scenario scenario = Scenario.init(html(
                 head(
                         title("Randomize non-numeric seed"),
                         model(


### PR DESCRIPTION
Work towards https://github.com/getodk/collect/issues/7118

#### What has been done to verify that this works as intended?

I've tried this out with my draft PR (https://github.com/getodk/collect/pull/7235) for https://github.com/getodk/collect/issues/7118 to check that geo questions now have attached choices.

#### Why is this the best possible solution? Were any other approaches considered?

We discussed just adding the geo questions to the optional list, but it honestly felt like the more complex solution given that all questions (`FormEntryPrompt` instances) have a `selectChoices` property.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There should not be any effect on behaviour other than allowing us to build the new features in https://github.com/getodk/collect/issues/7118. I've actually only had to delete untested code to get this working (the test I added is backfilling missing coverage).
