### PR TITLE
Handle unparseable date, time and dateTime values gracefully in wrapData

### DIFF
--- a/src/main/java/org/javarosa/core/model/data/IAnswerData.java
+++ b/src/main/java/org/javarosa/core/model/data/IAnswerData.java
@@ -111,7 +111,8 @@ public interface IAnswerData extends Externalizable {
             return new MultipleItemsData().cast(new UncastData(String.valueOf(val)));
         } else if (dataType == TIME) {
             if (val instanceof String) {
-                return new TimeData().cast(new UncastData(String.valueOf(val)));
+                Date time = DateUtils.parseTime(String.valueOf(val));
+                return time == null ? null : new TimeData(time);
             } else {
                 return new TimeData((Date) val);
             }

--- a/src/main/java/org/javarosa/core/model/data/IAnswerData.java
+++ b/src/main/java/org/javarosa/core/model/data/IAnswerData.java
@@ -117,13 +117,15 @@ public interface IAnswerData extends Externalizable {
             }
         } else if (dataType == DATE) {
             if (val instanceof String) {
-                return new DateData(DateUtils.parseDate(String.valueOf(val)));
+                Date date = DateUtils.parseDate(String.valueOf(val));
+                return date == null ? null : new DateData(date);
             } else {
                 return new DateData((Date) val);
             }
         } else if (dataType == DATE_TIME) {
             if (val instanceof String) {
-                return new DateTimeData(DateUtils.parseDateTime(String.valueOf(val)));
+                Date dateTime = DateUtils.parseDateTime(String.valueOf(val));
+                return dateTime == null ? null : new DateTimeData(dateTime);
             } else {
                 return new DateTimeData((Date) val);
             }

--- a/src/test/java/org/javarosa/core/model/DateTimeTest.java
+++ b/src/test/java/org/javarosa/core/model/DateTimeTest.java
@@ -209,4 +209,49 @@ public class DateTimeTest {
         IAnswerData answer = scenario.answerOf("/data/calculateReference");
         assertThat(answer, nullValue());
     }
+
+    @Test
+    public void timeQuestionWithInvalidTimeFormatLiteralResultsInNoAnswer() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("Time form"),
+                model(
+                    mainInstance(t("data id=\"time-form\"",
+                        t("calculateLiteral")
+                    )),
+                    bind("/data/calculateLiteral").type("time").calculate("&quot;notatime&quot;")
+                )
+            ),
+            body(
+                input("/data/calculateLiteral")
+            )
+        ));
+
+        IAnswerData answer = scenario.answerOf("/data/calculateLiteral");
+        assertThat(answer, nullValue());
+    }
+
+    @Test
+    public void timeQuestionWithInvalidTimeFormatReferenceResultsInNoAnswer() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("Time form"),
+                model(
+                    mainInstance(t("data id=\"time-form\"",
+                        t("invalid", "notatime"),
+                        t("calculateReference")
+                    )),
+                    bind("/data/invalid").type("string"),
+                    bind("/data/calculateReference").type("time").calculate("/data/invalid")
+                )
+            ),
+            body(
+                input("/data/invalid"),
+                input("/data/calculateReference")
+            )
+        ));
+
+        IAnswerData answer = scenario.answerOf("/data/calculateReference");
+        assertThat(answer, nullValue());
+    }
 }

--- a/src/test/java/org/javarosa/core/model/DateTimeTest.java
+++ b/src/test/java/org/javarosa/core/model/DateTimeTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.javarosa.test.BindBuilderXFormsElement.bind;
 import static org.javarosa.test.XFormsElement.body;
