### PR TITLE
Remove synchronization on java.lang.Boolean

### DIFF
--- a/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
+++ b/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
@@ -29,6 +29,7 @@ import org.javarosa.xpath.expr.XPathPathExpr;
  */
 public class XPathLazyNodeset extends XPathNodeset {
 
+    private final Object lock = new Object();
     Boolean evaluated = Boolean.FALSE;
     TreeReference unExpandedRef;
 
@@ -46,7 +47,7 @@ public class XPathLazyNodeset extends XPathNodeset {
 
 
     private void performEvaluation() {
-        synchronized(evaluated) {
+        synchronized(lock) {
             if(evaluated.booleanValue()) {
                 return;
             }
@@ -71,7 +72,7 @@ public class XPathLazyNodeset extends XPathNodeset {
      * existed, but didn't, rather than a reference which could not represent a real node).
      */
     public Object unpack () {
-        synchronized(evaluated) {
+        synchronized(lock) {
             if(evaluated.booleanValue()) {
                 return super.unpack();
             }


### PR DESCRIPTION
This makes sure that `evaluated` is accessed while holding the same monitor.
Also makes this class value classes ready.

Closes https://github.com/getodk/javarosa/issues/858

#### What has been done to verify that this works as intended?

./gradlew build

#### Why is this the best possible solution? Were any other approaches considered?

Fixes immediate problem.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Makes their code JEP-401 (value classes) ready.

#### Do we need any specific form for testing your changes? If so, please attach one.

Probably not.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No