### PR TITLE
Test current whitespace behavior, don't crash if geojson geometry is missing

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
+++ b/src/main/java/org/javarosa/core/model/instance/geojson/GeojsonFeature.java
@@ -16,12 +16,14 @@
 
 package org.javarosa.core.model.instance.geojson;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.io.IOException;
-import java.util.Map;
 import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.instance.TreeElement;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -40,9 +42,11 @@ public class GeojsonFeature {
 
         TreeElement item = new TreeElement("item", multiplicity);
 
-        TreeElement geoField = new TreeElement(GEOMETRY_CHILD_NAME, 0);
-        geoField.setValue(new UncastData(geometry.getOdkCoordinates()));
-        item.addChild(geoField);
+        if (geometry != null) {
+            TreeElement geoField = new TreeElement(GEOMETRY_CHILD_NAME, 0);
+            geoField.setValue(new UncastData(geometry.getOdkCoordinates()));
+            item.addChild(geoField);
+        }
 
         if (properties != null) {
             for (String property : properties.keySet()) {

--- a/src/test/java/org/javarosa/core/model/instance/CsvExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/CsvExternalInstanceTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.javarosa.test.ResourcePathHelper.r;
 import static org.junit.Assert.assertEquals;
 
@@ -67,5 +68,18 @@ public class CsvExternalInstanceTest {
     public void parses_utf8_characters() throws IOException {
         TreeElement bomCsv = new CsvExternalInstance().parse("id", r("external-secondary-csv-bom.csv").toString());
         assertThat(bomCsv.getChildAt(0).getChild("elevation", 0).getValue().getValue(), is("testé"));
+    }
+
+    @Test
+    public void preserves_whitespace() throws IOException {
+        TreeElement csv = new CsvExternalInstance().parse("csv", r("whitespace.csv").toString());
+        assertThat(csv.getChildAt(0).getChild("name", 0), nullValue());
+        assertThat(csv.getChildAt(0).getChild(" name", 0).getValue().getDisplayText(), is(" person1"));
+
+        assertThat(csv.getChildAt(0).getChild("label", 0), nullValue());
+        assertThat(csv.getChildAt(0).getChild(" label", 0).getValue().getDisplayText(), is(" Person1"));
+
+        assertThat(csv.getChildAt(0).getChild("age", 0), nullValue());
+        assertThat(csv.getChildAt(0).getChild("age ", 0).getValue().getDisplayText(), is("13 "));
     }
 }

--- a/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/geojson/GeoJsonExternalInstanceTest.java
@@ -162,4 +162,18 @@ public class GeoJsonExternalInstanceTest {
         assertThat(featureCollection.getChildAt(0).getNumChildren(), is(4));
         assertThat(featureCollection.getChildAt(0).getChild("extra", 0).getValue().getDisplayText(), is(""));
     }
+
+    @Test
+    public void parse_preservesWhiteSpace() throws IOException {
+        TreeElement featureCollection = new GeoJsonExternalInstance().parse("places", r("spaces-in-names.geojson").toString());
+        assertThat(featureCollection.getChildAt(0).getChild("geometry", 0), nullValue());
+
+        assertThat(featureCollection.getChildAt(0).getChild("name", 0), nullValue());
+        assertThat(featureCollection.getChildAt(0).getChild(" name ", 0).getValue().getDisplayText(), is(" My cool point "));
+        assertThat(featureCollection.getChildAt(0).getChild("id", 0), nullValue());
+        assertThat(featureCollection.getChildAt(0).getChild(" id ", 0).getValue().getDisplayText(), is(" fs87b "));
+
+        assertThat(featureCollection.getChildAt(0).getChild("foo", 0), nullValue());
+        assertThat(featureCollection.getChildAt(0).getChild(" foo ", 0).getValue().getDisplayText(), is(" bar "));
+    }
 }

--- a/src/test/resources/org/javarosa/core/model/instance/geojson/spaces-in-names.geojson
+++ b/src/test/resources/org/javarosa/core/model/instance/geojson/spaces-in-names.geojson
@@ -1,0 +1,20 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            " geometry ": {
+                "type": "Point",
+                "coordinates": [
+                    102,
+                    0.5
+                ]
+            },
+            "properties": {
+                " id ": " fs87b ",
+                " name ": " My cool point ",
+                " foo ": " bar "
+            }
+        }
+    ]
+}

--- a/src/test/resources/org/javarosa/xform/parse/whitespace.csv
+++ b/src/test/resources/org/javarosa/xform/parse/whitespace.csv
@@ -1,0 +1,2 @@
+ name, label,age , score
+ person1, Person1,13 , 23


### PR DESCRIPTION
In support of https://github.com/getodk/xforms-spec/issues/351, https://github.com/getodk/javarosa/issues/665

#### What has been done to verify that this works as intended?

There's one small functional change which is that if a geojson feature has no geometry then it's skipped rather than crashing with an npe. That is now tested indirectly. This is more consistent with what happens if a geometry is missing in a CSV.

#### Why is this the best possible solution? Were any other approaches considered?

I put the tests in parsing for CSV and geojson files because they feel like they fit best with the tests in each of those files.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The small behavior change makes this more permissive. It could mean a geojson file with missing geometry gets missed but a file with accidental missing geometry doesn't feel likely to me.

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