@@ -117,5 +118,95 @@ public class DateTimeTest {
 
         IAnswerData answer3 = scenario.answerOf("/data/calculateReference");
         assertThat(answer3 instanceof DateTimeData, equalTo(true));
+    }
+
+    @Test
+    public void dateQuestionWithInvalidDateFormatLiteralResultsInNoAnswer() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("Date form"),
+                model(
+                    mainInstance(t("data id=\"date-form\"",
+                        t("calculateLiteral")
+                    )),
+                    bind("/data/calculateLiteral").type("date").calculate("&quot;not-a-date&quot;")
+                )
+            ),
+            body(
+                input("/data/calculateLiteral")
+            )
+        ));
+
+        IAnswerData answer = scenario.answerOf("/data/calculateLiteral");
+        assertThat(answer, nullValue());
+    }
+
+    @Test
+    public void dateQuestionWithInvalidDateFormatReferenceResultsInNoAnswer() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("Date form"),
+                model(
+                    mainInstance(t("data id=\"date-form\"",
+                        t("invalid", "not-a-date"),
+                        t("calculateReference")
+                    )),
+                    bind("/data/invalid").type("string"),
+                    bind("/data/calculateReference").type("date").calculate("/data/invalid")
+                )
+            ),
+            body(
+                input("/data/invalid"),
+                input("/data/calculateReference")
+            )
+        ));
+
+        IAnswerData answer = scenario.answerOf("/data/calculateReference");
+        assertThat(answer, nullValue());
+    }
+
+    @Test
+    public void dateTimeQuestionWithInvalidDateFormatLiteralResultsInNoAnswer() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("DateTime form"),
+                model(
+                    mainInstance(t("data id=\"datetime-form\"",
+                        t("calculateLiteral")
+                    )),
+                    bind("/data/calculateLiteral").type("dateTime").calculate("&quot;not-a-datetime&quot;")
+                )
+            ),
+            body(
+                input("/data/calculateLiteral")
+            )
+        ));
+
+        IAnswerData answer = scenario.answerOf("/data/calculateLiteral");
+        assertThat(answer, nullValue());
+    }
+
+    @Test
+    public void dateTimeQuestionWithInvalidDateFormatReferenceResultsInNoAnswer() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("DateTime form"),
+                model(
+                    mainInstance(t("data id=\"datetime-form\"",
+                        t("invalid", "not-a-datetime"),
+                        t("calculateReference")
+                    )),
+                    bind("/data/invalid").type("string"),
+                    bind("/data/calculateReference").type("dateTime").calculate("/data/invalid")
+                )
+            ),
+            body(
+                input("/data/invalid"),
+                input("/data/calculateReference")
+            )
+        ));
+
+        IAnswerData answer = scenario.answerOf("/data/calculateReference");
+        assertThat(answer, nullValue());
     }
 }

--- a/src/test/java/org/javarosa/core/model/DateTimeTest.java
+++ b/src/test/java/org/javarosa/core/model/DateTimeTest.java
@@ -121,137 +121,86 @@ public class DateTimeTest {
     }
 
     @Test
