### PR TITLE
Display time component of datetime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,23 +56,6 @@ if (!project.hasProperty("android")) {
         }
     }
 
-    test {
-        exclude '**/DateTimeTest.class'
-    }
-
-    tasks.register('isolatedDateTimeTest', Test) {
-        description = 'Runs DateTimeTest without parallelization'
-        group = 'verification'
-
-        testClassesDirs = sourceSets.test.output.classesDirs
-        classpath = sourceSets.test.runtimeClasspath
-
-        include '**/DateTimeTest.class'
-        maxParallelForks = 1
-    }
-
-    check.dependsOn isolatedDateTimeTest
-
     tasks.named('compileJava', JavaCompile) {
         options.encoding = "UTF-8"
         options.compilerArgs << "-Xlint:deprecation"

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,23 @@ if (!project.hasProperty("android")) {
         }
     }
 
+    test {
+        exclude '**/DateTimeTest.class'
+    }
+
+    tasks.register('isolatedDateTimeTest', Test) {
+        description = 'Runs DateTimeTest without parallelization'
+        group = 'verification'
+
+        testClassesDirs = sourceSets.test.output.classesDirs
+        classpath = sourceSets.test.runtimeClasspath
+
+        include '**/DateTimeTest.class'
+        maxParallelForks = 1
+    }
+
+    check.dependsOn isolatedDateTimeTest
+
     tasks.named('compileJava', JavaCompile) {
         options.encoding = "UTF-8"
         options.compilerArgs << "-Xlint:deprecation"

--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -16,15 +16,16 @@
 
 package org.javarosa.core.model.utils;
 
+import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.MathUtils;
+import org.joda.time.LocalDateTime;
+import org.joda.time.format.DateTimeFormat;
+
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
-import org.javarosa.core.services.locale.Localization;
-import org.javarosa.core.util.MathUtils;
-import org.joda.time.LocalDateTime;
-import org.joda.time.format.DateTimeFormat;
 
 /**
  * Static utility methods for Dates in j2me
@@ -554,6 +555,16 @@ public class DateUtils {
         if ( d == null ) return null;
         DateFields f = getFields(d);
         return getDate(f.year, f.month, f.day);
+    }
+
+    public static boolean isMidnight(Date d) {
+        Calendar c = Calendar.getInstance();
+        c.setTime(d);
+
+        return c.get(Calendar.HOUR_OF_DAY) == 0
+            && c.get(Calendar.MINUTE) == 0
+            && c.get(Calendar.SECOND) == 0
+            && c.get(Calendar.MILLISECOND) == 0;
     }
 
     public static Date today () {

--- a/src/main/java/org/javarosa/test/Scenario.java
+++ b/src/main/java/org/javarosa/test/Scenario.java
@@ -27,6 +27,7 @@ import org.javarosa.core.model.ValidateOutcome;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.data.BooleanData;
 import org.javarosa.core.model.data.DateData;
+import org.javarosa.core.model.data.DateTimeData;
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
@@ -69,10 +70,11 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.sql.Date;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -629,10 +631,26 @@ public class Scenario {
     }
 
     /**
-     * Answers the question at the form index
+     * Answers with DateData representing the LocalDate as midnight UTC on that date.
+     *
+     * Because the resulting value represents an instant in time, viewing it in a
+     * non-UTC time zone may yield a different local calendar date. For example,
+     * 2024-01-01 is stored as 2024-01-01T00:00:00Z, which is 2023-12-31 in some
+     * western time zones.
      */
     public AnswerResult answer(LocalDate value) {
         return answer(new DateData(Date.from(value.atStartOfDay(ZoneId.of("UTC")).toInstant())));
+    }
+
+    /**
+     * Answers with either DateTimeData or DateData for the specified instant.
+     *
+     * When {@code isDateTime} is false, the instant is converted to a DateData and
+     * normalized according to DateData's date-only semantics.
+     */
+    public AnswerResult answer(Instant instant, boolean isDateTime) {
+        Date date = Date.from(instant);
+        return answer(isDateTime ? new DateTimeData(date) : new DateData(date));
     }
 
     /**

--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -345,7 +345,8 @@ public class XPathFuncExpr extends XPathExpression {
             }
         } else if (name.equals("today")) {
             assertArgsCount(name, args, 0);
-            return DateUtils.roundDate(new Date());
+            DateTime dt = new DateTime();
+            return DateUtils.roundDate(dt.toDate());
         } else if (name.equals("now")) {
             assertArgsCount(name, args, 0);
             return new DateTime().toDate();

--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -825,7 +825,13 @@ public class XPathFuncExpr extends XPathExpression {
         } else if (o instanceof String) {
             val = (String) o;
         } else if (o instanceof Date) {
-            val = DateUtils.formatDate((Date) o, DateUtils.FORMAT_ISO8601);
+            Date d = (Date) o;
+            // java.util.Date does not distinguish XForms date from dateTime. DateData values
+            // are normalized to local midnight, so treat midnight Dates as date-only values.
+            // This means dateTime values exactly at midnight will also be displayed as dates.
+            val = DateUtils.isMidnight(d) ?
+                DateUtils.formatDate(d, DateUtils.FORMAT_ISO8601)
+                : DateUtils.formatDateTime(d, DateUtils.FORMAT_ISO8601);
         } else if (o instanceof IExprDataType) {
             val = ((IExprDataType) o).toString();
         }

--- a/src/test/java/org/javarosa/xpath/expr/DateTimeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/DateTimeTest.java
@@ -27,10 +27,6 @@ import static org.javarosa.test.XFormsElement.model;
 import static org.javarosa.test.XFormsElement.t;
 import static org.javarosa.test.XFormsElement.title;
 
-/**
- * SIDE-EFFECT: Mutates JVM-default timezone and Joda-Time's current millis.
- * Must not be run in parallel with other timezone-sensitive tests.
- */
 public class DateTimeTest {
     private TimeZone originalTimeZone;
     private static final String SIMULATED_NOW = "1998-05-23T17:49:42.123-07:00"; // 1998-05-24 in UTC
@@ -40,17 +36,17 @@ public class DateTimeTest {
 
     @Before
     public void setUp() {
-        originalTimeZone = TimeZone.getDefault();
-
         DateTimeUtils.setCurrentMillisFixed(SIMULATED_INSTANT.toEpochMilli());
 
+        originalTimeZone = TimeZone.getDefault();
         TimeZone.setDefault(SIMULATED_TZ);
     }
 
     @After
     public void tearDown() {
-        DateTimeUtils.setCurrentMillisSystem();
         TimeZone.setDefault(originalTimeZone);
+
+        DateTimeUtils.setCurrentMillisSystem();
     }
 
     @Test

--- a/src/test/java/org/javarosa/xpath/expr/DateTimeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/DateTimeTest.java
@@ -1,0 +1,239 @@
+package org.javarosa.xpath.expr;
+
+import org.javarosa.form.api.FormEntryCaption;
+import org.javarosa.test.Scenario;
+import org.javarosa.xform.parse.XFormParser;
+import org.joda.time.DateTimeUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.javarosa.test.BindBuilderXFormsElement.bind;
+import static org.javarosa.test.XFormsElement.body;
+import static org.javarosa.test.XFormsElement.head;
+import static org.javarosa.test.XFormsElement.html;
+import static org.javarosa.test.XFormsElement.input;
+import static org.javarosa.test.XFormsElement.label;
+import static org.javarosa.test.XFormsElement.mainInstance;
+import static org.javarosa.test.XFormsElement.model;
+import static org.javarosa.test.XFormsElement.t;
+import static org.javarosa.test.XFormsElement.title;
+
+public class DateTimeTest {
+    private TimeZone originalTimeZone;
+    String SIMULATED_NOW = "1998-05-23T17:49:42-07:00"; // 1998-05-24 in UTC
+    Instant SIMULATED_INSTANT = OffsetDateTime.parse(SIMULATED_NOW).toInstant();
+
+    TimeZone SIMULATED_TZ = TimeZone.getTimeZone("America/Los_Angeles");
+
+    @Before
+    public void setUp() {
+        originalTimeZone = TimeZone.getDefault();
+
+        DateTimeUtils.setCurrentMillisFixed(SIMULATED_INSTANT.toEpochMilli());
+
+        TimeZone.setDefault(SIMULATED_TZ);
+    }
+
+    @After
+    public void tearDown() {
+        DateTimeUtils.setCurrentMillisSystem();
+        TimeZone.setDefault(originalTimeZone);
+    }
+
+    @Test
+    public void nowLabelOutput_isIsoOffsetDateTime() throws IOException, XFormParser.ParseException {
+            Scenario scenario = Scenario.init(html(
+                head(
+                    title("Date time"),
+                    model(
+                        mainInstance(t("data id=\"date-time\"",
+                            t("now"),
+                            t("now_note")
+                        )),
+                        bind("/data/now").type("string").calculate("now()")
+                    )
+                ),
+                body(
+                    input("/data/now_note",
+                        label("Now: <output ref=\"/data/now\"/>"))
+                )));
+
+            scenario.next();
+            assertThat(scenario.answerOf("/data/now").getValue(), is(Date.from(SIMULATED_INSTANT)));
+
+            // Unclear if/where getDisplayText is used; outputs in labels use XPathFuncExpr.toString
+            assertThat(scenario.answerOf("/data/now").getDisplayText(), is("23/05/98 17:49"));
+            FormEntryCaption nowCaption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
+            assertThat(nowCaption.getQuestionText(), is("Now: 1998-05-23T17:49:42-07:00"));
+    }
+
+    @Test
+    public void dateTimeStringLabelOutput_isIsoOffsetDateTime() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("Date time"),
+                model(
+                    mainInstance(t("data id=\"date-time\"",
+                        t("date_time", "1998-05-23T17:49:42-07:00"),
+                        t("date_time_note")
+                    )),
+                    bind("/data/date_time").type("string")
+                )
+            ),
+            body(
+                input("/data/date_time_note",
+                    label("Date time: <output ref=\"/data/date_time\"/>"))
+            )));
+
+        scenario.next();
+        assertThat(scenario.answerOf("/data/date_time").getValue(), is("1998-05-23T17:49:42-07:00"));
+        assertThat(scenario.answerOf("/data/date_time").getDisplayText(), is("1998-05-23T17:49:42-07:00"));
+        FormEntryCaption caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
+        assertThat(caption.getQuestionText(), is("Date time: 1998-05-23T17:49:42-07:00"));
+    }
+
+    @Test
+    public void dateTimeQuestionLabelOutput_isIsoOffsetDateTime() throws IOException, XFormParser.ParseException {
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("Date time"),
+                model(
+                    mainInstance(t("data id=\"date-time\"",
+                        t("date_time"),
+                        t("date_time_note")
+                    )),
+                    bind("/data/date_time").type("dateTime")
+                )
+            ),
+            body(
+                input("/data/date_time",
+                    label("Enter a date time")),
+                input("/data/date_time_note",
+                    label("Date time: <output ref=\"/data/date_time\"/>"))
+            )));
+
+        scenario.next();
+        scenario.answer(SIMULATED_INSTANT, true);
+        assertThat(scenario.answerOf("/data/date_time").getValue(), is(Date.from(SIMULATED_INSTANT)));
+        assertThat(scenario.answerOf("/data/date_time").getDisplayText(), is("23/05/98 17:49"));
+
+        scenario.next();
+        FormEntryCaption caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
+        assertThat(caption.getQuestionText(), is("Date time: 1998-05-23T17:49-07:00"));
+    }
+
+    @Test
+    public void todayLabelOutput_isIsoDate() throws IOException, XFormParser.ParseException {
+        Date expectedDay = Date.from(
+            SIMULATED_INSTANT.atZone(SIMULATED_TZ.toZoneId())
+                .toLocalDate()
+                .atStartOfDay(SIMULATED_TZ.toZoneId())
+                .toInstant()
+        );
+
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("Date"),
+                model(
+                    mainInstance(t("data id=\"date\"",
+                        t("today"),
+                        t("today_note")
+                    )),
+                    bind("/data/today").type("date").calculate("today()")
+                )
+            ),
+            body(
+                input("/data/today_note",
+                    label("Today: <output ref=\"/data/today\"/>"))
+            )));
+
+        scenario.next();
+        assertThat(scenario.answerOf("/data/today").getValue(), is(expectedDay));
+
+        // Unclear if/where getDisplayText is used; outputs in labels use XPathFuncExpr.toString
+        assertThat(scenario.answerOf("/data/today").getDisplayText(), is("23/05/98"));
+        FormEntryCaption nowCaption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
+        assertThat(nowCaption.getQuestionText(), is("Today: 1998-05-23"));
+    }
+
+    // Date field type, now() expression
+    @Test
+    public void nowDateLabelOutput_isIsoDate() throws IOException, XFormParser.ParseException {
+        Date expectedDay = Date.from(
+            SIMULATED_INSTANT.atZone(SIMULATED_TZ.toZoneId())
+                .toLocalDate()
+                .atStartOfDay(SIMULATED_TZ.toZoneId())
+                .toInstant()
+        );
+
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("Now date"),
+                model(
+                    mainInstance(t("data id=\"now-date\"",
+                        t("now"),
+                        t("now_note")
+                    )),
+                    bind("/data/now").type("date").calculate("now()")
+                )
+            ),
+            body(
+                input("/data/now_note",
+                    label("Today: <output ref=\"/data/now\"/>"))
+            )));
+
+        scenario.next();
+        assertThat(scenario.answerOf("/data/now").getValue(), is(expectedDay));
+
+        // Unclear if/where getDisplayText is used; outputs in labels use XPathFuncExpr.toString
+        assertThat(scenario.answerOf("/data/now").getDisplayText(), is("23/05/98"));
+        FormEntryCaption nowCaption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
+        assertThat(nowCaption.getQuestionText(), is("Today: 1998-05-23"));
+    }
+
+    @Test
+    public void dateQuestionLabelOutput_isIsoDate() throws IOException, XFormParser.ParseException {
+        Date expectedDay = Date.from(
+            SIMULATED_INSTANT.atZone(SIMULATED_TZ.toZoneId())
+                .toLocalDate()
+                .atStartOfDay(SIMULATED_TZ.toZoneId())
+                .toInstant()
+        );
+
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("Date"),
+                model(
+                    mainInstance(t("data id=\"date\"",
+                        t("date"),
+                        t("date_note")
+                    )),
+                    bind("/data/date").type("date")
+                )
+            ),
+            body(
+                input("/data/date",
+                    label("Enter a date")),
+                input("/data/date_note",
+                    label("Date: <output ref=\"/data/date\"/>"))
+            )));
+
+        scenario.next();
+        scenario.answer(SIMULATED_INSTANT, false);
+        assertThat(scenario.answerOf("/data/date").getValue(), is(expectedDay));
+        assertThat(scenario.answerOf("/data/date").getDisplayText(), is("23/05/98"));
+
+        scenario.next();
+        FormEntryCaption caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
+        assertThat(caption.getQuestionText(), is("Date: 1998-05-23"));
+    }
+}

