### PR TITLE
Bump version for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>javarosa</artifactId>
   <!-- snapshot release = x.x.x-${revision}-SNAPSHOT -->
   <!-- production release = x.x.x -->
-  <version>5.2.0-${revision}-SNAPSHOT</version>
+  <version>6.0.0</version>
   <packaging>jar</packaging>
   <name>javarosa</name>
   <description>A Java library for rendering forms that are compliant with ODK XForms spec</description>


### PR DESCRIPTION
Does what it says on the tin! We're going with 6.0.0 as we've made a few changes that could arguably be considered breaking.