-    public void dateQuestionWithInvalidDateFormatLiteralResultsInNoAnswer() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init(html(
-            head(
-                title("Date form"),
-                model(
-                    mainInstance(t("data id=\"date-form\"",
-                        t("calculateLiteral")
-                    )),
-                    bind("/data/calculateLiteral").type("date").calculate("&quot;not-a-date&quot;")
-                )
-            ),
-            body(
-                input("/data/calculateLiteral")
-            )
-        ));
-
-        IAnswerData answer = scenario.answerOf("/data/calculateLiteral");
-        assertThat(answer, nullValue());
-    }
-
-    @Test
-    public void dateQuestionWithInvalidDateFormatReferenceResultsInNoAnswer() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init(html(
-            head(
-                title("Date form"),
-                model(
-                    mainInstance(t("data id=\"date-form\"",
-                        t("invalid", "not-a-date"),
-                        t("calculateReference")
-                    )),
-                    bind("/data/invalid").type("string"),
-                    bind("/data/calculateReference").type("date").calculate("/data/invalid")
-                )
-            ),
-            body(
-                input("/data/invalid"),
-                input("/data/calculateReference")
-            )
-        ));
-
-        IAnswerData answer = scenario.answerOf("/data/calculateReference");
-        assertThat(answer, nullValue());
-    }
-
-    @Test
-    public void dateTimeQuestionWithInvalidDateFormatLiteralResultsInNoAnswer() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init(html(
-            head(
-                title("DateTime form"),
-                model(
-                    mainInstance(t("data id=\"datetime-form\"",
-                        t("calculateLiteral")
-                    )),
-                    bind("/data/calculateLiteral").type("dateTime").calculate("&quot;not-a-datetime&quot;")
-                )
-            ),
-            body(
-                input("/data/calculateLiteral")
-            )
-        ));
-
-        IAnswerData answer = scenario.answerOf("/data/calculateLiteral");
-        assertThat(answer, nullValue());
-    }
-
-    @Test
-    public void dateTimeQuestionWithInvalidDateFormatReferenceResultsInNoAnswer() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init(html(
-            head(
-                title("DateTime form"),
-                model(
-                    mainInstance(t("data id=\"datetime-form\"",
-                        t("invalid", "not-a-datetime"),
-                        t("calculateReference")
-                    )),
-                    bind("/data/invalid").type("string"),
-                    bind("/data/calculateReference").type("dateTime").calculate("/data/invalid")
-                )
-            ),
-            body(
-                input("/data/invalid"),
-                input("/data/calculateReference")
-            )
-        ));
-
-        IAnswerData answer = scenario.answerOf("/data/calculateReference");
-        assertThat(answer, nullValue());
-    }
-
-    @Test
-    public void timeQuestionWithInvalidTimeFormatLiteralResultsInNoAnswer() throws IOException, XFormParser.ParseException {
+    public void timeQuestionWithInvalidTimeFormatResultsInNoAnswer() throws IOException, XFormParser.ParseException {
         Scenario scenario = Scenario.init(html(
             head(
                 title("Time form"),
                 model(
                     mainInstance(t("data id=\"time-form\"",
-                        t("calculateLiteral")
-                    )),
-                    bind("/data/calculateLiteral").type("time").calculate("&quot;notatime&quot;")
-                )
-            ),
-            body(
-                input("/data/calculateLiteral")
-            )
-        ));
-
-        IAnswerData answer = scenario.answerOf("/data/calculateLiteral");
-        assertThat(answer, nullValue());
-    }
-
-    @Test
-    public void timeQuestionWithInvalidTimeFormatReferenceResultsInNoAnswer() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init(html(
-            head(
-                title("Time form"),
-                model(
-                    mainInstance(t("data id=\"time-form\"",
-                        t("invalid", "notatime"),
+                        t("calculateLiteral"),
+                        t("empty", "notatime"),
                         t("calculateReference")
                     )),
-                    bind("/data/invalid").type("string"),
-                    bind("/data/calculateReference").type("time").calculate("/data/invalid")
+                    bind("/data/calculateLiteral").type("time").calculate("&quot;notatime&quot;"),
+                    bind("/data/empty").type("time"),
+                    bind("/data/calculateReference").type("time").calculate("/data/empty")
                 )
             ),
             body(
-                input("/data/invalid"),
+                input("/data/calculateLiteral"),
+                input("/data/empty"),
                 input("/data/calculateReference")
             )
         ));
 
-        IAnswerData answer = scenario.answerOf("/data/calculateReference");
-        assertThat(answer, nullValue());
+        assertThat(scenario.answerOf("/data/calculateLiteral"), nullValue());
+        assertThat(scenario.answerOf("/data/empty"), nullValue());
+        assertThat(scenario.answerOf("/data/calculateReference"), nullValue());
+    }
+
+    @Test
+    public void dateQuestionWithInvalidDateFormatResultsInNoAnswer() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("Date form"),
+                model(
+                    mainInstance(t("data id=\"date-form\"",
+                        t("calculateLiteral"),
+                        t("empty", "not-a-date"),
+                        t("calculateReference")
+                    )),
+                    bind("/data/calculateLiteral").type("date").calculate("&quot;not-a-date&quot;"),
+                    bind("/data/empty").type("date"),
+                    bind("/data/calculateReference").type("date").calculate("/data/empty")
+                )
+            ),
+            body(
+                input("/data/calculateLiteral"),
+                input("/data/empty"),
+                input("/data/calculateReference")
+            )
+        ));
+
+        assertThat(scenario.answerOf("/data/calculateLiteral"), nullValue());
+        assertThat(scenario.answerOf("/data/empty"), nullValue());
+        assertThat(scenario.answerOf("/data/calculateReference"), nullValue());
+    }
+
+    @Test
+    public void dateTimeQuestionWithInvalidDateTimeFormatResultsInNoAnswer() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("DateTime form"),
+                model(
+                    mainInstance(t("data id=\"datetime-form\"",
+                        t("calculateLiteral"),
+                        t("empty", "not-a-datetime"),
+                        t("calculateReference")
+                    )),
+                    bind("/data/calculateLiteral").type("dateTime").calculate("&quot;not-a-datetime&quot;"),
+                    bind("/data/empty").type("dateTime"),
+                    bind("/data/calculateReference").type("dateTime").calculate("/data/empty")
+                )
+            ),
+            body(
+                input("/data/calculateLiteral"),
+                input("/data/empty"),
+                input("/data/calculateReference")
+            )
+        ));
+
+        assertThat(scenario.answerOf("/data/calculateLiteral"), nullValue());
+        assertThat(scenario.answerOf("/data/empty"), nullValue());
+        assertThat(scenario.answerOf("/data/calculateReference"), nullValue());
     }
 }


### PR DESCRIPTION
Closes #https://github.com/getodk/collect/issues/7239

#### What has been done to verify that this works as intended?
I've added unit tests in `DateTimeTest` covering all three temporal types (`date`, `time`, `dateTime`) and also tested the changes manually with Collect.

#### Why is this the best possible solution? Were any other approaches considered?
`DateUtils.parseDate/parseTime/parseDateTime` already signal `unparseable` by returning `null`. The bug was that `wrapData` fed that null straight into a `DateData`/`TimeData`/`DateTimeData` constructor, whose `setValue` rejects `null`. Returning `null` from `wrapData` instead is the smallest, most consistent fix: it matches how `wrapData` already handles empty strings, and it honours the `IAnswerData` contract that a non-existent response is represented by a `null` reference (not a data object wrapping `null`).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
When a calculation yields a value that can't be parsed as a `date`/`time`/`dateTime`, the target node is now left blank instead of throwing an exception that might cause a crash.

#### Do we need any specific form for testing your changes? If so, please attach one.
There is one linked in https://github.com/getodk/collect/issues/7239

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.