--- a/src/test/java/org/javarosa/xpath/expr/DateTimeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/DateTimeTest.java
@@ -74,7 +74,6 @@ public class DateTimeTest {
         scenario.next();
         assertThat(scenario.answerOf("/data/now").getValue(), is(Date.from(SIMULATED_INSTANT)));
 
-        // Unclear if/where getDisplayText is used; outputs in labels use XPathFuncExpr.toString
         assertThat(scenario.answerOf("/data/now").getDisplayText(), is("23/05/98 17:49"));
         FormEntryCaption nowCaption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
         assertThat(nowCaption.getQuestionText(), is("Now: 1998-05-23T17:49:42.123-07:00"));
@@ -163,7 +162,6 @@ public class DateTimeTest {
         scenario.next();
         assertThat(scenario.answerOf("/data/today").getValue(), is(expectedDay));
 
-        // Unclear if/where getDisplayText is used; outputs in labels use XPathFuncExpr.toString
         assertThat(scenario.answerOf("/data/today").getDisplayText(), is("23/05/98"));
         FormEntryCaption nowCaption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
         assertThat(nowCaption.getQuestionText(), is("Today: 1998-05-23"));
@@ -198,7 +196,6 @@ public class DateTimeTest {
         scenario.next();
         assertThat(scenario.answerOf("/data/now").getValue(), is(expectedDay));
 
-        // Unclear if/where getDisplayText is used; outputs in labels use XPathFuncExpr.toString
         assertThat(scenario.answerOf("/data/now").getDisplayText(), is("23/05/98"));
         FormEntryCaption nowCaption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
         assertThat(nowCaption.getQuestionText(), is("Today: 1998-05-23"));

--- a/src/test/java/org/javarosa/xpath/expr/DateTimeTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/DateTimeTest.java
@@ -27,12 +27,16 @@ import static org.javarosa.test.XFormsElement.model;
 import static org.javarosa.test.XFormsElement.t;
 import static org.javarosa.test.XFormsElement.title;
 
+/**
+ * SIDE-EFFECT: Mutates JVM-default timezone and Joda-Time's current millis.
+ * Must not be run in parallel with other timezone-sensitive tests.
+ */
 public class DateTimeTest {
     private TimeZone originalTimeZone;
-    String SIMULATED_NOW = "1998-05-23T17:49:42-07:00"; // 1998-05-24 in UTC
-    Instant SIMULATED_INSTANT = OffsetDateTime.parse(SIMULATED_NOW).toInstant();
+    private static final String SIMULATED_NOW = "1998-05-23T17:49:42.123-07:00"; // 1998-05-24 in UTC
+    private static final Instant SIMULATED_INSTANT = OffsetDateTime.parse(SIMULATED_NOW).toInstant();
 
-    TimeZone SIMULATED_TZ = TimeZone.getTimeZone("America/Los_Angeles");
+    private static final TimeZone SIMULATED_TZ = TimeZone.getTimeZone("America/Los_Angeles");
 
     @Before
     public void setUp() {
@@ -51,29 +55,29 @@ public class DateTimeTest {
 
     @Test
     public void nowLabelOutput_isIsoOffsetDateTime() throws IOException, XFormParser.ParseException {
-            Scenario scenario = Scenario.init(html(
-                head(
-                    title("Date time"),
-                    model(
-                        mainInstance(t("data id=\"date-time\"",
-                            t("now"),
-                            t("now_note")
-                        )),
-                        bind("/data/now").type("string").calculate("now()")
-                    )
-                ),
-                body(
-                    input("/data/now_note",
-                        label("Now: <output ref=\"/data/now\"/>"))
-                )));
+        Scenario scenario = Scenario.init(html(
+            head(
+                title("Date time"),
+                model(
+                    mainInstance(t("data id=\"date-time\"",
+                        t("now"),
+                        t("now_note")
+                    )),
+                    bind("/data/now").type("string").calculate("now()")
+                )
+            ),
+            body(
+                input("/data/now_note",
+                    label("Now: <output ref=\"/data/now\"/>"))
+            )));
 
-            scenario.next();
-            assertThat(scenario.answerOf("/data/now").getValue(), is(Date.from(SIMULATED_INSTANT)));
+        scenario.next();
+        assertThat(scenario.answerOf("/data/now").getValue(), is(Date.from(SIMULATED_INSTANT)));
 
-            // Unclear if/where getDisplayText is used; outputs in labels use XPathFuncExpr.toString
-            assertThat(scenario.answerOf("/data/now").getDisplayText(), is("23/05/98 17:49"));
-            FormEntryCaption nowCaption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
-            assertThat(nowCaption.getQuestionText(), is("Now: 1998-05-23T17:49:42-07:00"));
+        // Unclear if/where getDisplayText is used; outputs in labels use XPathFuncExpr.toString
+        assertThat(scenario.answerOf("/data/now").getDisplayText(), is("23/05/98 17:49"));
+        FormEntryCaption nowCaption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
+        assertThat(nowCaption.getQuestionText(), is("Now: 1998-05-23T17:49:42.123-07:00"));
     }
 
     @Test
@@ -83,7 +87,7 @@ public class DateTimeTest {
                 title("Date time"),
                 model(
                     mainInstance(t("data id=\"date-time\"",
-                        t("date_time", "1998-05-23T17:49:42-07:00"),
+                        t("date_time", "1998-05-23T17:49:42.123-07:00"),
                         t("date_time_note")
                     )),
                     bind("/data/date_time").type("string")
@@ -95,10 +99,10 @@ public class DateTimeTest {
             )));
 
         scenario.next();
-        assertThat(scenario.answerOf("/data/date_time").getValue(), is("1998-05-23T17:49:42-07:00"));
-        assertThat(scenario.answerOf("/data/date_time").getDisplayText(), is("1998-05-23T17:49:42-07:00"));
+        assertThat(scenario.answerOf("/data/date_time").getValue(), is("1998-05-23T17:49:42.123-07:00"));
+        assertThat(scenario.answerOf("/data/date_time").getDisplayText(), is("1998-05-23T17:49:42.123-07:00"));
         FormEntryCaption caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
-        assertThat(caption.getQuestionText(), is("Date time: 1998-05-23T17:49:42-07:00"));
+        assertThat(caption.getQuestionText(), is("Date time: 1998-05-23T17:49:42.123-07:00"));
     }
 
     @Test
@@ -128,7 +132,7 @@ public class DateTimeTest {
 
         scenario.next();
         FormEntryCaption caption = new FormEntryCaption(scenario.getFormDef(), scenario.getCurrentIndex());
-        assertThat(caption.getQuestionText(), is("Date time: 1998-05-23T17:49-07:00"));
+        assertThat(caption.getQuestionText(), is("Date time: 1998-05-23T17:49:42.123-07:00"));
     }
 
     @Test


### PR DESCRIPTION
Closes #282 
Closes #680

#### What has been done to verify that this works as intended?

Newly-added tests.

#### Why is this the best possible solution? Were any other approaches considered?

This is the least-invasive, least-risky approach I could think of for both the fix and the tests. In the fullness of time it would be great to refactor this date/time code. For example, `LocalDate` would be a better underlying type for `DateData`. Ideally we wouldn't have to set the global time and timezone to write tests. But I think it makes sense to add more testing of this kind first before taking on a bigger refactor.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is intended to be very narrow and just display the time component for datetime values used in outputs. This matches Enketo and Web Forms and makes it easier to compare behavior between the 3.

#### Do we need any specific form for testing your changes? If so, please attach one.

[now.xlsx](https://github.com/user-attachments/files/29150376/now.xlsx) is a good one to illustrate why we're making the change.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No.